### PR TITLE
Make array and value type conversion logic more robust

### DIFF
--- a/slangpy/builtin/array.py
+++ b/slangpy/builtin/array.py
@@ -5,9 +5,7 @@ from slangpy.core.native import Shape
 
 import slangpy.bindings.typeregistry as tr
 from slangpy.builtin.value import ValueMarshall
-from slangpy.reflection import SlangType, ArrayType, ScalarType
-from slangpy.bindings import Marshall, BindContext, CodeGenBlock, BoundVariable
-from slangpy.reflection import SlangProgramLayout
+from slangpy.reflection import SlangType, SlangProgramLayout
 
 
 class ArrayMarshall(ValueMarshall):
@@ -19,19 +17,6 @@ class ArrayMarshall(ValueMarshall):
             st = layout.array_type(st, dim)
         self.slang_type = st
         self.concrete_shape = shape
-
-    def resolve_type(self, context: BindContext, bound_type: SlangType):
-        # If we're dealing with scalars, conform to the target type. Otherwise, passing
-        # scalar types becomes quite hard - e.g. python only knows int, and trying to
-        # pass to uint/int16 etc. would always throw an error
-        if isinstance(bound_type, ArrayType) and isinstance(bound_type.element_type, ScalarType):
-            return bound_type
-
-        return self.slang_type
-
-    def gen_calldata(self, cgb: CodeGenBlock, context: BindContext, binding: BoundVariable):
-        name = binding.variable_name
-        cgb.type_alias(f"_t_{name}", f"ValueType<{binding.vector_type.full_name}>")
 
 
 def _distill_array(layout: SlangProgramLayout, value: list[Any] | tuple[Any]):

--- a/slangpy/core/utils.py
+++ b/slangpy/core/utils.py
@@ -6,6 +6,7 @@ from typing import Sequence, Union
 from slangpy.backend import (DeclReflection, ProgramLayout,
                              TypeLayoutReflection, TypeReflection,
                              DeviceType, Device)
+from slangpy.reflection import SlangType
 
 
 def create_device(type: DeviceType = DeviceType.automatic, enable_debug_layers: bool = False, adapter_luid: Sequence[int] | None = None, include_paths: Sequence[str | PathLike] = []):
@@ -67,6 +68,16 @@ def try_find_function_overloads_via_ast(root: DeclReflection, type_name: str, fu
 
     func_decls = type_decl.find_children_of_kind(DeclReflection.Kind.func, func_name)
     return (type_decl.as_type(), [x.as_function() for x in func_decls])
+
+
+# This function checks if we can replace a python value's type with the destination
+# type in resolve_type. This lets us e.g. pass a python int to a python uint16_t
+# This is done by specializing a class with a specific generic constraint.
+# If specialization succeeds, slang tells us this is A-OK
+def is_type_castable_on_host(from_type: SlangType, to_type: SlangType) -> bool:
+    witness_name = f"impl::AllowedConversionWitness<{from_type.full_name}, {to_type.full_name}>"
+    witness = to_type.program.find_type_by_name(witness_name)
+    return witness is not None
 
 
 def parse_generic_signature(name: str):

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -348,3 +348,35 @@ public struct RWNDBuffer<T, let N : int>
         }
     }
 }
+
+namespace impl
+{
+
+    // Utility interface to check if a python type is safe to replace by the target
+    // slang type. This works around mismatches between the type systems: Python e.g.
+    // only knows float or int, but slang has a much wider array of scalar types;
+    // integers alone have 8 different types.
+    // This gets even worse when lists are thrown into the mix, and trying to pass
+    // e.g. [1, 2, 3] to uint16_t[3] would fail if the ValueType picks the default
+    // of int[3] to pass to slang. We could attempt to check this in python, but
+    // this would require deep slang type inspection and would inevitably be brittle
+    // 
+    // To solve this, we check if the python type (e.g. float[3]) type can be converted
+    // safely to the slang type using slang generic constraints.
+    // If type B implements IConvertibleFrom<A>, then we can safely convert from A to B
+    interface IConvertibleFrom<From> {}
+
+    // A python int can be passed to any slang integer scalar type
+    extension<T : __BuiltinIntegerType> T : IConvertibleFrom<int> {}
+    // A python float can be passed to any slang float scalar type
+    extension<T : __BuiltinFloatingPointType> T : IConvertibleFrom<float> {}
+    // A python array can be passed to any slang array of the same length, as
+    // long as their element types can be safely passed
+    extension<S, T : IConvertibleFrom<S>, let N : int, ArrT : ISizedArray<T, N>> ArrT : IConvertibleFrom<Array<S, N>> {}
+
+    // This function allows us to check if type A is convertible to type B.
+    // We attempt to specialize allowedConversionWitness with types [A, B]
+    // If it succeeds, the interface requirements are satisfied.
+    struct AllowedConversionWitness<From, To : IConvertibleFrom<From>> {}
+
+}

--- a/slangpy/tests/test_simple_function_call.py
+++ b/slangpy/tests/test_simple_function_call.py
@@ -391,5 +391,71 @@ int add_numbers(NDBuffer<int,1> a, NDBuffer<int,1> b) {
     assert np.all(res == a_data[0] + b_data[0])
 
 
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("scalar_type", ["float", "half", "double"])
+def test_pass_float_array(device_type: DeviceType, scalar_type: str):
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(
+        device, f"{scalar_type} first({scalar_type} x[3]) {{ return x[0]; }}")
+
+    arg = [3.0, 4.0, 5.0]
+    result = module.first(arg)
+
+    assert np.abs(result - arg[0]) < 1e-5
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("scalar_type", ["uint8_t", "uint16_t", "uint", "uint64_t", "int8_t", "int16_t", "int", "int64_t"])
+def test_pass_int_array(device_type: DeviceType, scalar_type: str):
+    if device_type == DeviceType.d3d12 and scalar_type in ("int8_t", "uint8_t"):
+        pytest.skip("8-bit types are unsupported by DXC")
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(
+        device, f"{scalar_type} first({scalar_type} x[3]) {{ return x[0]; }}")
+
+    arg = [3, 4, 5]
+    result = module.first(arg)
+
+    assert result == arg[0]
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("scalar_type", ["float", "half", "double"])
+def test_pass_float_field(device_type: DeviceType, scalar_type: str):
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(
+        device,
+        f"""
+struct Foo {{ {scalar_type} x; }}
+{scalar_type} unwrap(Foo foo) {{ return foo.x; }}
+""",
+    )
+
+    arg = 3.0
+    result = module.unwrap({"x": arg})
+
+    assert np.abs(result - arg) < 1e-5
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("scalar_type", ["uint8_t", "uint16_t", "uint", "uint64_t", "int8_t", "int16_t", "int", "int64_t"])
+def test_pass_int_field(device_type: DeviceType, scalar_type: str):
+    if device_type == DeviceType.d3d12 and scalar_type in ("int8_t", "uint8_t"):
+        pytest.skip("8-bit types are unsupported by DXC")
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(
+        device,
+        f"""
+struct Foo {{ {scalar_type} x; }}
+{scalar_type} unwrap(Foo foo) {{ return foo.x; }}
+""",
+    )
+
+    arg = 3
+    result = module.unwrap({"x": arg})
+
+    assert result == arg
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
This fixes a few issues when we try to pass python ints or floats, or arrays of them.

Python only knows int or float for numerical scalar values. Slang has a much wider variety (e.g. uint16_t, half, etc.). By default, scalars are passed with the `ValueType`, which maintains the python type (i.e. `int` or `float`). This has a few potential issues:
- When passing to a function argument, this always passes a 32 bit int or float and relies on an implicit conversion slang-side. If the destination type has fewer bits, this causes a warning; if it has more bits, the value could be truncated in the `CallData` parameter block
- When passing to a field of a struct, we directly invoke `.load(context, x.field)`. This allows no implicit conversion on the slang side, and trying to pass to anything but a slang `int` or `float` field will always fail. If a struct has such a field, it's not possible to pass it from slangpy directly (you can still store it in a structuredbuffer and pass that, but you can't pass e.g. a `dict`)
- The same thing happens for python lists, which are always passed as `int[N]` or `float[N]`. Slang does not allow implicit conversions for lists, and trying to pass a python list of scalar values to a function expecting e.g. `half[N]` or `uint[N]` fails

The previous fix for arrays was to return `bound_type` in `resolve_type`. That fixes what didn't work before, but also disables any Python side type checks like `specialize_with_arg_types`. E.g. it would waive through passing an `int[5]` to an `int[2]` and it would not be caught until we try to compile the generated entry point.

This MR fixes all these issues by introducing a `is_type_castable_on_host` function that checks if it is safe to replace the slang type with the bound type. To avoid brittle slang type inspection in Python, it instead uses slang's type system. It tries to reflect a type `AllowedConversionWitness<A, B>` which will only succeed if we can replace python type A with bound type B. This is achieved with generic constraints.