### PR TITLE
Tensor cleanup

### DIFF
--- a/slangpy/builtin/tensor.py
+++ b/slangpy/builtin/tensor.py
@@ -209,7 +209,7 @@ class TensorMarshall(Marshall):
         primal_calldata = {
             'buffer': data.storage,
             'layout': {'offset': data.offset, 'strides': strides},
-            'shape': data.shape
+            '_shape': data.shape
         }
 
         if not self.d_in and not self.d_out:

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -233,6 +233,8 @@ public struct Tensor<T : IDifferentiable, let D : int> : ITensor<T, D>
     {
         value.buffer = buffer;
         value.layout = layout.slice<SliceD>(ctx.call_id);
+        for (int i = 0; i < SliceD; ++i)
+            value.shape[i] = shape[D - SliceD + i];
     }
 
     ITensorSubscript
@@ -255,6 +257,8 @@ public struct RWTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
     {
         value.buffer = buffer;
         value.layout = layout.slice<SliceD>(ctx.call_id);
+        for (int i = 0; i < SliceD; ++i)
+            value.shape[i] = shape[D - SliceD + i];
     }
 
     IRWTensorSubscript
@@ -283,6 +287,8 @@ public struct AtomicTensor<T, let D : int> : IRWTensor<T, D> where T : IDifferen
     {
         value.buffer = buffer;
         value.layout = layout.slice<SliceD>(ctx.call_id);
+        for (int i = 0; i < SliceD; ++i)
+            value.shape[i] = shape[D - SliceD + i];
     }
 
     IRWTensorSubscript

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -117,8 +117,7 @@ namespace impl
     public void load<let N : int>(ContextND<D - 1> ctx, out T[N] value)                     \
     {                                                                                       \
         int idx[D];                                                                         \
-        /*[ForceUnroll]*/                                                                   \
-        [MaxIters(8)] /* Workaround for slang bug #5917 */                                  \
+        [ForceUnroll]                                                                       \
         for (int i = 0; i < D - 1; ++i)                                                     \
             idx[i] = ctx.call_id[i];                                                        \
                                                                                             \
@@ -132,8 +131,7 @@ namespace impl
     public void load<let N : int>(ContextND<D - 1> ctx, out vector<T,N> value)              \
     {                                                                                       \
         int idx[D];                                                                         \
-        /*[ForceUnroll]*/                                                                   \
-        [MaxIters(8)] /* Workaround for slang bug #5917 */                                  \
+        [ForceUnroll]                                                                       \
         for (int i = 0; i < D - 1; ++i)                                                     \
             idx[i] = ctx.call_id[i];                                                        \
                                                                                             \
@@ -148,8 +146,7 @@ namespace impl
     public void load<let M : int, let N : int>(ContextND<D - 2> context, out T value[M][N]) \
     {                                                                                       \
         int idx[D];                                                                         \
-        /*[ForceUnroll]*/                                                                   \
-        [MaxIters(8)] /* Workaround for slang bug #5917 */                                  \
+        [ForceUnroll]                                                                       \
         for (int i = 0; i < D - 2; ++i)                                                     \
             idx[i] = context.call_id[i];                                                    \
         [ForceUnroll]                                                                       \
@@ -176,8 +173,7 @@ namespace impl
     public void store<let N : int>(ContextND<D - 1> context, in T[N] value)                 \
     {                                                                                       \
         int idx[D];                                                                         \
-        /*[ForceUnroll]*/                                                                   \
-        [MaxIters(8)] /* Workaround for slang bug #5917 */                                  \
+        [ForceUnroll]                                                                       \
         for (int i = 0; i < D - 1; ++i)                                                     \
             idx[i] = context.call_id[i];                                                    \
         [ForceUnroll]                                                                       \
@@ -191,8 +187,7 @@ namespace impl
     public void store<let N : int>(ContextND<D - 1> context, in vector<T,N> value)          \
     {                                                                                       \
         int idx[D];                                                                         \
-        /*[ForceUnroll]*/                                                                   \
-        [MaxIters(8)] /* Workaround for slang bug #5917 */                                  \
+        [ForceUnroll]                                                                       \
         for (int i = 0; i < D - 1; ++i)                                                     \
             idx[i] = context.call_id[i];                                                    \
         [ForceUnroll]                                                                       \
@@ -206,8 +201,7 @@ namespace impl
     public void store<let M : int, let N : int>(ContextND<D - 2> context, in T value[M][N]) \
     {                                                                                       \
         int idx[D];                                                                         \
-        /*[ForceUnroll]*/                                                                   \
-        [MaxIters(8)] /* Workaround for slang bug #5917 */                                  \
+        [ForceUnroll]                                                                       \
         for (int i = 0; i < D - 2; ++i)                                                     \
             idx[i] = context.call_id[i];                                                    \
         [ForceUnroll]                                                                       \

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -10,6 +10,8 @@ public interface ITensor<T : IDifferentiable, let D : int>
     {
         [BackwardDifferentiable] get;
     }
+
+    public property shape : uint[D];
 }
 public interface IRWTensor<T : IDifferentiable, let D : int> : ITensor<T, D>
 {
@@ -224,7 +226,9 @@ public struct Tensor<T : IDifferentiable, let D : int> : ITensor<T, D>
 {
     public StructuredBuffer<T> buffer;
     public StridedLayout<D> layout;
-    public int[D] shape;
+    private uint _shape[D];
+
+    public property shape : uint[D] { get { return _shape; } }
 
     [TreatAsDifferentiable]
     public T get(int[D] idx) { return buffer[layout.at(idx)]; }
@@ -234,7 +238,7 @@ public struct Tensor<T : IDifferentiable, let D : int> : ITensor<T, D>
         value.buffer = buffer;
         value.layout = layout.slice<SliceD>(ctx.call_id);
         for (int i = 0; i < SliceD; ++i)
-            value.shape[i] = shape[D - SliceD + i];
+            value._shape[i] = _shape[D - SliceD + i];
     }
 
     ITensorSubscript
@@ -245,7 +249,9 @@ public struct RWTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
 {
     public RWStructuredBuffer<T> buffer;
     public StridedLayout<D> layout;
-    public int[D] shape;
+    private uint _shape[D];
+
+    public property shape : uint[D] { get { return _shape; } }
 
     [TreatAsDifferentiable]
     public T get(int[D] idx) { return buffer[layout.at(idx)]; }
@@ -258,7 +264,7 @@ public struct RWTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
         value.buffer = buffer;
         value.layout = layout.slice<SliceD>(ctx.call_id);
         for (int i = 0; i < SliceD; ++i)
-            value.shape[i] = shape[D - SliceD + i];
+            value._shape[i] = _shape[D - SliceD + i];
     }
 
     IRWTensorSubscript
@@ -270,7 +276,9 @@ public struct AtomicTensor<T, let D : int> : IRWTensor<T, D> where T : IDifferen
 {
     public RWByteAddressBuffer buffer;
     public StridedLayout<D> layout;
-    public int[D] shape;
+    private uint _shape[D];
+
+    public property shape : uint[D] { get { return _shape; } }
 
     [TreatAsDifferentiable]
     public T get(int[D] idx) { return buffer.Load<T>(layout.at(idx) * sizeof(T), sizeof(T)); }
@@ -288,7 +296,7 @@ public struct AtomicTensor<T, let D : int> : IRWTensor<T, D> where T : IDifferen
         value.buffer = buffer;
         value.layout = layout.slice<SliceD>(ctx.call_id);
         for (int i = 0; i < SliceD; ++i)
-            value.shape[i] = shape[D - SliceD + i];
+            value._shape[i] = _shape[D - SliceD + i];
     }
 
     IRWTensorSubscript
@@ -300,6 +308,8 @@ public struct GradOutTensor<T : IDifferentiable, let D : int> : ITensor<T, D> wh
 {
     public Tensor<T, D> primal;
     public AtomicTensor<T.Differential, D> d_out;
+
+    public property shape : uint[D] { get { return primal.shape; } }
 
     [Differentiable]
     public T get(int[D] idx) { return primal.get(idx); }
@@ -324,6 +334,8 @@ public struct GradInTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
 {
     public RWTensor<T, D> primal;
     public Tensor<T.Differential, D> d_in;
+
+    public property shape : uint[D] { get { return primal.shape; } }
 
     [TreatAsDifferentiable]
     public T get(int[D] idx) { return primal.get(idx); }
@@ -350,6 +362,8 @@ public struct GradInOutTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D
     public RWTensor<T, D> primal;
     public AtomicTensor<T.Differential, D> d_out;
     public Tensor<T.Differential, D> d_in;
+
+    public property shape : uint[D] { get { return primal.shape; } }
 
     [Differentiable]
     public T get(int[D] idx) { return primal.get(idx); }

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -5,12 +5,6 @@ public interface ITensor<T : IDifferentiable, let D : int>
 {
     [Differentiable] public T get(int idx[D]);
 
-    __generic<each Is : IInteger>
-    __subscript(expand each Is indices) -> T
-    {
-        [BackwardDifferentiable] get;
-    }
-
     public property shape : uint[D];
 }
 public interface IRWTensor<T : IDifferentiable, let D : int> : ITensor<T, D>
@@ -71,150 +65,151 @@ namespace impl
     }
 }
 
-// Workaround for slang bug #5900. These should move into extensions once they are safe
-#define ITensorSubscript                                         \
-    public __generic<each Is : IInteger>                         \
-    __subscript(expand each Is indices)->T                       \
-    {                                                            \
-        [BackwardDifferentiable] get { return get(impl::makeIndex<D>(expand each indices)); }                                                        \
-    }                                                            \
-    public __generic<I : IInteger> \
-    __subscript(ISizedArray<I, D> indices) -> T \
-    { \
-        [BackwardDifferentiable] get { return get(impl::makeIndex<D, I>(indices)); } \
+public extension<T : IDifferentiable, let D : int, TensorType : ITensor<T, D>> TensorType
+{
+    __generic<each Is : IInteger>
+    public __subscript(expand each Is indices)->T
+    {
+        [BackwardDifferentiable] get { return get(impl::makeIndex<D>(expand each indices)); }
+    }
+    __generic<I : IInteger>
+    __subscript(ISizedArray<I, D> indices)->T
+    {
+        [BackwardDifferentiable] get { return get(impl::makeIndex<D, I>(indices)); }
     }
 
-#define IRWTensorSubscript                                                 \
-    public __generic<each Is : IInteger>                                   \
-    __subscript(expand each Is indices)->T                                 \
-    {                                                                      \
-        [BackwardDifferentiable] get { return get(impl::makeIndex<D>(expand each indices)); }                                                                  \
-        [nonmutating, BackwardDifferentiable] set { return set(impl::makeIndex<D>(expand each indices), newValue); }                                                                  \
-    }                                                                      \
-    public __generic<I : IInteger> \
-    __subscript(ISizedArray<I, D> indices) -> T \
-    { \
-        [BackwardDifferentiable] get { return get(impl::makeIndex<D, I>(indices)); } \
-        [nonmutating, BackwardDifferentiable] set { return set(impl::makeIndex<D, I>(indices), newValue); } \
+    [Differentiable]
+    public void load(ContextND<D> ctx, out T value)
+    {
+        value = get(ctx.call_id);
     }
 
-#define ITensorLoads                                                                        \
-    public __generic<each Ts : IInteger>                                                    \
-    __subscript(expand each Ts indices)->T                                                  \
-    {                                                                                       \
-        [BackwardDifferentiable] get { return get(impl::makeIndex<D>(expand each indices)); }                                                                                   \
-    }                                                                                       \
-    [Differentiable]                                                                        \
-    public void load(ContextND<D> ctx, out T value)                                         \
-    {                                                                                       \
-        value = get(ctx.call_id);                                                           \
-    }                                                                                       \
-    public void load(Context0D context, out This value)                                     \
-    {                                                                                       \
-        value = this;                                                                       \
-    }                                                                                       \
-    [Differentiable]                                                                        \
-    public void load<let N : int>(ContextND<D - 1> ctx, out T[N] value)                     \
-    {                                                                                       \
-        int idx[D];                                                                         \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < D - 1; ++i)                                                     \
-            idx[i] = ctx.call_id[i];                                                        \
-                                                                                            \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < N; i++) {                                                       \
-            idx[D - 1] = i;                                                                 \
-            value[i] = get(idx);                                                            \
-        }                                                                                   \
-    }                                                                                       \
-    [Differentiable]                                                                        \
-    public void load<let N : int>(ContextND<D - 1> ctx, out vector<T,N> value)              \
-    {                                                                                       \
-        int idx[D];                                                                         \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < D - 1; ++i)                                                     \
-            idx[i] = ctx.call_id[i];                                                        \
-                                                                                            \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < N; i++) {                                                       \
-            idx[D - 1] = i;                                                                 \
-            value[i] = get(idx);                                                            \
-        }                                                                                   \
-    }                                                                                       \
-                                                                                            \
-    [Differentiable]                                                                        \
-    public void load<let M : int, let N : int>(ContextND<D - 2> context, out T value[M][N]) \
-    {                                                                                       \
-        int idx[D];                                                                         \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < D - 2; ++i)                                                     \
-            idx[i] = context.call_id[i];                                                    \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < M; i++) {                                                       \
-            [ForceUnroll]                                                                   \
-            for (int j = 0; j < N; j++) {                                                   \
-                idx[D - 2] = i;                                                             \
-                idx[D - 1] = j;                                                             \
-                                                                                            \
-                value[i][j] = get(idx);                                                     \
-            }                                                                               \
-        }                                                                                   \
+    public void load(Context0D context, out This value)
+    {
+        value = this;
     }
 
+    [Differentiable]
+    public void load<let N : int>(ContextND<D - 1> ctx, out T[N] value)
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 1; ++i)
+            idx[i] = ctx.call_id[i];
 
-#define IRWTensorStores                                                                     \
-    [Differentiable]                                                                        \
-    public void store(ContextND<D> ctx, in T value)                                         \
-    {                                                                                       \
-        set(ctx.call_id, value);                                                            \
-    }                                                                                       \
-                                                                                            \
-    [Differentiable]                                                                        \
-    public void store<let N : int>(ContextND<D - 1> context, in T[N] value)                 \
-    {                                                                                       \
-        int idx[D];                                                                         \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < D - 1; ++i)                                                     \
-            idx[i] = context.call_id[i];                                                    \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < N; i++) {                                                       \
-            idx[D - 1] = i;                                                                 \
-            set(idx, value[i]);                                                             \
-        }                                                                                   \
-    }                                                                                       \
-                                                                                            \
-    [Differentiable]                                                                        \
-    public void store<let N : int>(ContextND<D - 1> context, in vector<T,N> value)          \
-    {                                                                                       \
-        int idx[D];                                                                         \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < D - 1; ++i)                                                     \
-            idx[i] = context.call_id[i];                                                    \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < N; i++) {                                                       \
-            idx[D - 1] = i;                                                                 \
-            set(idx, value[i]);                                                             \
-        }                                                                                   \
-    }                                                                                       \
-                                                                                            \
-    [Differentiable]                                                                        \
-    public void store<let M : int, let N : int>(ContextND<D - 2> context, in T value[M][N]) \
-    {                                                                                       \
-        int idx[D];                                                                         \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < D - 2; ++i)                                                     \
-            idx[i] = context.call_id[i];                                                    \
-        [ForceUnroll]                                                                       \
-        for (int i = 0; i < M; i++) {                                                       \
-            [ForceUnroll]                                                                   \
-            for (int j = 0; j < N; j++) {                                                   \
-                idx[D - 2] = i;                                                             \
-                idx[D - 1] = j;                                                             \
-                                                                                            \
-                set(idx, value[i][j]);                                                      \
-            }                                                                               \
-        }                                                                                   \
+        [ForceUnroll]
+        for (int i = 0; i < N; i++) {
+            idx[D - 1] = i;
+            value[i] = get(idx);
+        }
     }
+
+    [Differentiable]
+    public void load<let N : int>(ContextND<D - 1> ctx, out vector<T, N> value)
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 1; ++i)
+            idx[i] = ctx.call_id[i];
+
+        [ForceUnroll]
+        for (int i = 0; i < N; i++) {
+            idx[D - 1] = i;
+            value[i] = get(idx);
+        }
+    }
+
+    [Differentiable]
+    public void load<let M : int, let N : int>(ContextND<D - 2> context, out T value[M][N])
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 2; ++i)
+            idx[i] = context.call_id[i];
+        [ForceUnroll]
+        for (int i = 0; i < M; i++) {
+            [ForceUnroll]
+            for (int j = 0; j < N; j++) {
+                idx[D - 2] = i;
+                idx[D - 1] = j;
+
+                value[i][j] = get(idx);
+            }
+        }
+    }
+}
+
+public extension<T : IDifferentiable, let D : int, TensorType : IRWTensor<T, D>> TensorType
+{
+    [Differentiable]
+    public void store(ContextND<D> ctx, in T value)
+    {
+        set(ctx.call_id, value);
+    }
+
+    [Differentiable]
+    public void store<let N : int>(ContextND<D - 1> context, in T[N] value)
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 1; ++i)
+            idx[i] = context.call_id[i];
+        [ForceUnroll]
+        for (int i = 0; i < N; i++) {
+            idx[D - 1] = i;
+            set(idx, value[i]);
+        }
+    }
+
+    [Differentiable]
+    public void store<let N : int>(ContextND<D - 1> context, in vector<T, N> value)
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 1; ++i)
+            idx[i] = context.call_id[i];
+        [ForceUnroll]
+        for (int i = 0; i < N; i++) {
+            idx[D - 1] = i;
+            set(idx, value[i]);
+        }
+    }
+
+    [Differentiable]
+    public void store<let M : int, let N : int>(ContextND<D - 2> context, in T value[M][N])
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 2; ++i)
+            idx[i] = context.call_id[i];
+        [ForceUnroll]
+        for (int i = 0; i < M; i++) {
+            [ForceUnroll]
+            for (int j = 0; j < N; j++) {
+                idx[D - 2] = i;
+                idx[D - 1] = j;
+
+                set(idx, value[i][j]);
+            }
+        }
+    }
+
+    // Operator [] currently causes compiler crash and is disabled 
+#if 0
+    __generic<each Is : IInteger>
+    __subscript(expand each Is indices)->T
+    {
+        [BackwardDifferentiable] get { return get(impl::makeIndex<D>(expand each indices)); }
+        [nonmutating, BackwardDifferentiable] set { return set(impl::makeIndex<D>(expand each indices), newValue); }
+    }
+    __generic<I : IInteger>
+    __subscript(ISizedArray<I, D> indices)->T
+    {
+        [BackwardDifferentiable] get { return get(impl::makeIndex<D, I>(indices)); }
+        [nonmutating, BackwardDifferentiable] set { return set(impl::makeIndex<D, I>(indices), newValue); }
+    }
+#endif
+}
 
 public struct Tensor<T : IDifferentiable, let D : int> : ITensor<T, D>
 {
@@ -234,9 +229,6 @@ public struct Tensor<T : IDifferentiable, let D : int> : ITensor<T, D>
         for (int i = 0; i < SliceD; ++i)
             value._shape[i] = _shape[D - SliceD + i];
     }
-
-    ITensorSubscript
-    ITensorLoads
 }
 
 public struct RWTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
@@ -260,10 +252,6 @@ public struct RWTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
         for (int i = 0; i < SliceD; ++i)
             value._shape[i] = _shape[D - SliceD + i];
     }
-
-    IRWTensorSubscript
-    ITensorLoads
-    IRWTensorStores
 }
 
 public struct AtomicTensor<T, let D : int> : IRWTensor<T, D> where T : IDifferentiable, IAtomicAddable
@@ -292,10 +280,6 @@ public struct AtomicTensor<T, let D : int> : IRWTensor<T, D> where T : IDifferen
         for (int i = 0; i < SliceD; ++i)
             value._shape[i] = _shape[D - SliceD + i];
     }
-
-    IRWTensorSubscript
-    ITensorLoads
-    IRWTensorStores
 }
 
 public struct GradOutTensor<T : IDifferentiable, let D : int> : ITensor<T, D> where T.Differential : IAtomicAddable
@@ -319,9 +303,6 @@ public struct GradOutTensor<T : IDifferentiable, let D : int> : ITensor<T, D> wh
         primal.load(ctx, value.primal);
         d_out.load(ctx, value.d_out);
     }
-
-    ITensorSubscript
-    ITensorLoads
 }
 
 public struct GradInTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
@@ -345,10 +326,6 @@ public struct GradInTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
         primal.load(ctx, value.primal);
         d_in.load(ctx, value.d_in);
     }
-
-    IRWTensorSubscript
-    ITensorLoads
-    IRWTensorStores
 }
 
 public struct GradInOutTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D> where T.Differential : IAtomicAddable
@@ -380,8 +357,4 @@ public struct GradInOutTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D
         d_in.load(ctx, value.d_in);
         d_out.load(ctx, value.d_out);
     }
-
-    IRWTensorSubscript
-    ITensorLoads
-    IRWTensorStores
 }

--- a/slangpy/tests/test_torchintegration.py
+++ b/slangpy/tests/test_torchintegration.py
@@ -227,9 +227,6 @@ def test_polynomials(device_type: DeviceType, extra_dims: int, func_and_shape: t
 def test_add_tensors(device_type: DeviceType, extra_dims: int):
     torch.autograd.grad_mode.set_multithreading_enabled(False)
 
-    if extra_dims > 0:
-        pytest.skip("Adding sliced tensors currently not working")
-
     module = load_test_module(device_type)
 
     func_name = 'add_tensors'

--- a/slangpy/torchintegration/wrappedtensor.py
+++ b/slangpy/torchintegration/wrappedtensor.py
@@ -106,7 +106,7 @@ class WrappedTensorMarshall(TensorMarshall):
         primal_calldata = {
             'buffer': data.primal,
             'layout': {'offset': offset, 'strides': strides},
-            'shape': shape
+            '_shape': shape
         }
 
         if not self.d_in and not self.d_out:

--- a/slangpy/types/tensor.py
+++ b/slangpy/types/tensor.py
@@ -295,5 +295,5 @@ class Tensor:
         return {
             'buffer': self.storage,
             'strides': self.strides,
-            'shape': self.shape.as_tuple(),
+            '_shape': self.shape.as_tuple(),
         }


### PR DESCRIPTION
* Make tensor shape part of the interface
* Fix failing tensor test by tracking shape when slicing
* Remove workarounds for [ForceUnroll], extension
* Remove __subscript from interface as it triggers compiler corner cases and move it into extension instead