### PR TITLE
Tensor improvements

### DIFF
--- a/slangpy/backend/slangpynativeemulation.py
+++ b/slangpy/backend/slangpynativeemulation.py
@@ -368,7 +368,7 @@ class NativeCallData:
         self.last_call_shape = call_shape
 
         # Setup context
-        context = CallContext(device, call_shape)
+        context = CallContext(device, call_shape, self.call_mode)
 
         # Allocate a return value if not provided in kw args
         # This is redundant if command buffer supplied, as we don't return anything
@@ -446,10 +446,11 @@ class CallContext:
     Native call context
     """
 
-    def __init__(self, device: 'Device', call_shape: Shape):
+    def __init__(self, device: 'Device', call_shape: Shape, call_mode: CallMode):
         super().__init__()
         self.device = device
         self.call_shape = call_shape
+        self.call_mode = call_mode
 
 
 def unpack_arg(arg: Any) -> Any:

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -67,7 +67,7 @@ def specialize(
         ModifierID.static) and function.name != "$init"
 
     # Require '_result' argument for derivative calls, either as '_result' named parameter or last positional argument
-    last_arg_is_retval = function.return_type is not None and not "_result" in signature.kwargs and context.call_mode != CallMode.prim
+    last_arg_is_retval = function.return_type is not None and function.return_type.name != 'void' and not "_result" in signature.kwargs and context.call_mode != CallMode.prim
 
     # Select the positional arguments we need to match against
     signature_args = signature.args

--- a/slangpy/tests/test_tensor.py
+++ b/slangpy/tests/test_tensor.py
@@ -20,9 +20,9 @@ def get_test_tensors(device: Device, N: int = 4):
     np_x = np.random.randn(8).astype(np.float32)
     np_result = np.tile(np_weights.dot(np_x) + np_biases, (N, 1))
 
-    weights = Tensor.from_numpy(np_weights, device).broadcast_to((N, 5, 8))
-    biases = Tensor.from_numpy(np_biases, device).broadcast_to((N, 5))
-    x = Tensor.from_numpy(np_x, device).broadcast_to((N, 8))
+    weights = Tensor.from_numpy(device, np_weights, ).broadcast_to((N, 5, 8))
+    biases = Tensor.from_numpy(device, np_biases).broadcast_to((N, 5))
+    x = Tensor.from_numpy(device, np_x).broadcast_to((N, 8))
 
     return weights, biases, x, np_result
 


### PR DESCRIPTION
- Tensor initialization can happen with more flexible datatypes (as with NDBuffer)
- Simplified Tensor.with_grads to support calling with no args
- Re-ordered tensor init args to match buffers
- Fixed bug in specialize that was incorrectly assuming a function had a return type if returntype!=none