### PR TITLE
Transpose use of vector coordinates

### DIFF
--- a/slangpy/experimental/gridarg.py
+++ b/slangpy/experimental/gridarg.py
@@ -82,14 +82,12 @@ class GridArgMarshall(Marshall):
         return Shape(tuple(t))
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
-        if isinstance(bound_type, ArrayType):
-            return context.layout.array_type(context.layout.scalar_type(TypeReflection.ScalarType.int32), self.dims)
-        elif isinstance(bound_type, VectorType):
-            return context.layout.vector_type(TypeReflection.ScalarType.int32, self.dims)
-        else:
-            return bound_type
-            # raise ValueError(
-            #    f"Grid arguments must be passed to a function with an array or vector type, not {bound_type}")
+        conv_type = bound_type.program.find_type_by_name(
+            f"GridArgConversion<{bound_type.full_name}, {self.dims}>.ArgType")
+        if conv_type is None:
+            raise ValueError(
+                f"Could not find suitable conversion from GridArg<{self.dims}> to {bound_type.full_name}")
+        return conv_type
 
     def resolve_dimensionality(self, context: BindContext, binding: BoundVariable, vector_target_type: 'SlangType'):
         return self.dims

--- a/slangpy/experimental/gridarg.py
+++ b/slangpy/experimental/gridarg.py
@@ -82,8 +82,9 @@ class GridArgMarshall(Marshall):
         return Shape(tuple(t))
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
+        # Resolve type using reflection.
         conv_type = bound_type.program.find_type_by_name(
-            f"GridArgConversion<{bound_type.full_name}, {self.dims}>.ArgType")
+            f"VectorizeGridArgTo<{bound_type.full_name}, {self.dims}>.VectorType")
         if conv_type is None:
             raise ValueError(
                 f"Could not find suitable conversion from GridArg<{self.dims}> to {bound_type.full_name}")

--- a/slangpy/slang/callidarg.slang
+++ b/slangpy/slang/callidarg.slang
@@ -3,11 +3,23 @@ implementing slangpy;
 
 public struct CallIdArg {
 
-    public void load<let N : int>(ContextND<N> context, out vector<uint,N> value) {
+    // Array load
+    public void load<let N : int, T: __BuiltinIntegerType>(ContextND<N> context, out Array<T, N> value) {
         var t = context.call_id;
+        int end = N - 1;
         for (int i = 0; i < N; i++) {
-            value[i] = t[i];
+            value[i] = (T)t[i];
         }
     }
+
+    // Vector load (transpose of array load)
+    public void load<let N : int>(ContextND<N> context, out vector<uint,N> value) {
+        var t = context.call_id;
+        int end = N - 1;
+        for (int i = 0; i < N; i++) {
+            value[end-i] = t[i];
+        }
+    }
+
 
 }

--- a/slangpy/slang/callidarg.slang
+++ b/slangpy/slang/callidarg.slang
@@ -27,24 +27,24 @@ public struct CallIdArg {
     }    
 }
 
-// Set of generic rules to describe type conversion from call id arg to a slang type.
-struct CallIdArgConversion<SlangType, let Dim: int> {
+// Rules for how to vectorize a Python call id argument to a given Slang type.
+struct VectorizeCallidArgTo<SlangParameterType, let Dim: int> {
 }
-extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<Array<T,N>, N> {
-    typealias ArgType = Array<T,N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeCallidArgTo<Array<T,N>, N> {
+    typealias VectorType = Array<T,N>;
 }
-extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<Array<T, N>, -1>  {
-    typealias ArgType = Array<T, N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeCallidArgTo<Array<T, N>, -1>  {
+    typealias VectorType = Array<T, N>;
 }
-extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<vector<T,N>, N> {
-    typealias ArgType = vector<T, N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeCallidArgTo<vector<T,N>, N> {
+    typealias VectorType = vector<T, N>;
 }
-extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<vector<T, N>, -1> {
-    typealias ArgType = vector<T, N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeCallidArgTo<vector<T, N>, -1> {
+    typealias VectorType = vector<T, N>;
 }
-extension<T : __BuiltinIntegerType> CallIdArgConversion<T, -1> {
-    typealias ArgType = T;
+extension<T : __BuiltinIntegerType> VectorizeCallidArgTo<T, -1> {
+    typealias VectorType = T;
 }
-extension<T : __BuiltinIntegerType> CallIdArgConversion<T, 1> {
-    typealias ArgType = T;
+extension<T : __BuiltinIntegerType> VectorizeCallidArgTo<T, 1> {
+    typealias VectorType = T;
 }

--- a/slangpy/slang/callidarg.slang
+++ b/slangpy/slang/callidarg.slang
@@ -6,7 +6,6 @@ public struct CallIdArg {
     // Array load
     public void load<let N : int, T: __BuiltinIntegerType>(ContextND<N> context, out Array<T, N> value) {
         var t = context.call_id;
-        int end = N - 1;
         for (int i = 0; i < N; i++) {
             value[i] = (T)t[i];
         }
@@ -28,6 +27,7 @@ public struct CallIdArg {
 }
 
 // Rules for how to vectorize a Python call id argument to a given Slang type.
+// Dim is user specified Python side, -1 means use the same dimensionality as the Slang type.
 struct VectorizeCallidArgTo<SlangParameterType, let Dim: int> {
 }
 extension<let N : int, T : __BuiltinIntegerType> VectorizeCallidArgTo<Array<T,N>, N> {

--- a/slangpy/slang/callidarg.slang
+++ b/slangpy/slang/callidarg.slang
@@ -13,13 +13,38 @@ public struct CallIdArg {
     }
 
     // Vector load (transpose of array load)
-    public void load<let N : int>(ContextND<N> context, out vector<uint,N> value) {
+    public void load<let N : int, T : __BuiltinIntegerType>(ContextND<N> context, out vector<T,N> value) {
         var t = context.call_id;
         int end = N - 1;
         for (int i = 0; i < N; i++) {
-            value[end-i] = t[i];
+            value[end-i] = (T)t[i];
         }
     }
 
+    // Scalar load (works for N = 1)
+    public void load<T : __BuiltinIntegerType>(ContextND<1> context, out T value) {
+        value = (T)context.call_id[0];
+    }    
+}
 
+// Set of generic rules to describe type conversion from call id arg to a slang type.
+struct CallIdArgConversion<SlangType, let Dim: int> {
+}
+extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<Array<T,N>, N> {
+    typealias ArgType = Array<T,N>;
+}
+extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<Array<T, N>, -1>  {
+    typealias ArgType = Array<T, N>;
+}
+extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<vector<T,N>, N> {
+    typealias ArgType = vector<T, N>;
+}
+extension<let N : int, T : __BuiltinIntegerType> CallIdArgConversion<vector<T, N>, -1> {
+    typealias ArgType = vector<T, N>;
+}
+extension<T : __BuiltinIntegerType> CallIdArgConversion<T, -1> {
+    typealias ArgType = T;
+}
+extension<T : __BuiltinIntegerType> CallIdArgConversion<T, 1> {
+    typealias ArgType = T;
 }

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -6,18 +6,14 @@ public struct ContextND<let N: int>
     // Workaround for slang bug #6039
     public uint3 thread_id;
     public int[N] call_id;
-    
-    /*private uint3 _thread_id;
-    private int[N] _call_id;
 
-    public property uint3 thread_id { get { return _thread_id; } }
-    public property int[N] call_id { get { return _call_id; } }*/
-
+    // Conversion to vector gives transpose of the array based coordinate.
     public property vector<int, N> call_id_vec {
         get {
             vector<int, N> result;
+            int end = N - 1;
             for (int i = 0; i < N; ++i)
-                result[i] = call_id[i];
+                result[i] = call_id[end-i];
             return result;
         }
     }
@@ -56,9 +52,13 @@ int _idx<let N : int>(ContextND<N> index, int[N] stride) {
     for (int i = 0; i < N; i++) { idx += index.call_id[i] * stride[i]; }
     return idx;
 }
+
+// _idx_vec handles the fact that the vector form of the coordinate is the transpose
+// of the array form.
 int _idx_vec<let N : int>(vector<int,N> index, int[N] stride) {
     int idx = 0;
-    for (int i = 0; i < N; i++) { idx += index[i] * stride[i]; }
+    int end = N - 1;
+    for (int i = 0; i < N; i++) { idx += index[end-i] * stride[i]; }
     return idx;
 }
 
@@ -82,7 +82,7 @@ public struct ValueType<T>
 
 public struct VectorValueType<T,let N: int>
 {
-    vector<T,N> value;
+    vector<T, N> value;
 
     public void load(Context0D context, out vector<T,N> value) { value = this.value; }
     public void store(Context0D context, in vector<T,N> value) {};
@@ -150,7 +150,7 @@ public struct RWTexture1DType<T : ITexelElement> {
 
 public struct Texture2DType<T : ITexelElement> {
     Texture2D<T> value;
-    public void load(Context2D context, out T value) { value = this.value[context.call_id_vec.yx]; }
+    public void load(Context2D context, out T value) { value = this.value[context.call_id_vec]; }
     public void store(Context2D context, in T value) {};
 
     public void load(Context0D context, out Texture2D<T> value) { value = this.value; }
@@ -158,8 +158,8 @@ public struct Texture2DType<T : ITexelElement> {
 }
 public struct RWTexture2DType<T : ITexelElement> {
     RWTexture2D<T> value;
-    public void load(Context2D context, out T value) { value = this.value[context.call_id_vec.yx]; }
-    public void store(Context2D context, in T value) { this.value[context.call_id_vec.yx] = value;};
+    public void load(Context2D context, out T value) { value = this.value[context.call_id_vec]; }
+    public void store(Context2D context, in T value) { this.value[context.call_id_vec] = value;};
 
     public void load(Context0D context, out RWTexture2D<T> value) { value = this.value; }
     public void store(Context0D context, in RWTexture2D<T> value) {};
@@ -168,7 +168,7 @@ public struct RWTexture2DType<T : ITexelElement> {
 public struct Texture1DArrayType<T : ITexelElement> {
 
     // Map with the first index as the x coordinate and the second index as the array slice
-    int2 toidx(Context2D context) { return context.call_id_vec.yx; }
+    int2 toidx(Context2D context) { return context.call_id_vec; }
 
     Texture1DArray<T> value;
     public void load(Context2D context, out T value) { value = this.value[toidx(context)]; }
@@ -179,7 +179,7 @@ public struct Texture1DArrayType<T : ITexelElement> {
 }
 public struct RWTexture1DArrayType<T : ITexelElement> {
     // Map with the first index as the x coordinate and the second index as the array slice
-    int2 toidx(Context2D context) { return context.call_id_vec.yx; }
+    int2 toidx(Context2D context) { return context.call_id_vec; }
 
     RWTexture1DArray<T> value;
     public void load(Context2D context, out T value) { value = this.value[toidx(context)]; }
@@ -191,7 +191,7 @@ public struct RWTexture1DArrayType<T : ITexelElement> {
 
 public struct Texture3DType<T : ITexelElement> {
     Texture3D<T> value;
-    public void load(Context3D context, out T value) { value = this.value[context.call_id_vec.zyx]; }
+    public void load(Context3D context, out T value) { value = this.value[context.call_id_vec]; }
     public void store(Context3D context, in T value) {};
 
     public void load(Context0D context, out Texture3D<T> value) { value = this.value; }
@@ -199,8 +199,8 @@ public struct Texture3DType<T : ITexelElement> {
 }
 public struct RWTexture3DType<T : ITexelElement> {
     RWTexture3D<T> value;
-    public void load(Context3D context, out T value) { value = this.value[context.call_id_vec.zyx]; }
-    public void store(Context3D context, in T value) { this.value[context.call_id_vec.zyx] = value;};
+    public void load(Context3D context, out T value) { value = this.value[context.call_id_vec]; }
+    public void store(Context3D context, in T value) { this.value[context.call_id_vec] = value;};
 
     public void load(Context0D context, out RWTexture3D<T> value) { value = this.value; }
     public void store(Context0D context, in RWTexture3D<T> value) {};
@@ -208,7 +208,7 @@ public struct RWTexture3DType<T : ITexelElement> {
 
 public struct Texture2DArrayType<T : ITexelElement> {
     // slice is 0, y is 1, x is 2
-    int3 toidx(Context3D context) { return context.call_id_vec.zyx; }
+    int3 toidx(Context3D context) { return context.call_id_vec; }
 
     Texture2DArray<T> value;
     public void load(Context3D context, out T value) { value = this.value[toidx(context)]; }
@@ -219,7 +219,7 @@ public struct Texture2DArrayType<T : ITexelElement> {
 }
 public struct RWTexture2DArrayType<T : ITexelElement> {
     // slice is 0, xy are 1,2
-    int3 toidx(Context3D context) { return context.call_id_vec.zyx; }
+    int3 toidx(Context3D context) { return context.call_id_vec; }
 
     RWTexture2DArray<T> value;
     public void load(Context3D context, out T value) { value = this.value[toidx(context)]; }

--- a/slangpy/slang/gridarg.slang
+++ b/slangpy/slang/gridarg.slang
@@ -9,7 +9,6 @@ public struct GridArg<let N : int> {
     // Array load
     public void load<let N : int, T : __BuiltinIntegerType>(ContextND<N> context, out Array<T, N> value) {
         var t = context.call_id;
-        int end = N - 1;
         for (int i = 0; i < N; i++) {
             value[i] = (T)(offset[i] + t[i] * stride[i]);
         }
@@ -31,6 +30,7 @@ public struct GridArg<let N : int> {
 }
 
 // Rules for how to vectorize a Python grid argument to a given Slang type.
+// Dim is user specified Python side, -1 means use the same dimensionality as the Slang type.
 struct VectorizeGridArgTo<SlangParameterType, let Dim : int> {
 }
 extension<let N : int, T : __BuiltinIntegerType> VectorizeGridArgTo<Array<T, N>, N> {

--- a/slangpy/slang/gridarg.slang
+++ b/slangpy/slang/gridarg.slang
@@ -3,30 +3,52 @@ implementing slangpy;
 
 public struct GridArg<let N : int> {
 
-    public typealias VectorT = vector<int, N>;
-    public typealias ArrayT = Array<int, N>;
-
     int[N] offset;
     int[N] stride;
 
     // Array load
-    public void load(ContextND<N> context, out ArrayT value) {
+    public void load<let N : int, T : __BuiltinIntegerType>(ContextND<N> context, out Array<T, N> value) {
         var t = context.call_id;
+        int end = N - 1;
         for (int i = 0; i < N; i++) {
-            value[i] = offset[i] + t[i] * stride[i];
+            value[i] = (T)(offset[i] + t[i] * stride[i]);
         }
     }
 
     // Vector load (transpose of array load)
-    public void load(ContextND<N> context, out VectorT value) {
+    public void load<let N : int, T : __BuiltinIntegerType>(ContextND<N> context, out vector<T, N> value) {
         var t = context.call_id;
         int end = N - 1;
         for (int i = 0; i < N; i++) {
-            value[end - i] = offset[i] + t[i] * stride[i];
+            value[end - i] = (T)(offset[i] + t[i] * stride[i]);
         }
     }
 
-    public void load(ContextND<1> context, out int value) {
-        value = context.call_id[0];
+    // Scalar load (works for N = 1)
+    public void load<T : __BuiltinIntegerType>(ContextND<1> context, out T value) {
+        value = (T)context.call_id[0];
     }
+}
+
+// Experimental way of expressing rules for what types can be
+// passed as arguments to the load method of GridArg
+struct GridArgConversion<SlangType, let Dim : int> {
+}
+extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<Array<T, N>, N> {
+    typealias ArgType = Array<T, N>;
+}
+extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<Array<T, N>, -1> {
+    typealias ArgType = Array<T, N>;
+}
+extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<vector<T, N>, N> {
+    typealias ArgType = vector<T, N>;
+}
+extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<vector<T, N>, -1> {
+    typealias ArgType = vector<T, N>;
+}
+extension<T : __BuiltinIntegerType> GridArgConversion<T, -1> {
+    typealias ArgType = T;
+}
+extension<T : __BuiltinIntegerType> GridArgConversion<T, 1> {
+    typealias ArgType = T;
 }

--- a/slangpy/slang/gridarg.slang
+++ b/slangpy/slang/gridarg.slang
@@ -9,17 +9,20 @@ public struct GridArg<let N : int> {
     int[N] offset;
     int[N] stride;
 
-    public void load(ContextND<N> context, out VectorT value) {
+    // Array load
+    public void load(ContextND<N> context, out ArrayT value) {
         var t = context.call_id;
         for (int i = 0; i < N; i++) {
             value[i] = offset[i] + t[i] * stride[i];
         }
     }
 
-    public void load(ContextND<N> context, out ArrayT value) {
+    // Vector load (transpose of array load)
+    public void load(ContextND<N> context, out VectorT value) {
         var t = context.call_id;
+        int end = N - 1;
         for (int i = 0; i < N; i++) {
-            value[i] = offset[i] + t[i] * stride[i];
+            value[end - i] = offset[i] + t[i] * stride[i];
         }
     }
 

--- a/slangpy/slang/gridarg.slang
+++ b/slangpy/slang/gridarg.slang
@@ -30,25 +30,24 @@ public struct GridArg<let N : int> {
     }
 }
 
-// Experimental way of expressing rules for what types can be
-// passed as arguments to the load method of GridArg
-struct GridArgConversion<SlangType, let Dim : int> {
+// Rules for how to vectorize a Python grid argument to a given Slang type.
+struct VectorizeGridArgTo<SlangParameterType, let Dim : int> {
 }
-extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<Array<T, N>, N> {
-    typealias ArgType = Array<T, N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeGridArgTo<Array<T, N>, N> {
+    typealias VectorType = Array<T, N>;
 }
-extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<Array<T, N>, -1> {
-    typealias ArgType = Array<T, N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeGridArgTo<Array<T, N>, -1> {
+    typealias VectorType = Array<T, N>;
 }
-extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<vector<T, N>, N> {
-    typealias ArgType = vector<T, N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeGridArgTo<vector<T, N>, N> {
+    typealias VectorType = vector<T, N>;
 }
-extension<let N : int, T : __BuiltinIntegerType> GridArgConversion<vector<T, N>, -1> {
-    typealias ArgType = vector<T, N>;
+extension<let N : int, T : __BuiltinIntegerType> VectorizeGridArgTo<vector<T, N>, -1> {
+    typealias VectorType = vector<T, N>;
 }
-extension<T : __BuiltinIntegerType> GridArgConversion<T, -1> {
-    typealias ArgType = T;
+extension<T : __BuiltinIntegerType> VectorizeGridArgTo<T, -1> {
+    typealias VectorType = T;
 }
-extension<T : __BuiltinIntegerType> GridArgConversion<T, 1> {
-    typealias ArgType = T;
+extension<T : __BuiltinIntegerType> VectorizeGridArgTo<T, 1> {
+    typealias VectorType = T;
 }

--- a/slangpy/tests/test_custom_types.py
+++ b/slangpy/tests/test_custom_types.py
@@ -69,23 +69,27 @@ def test_thread_id(device_type: DeviceType, dimensions: int, signed: bool):
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 @pytest.mark.parametrize("dimensions", [-1, 1, 2, 3])
 @pytest.mark.parametrize("signed", [False, True])
-def test_call_id(device_type: DeviceType, dimensions: int, signed: bool):
+@pytest.mark.parametrize("array", [False, True])
+def test_call_id(device_type: DeviceType, dimensions: int, signed: bool, array: bool):
 
     inttype = 'int' if signed else 'uint'
 
     if dimensions > 0:
-        # If dimensions > 0, test passing explicit dimensions into corresponding vector type
-        type_name = f"{inttype}{dimensions}"
+        # If dimensions > 0, test passing explicit dimensions into corresponding vector/array type
+        type_name = f"int[{dimensions}]" if array else f"{inttype}{dimensions}"
         elements = dimensions
         dims = dimensions
     elif dimensions == 0:
+        if array:
+            pytest.skip("Array not supported for 0D call_id")
+
         # If dimensions == 0, test passing 1D value into corresponding scalar type
         type_name = inttype
         elements = 1
         dims = 1
     else:
-        # If dimensions == -1, test passing undefined dimensions to 3d vector type
-        type_name = f"{inttype}3"
+        # If dimensions == -1, test passing undefined dimensions to implicit array or 3d vector type
+        type_name = f"int[3]" if array else f"{inttype}3"
         elements = 3
         dims = -1
 
@@ -113,6 +117,12 @@ def test_call_id(device_type: DeviceType, dimensions: int, signed: bool):
     # Should get out the thread ids
     data = results.storage.to_numpy().view("int32").reshape((-1, elements))
     expected = np.indices((16,)*elements).reshape(elements, -1).T
+
+    # Reverse order of components in last dimension of expected
+    # if testing a vector type
+    if not array and elements > 1:
+        expected = np.flip(expected, axis=1)
+
     assert np.allclose(data, expected)
 
 

--- a/slangpy/tests/test_grid.py
+++ b/slangpy/tests/test_grid.py
@@ -102,7 +102,7 @@ int3 get(int3 input) {{
 }}
 """
                                    )
-    with pytest.raises(ValueError, match="After implicit casting"):
+    with pytest.raises(ValueError, match="Could not find suitable"):
         module.get(grid(shape=(2, 2)), _result='numpy')
 
 
@@ -116,7 +116,7 @@ int3 get(int[3] input) {{
 }}
 """
                                    )
-    with pytest.raises(ValueError, match="After implicit casting"):
+    with pytest.raises(ValueError, match="Could not find suitable"):
         module.get(grid(shape=(2, 2)), _result='numpy')
 
 

--- a/slangpy/tests/test_grid.py
+++ b/slangpy/tests/test_grid.py
@@ -59,6 +59,9 @@ def grid_test(device_type: DeviceType, dims: int = 2, datatype: str = 'array', s
     resdata = res.to_numpy().view(np.int32).reshape(shape + (dims,))
     expected = np.indices(shape).transpose(*transpose) * stride + offset
 
+    if datatype == 'vector':
+        expected = np.flip(expected, axis=-1)
+
     assert np.all(resdata == expected)
 
 

--- a/slangpy/types/callidarg.py
+++ b/slangpy/types/callidarg.py
@@ -55,10 +55,12 @@ class CallIdArgMarshall(Marshall):
             cgb.type_alias(f"_t_{name}", self.slang_type.full_name)
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
-        # Experimental way to resolve the bound type using reflection.
+        # Resolve type using reflection.
         conv_type = bound_type.program.find_type_by_name(
-            f"CallIdArgConversion<{bound_type.full_name}, {self.dims}>.ArgType")
-        # return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32, support_array=True)
+            f"VectorizeCallidArgTo<{bound_type.full_name}, {self.dims}>.VectorType")
+        if conv_type is None:
+            raise ValueError(
+                f"Could not find suitable conversion from CallIdArg<{self.dims}> to {bound_type.full_name}")
         return conv_type
 
     def resolve_dimensionality(self, context: BindContext, binding: BoundVariable, vector_target_type: 'SlangType'):

--- a/slangpy/types/callidarg.py
+++ b/slangpy/types/callidarg.py
@@ -55,8 +55,11 @@ class CallIdArgMarshall(Marshall):
             cgb.type_alias(f"_t_{name}", self.slang_type.full_name)
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
-        # Thread id arg is valid to pass to vector or scalar integer types.
-        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32, support_array=True)
+        # Experimental way to resolve the bound type using reflection.
+        conv_type = bound_type.program.find_type_by_name(
+            f"CallIdArgConversion<{bound_type.full_name}, {self.dims}>.ArgType")
+        # return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32, support_array=True)
+        return conv_type
 
     def resolve_dimensionality(self, context: BindContext, binding: BoundVariable, vector_target_type: 'SlangType'):
         # Thread id arg is generated for every thread and has no effect on call shape,

--- a/slangpy/types/callidarg.py
+++ b/slangpy/types/callidarg.py
@@ -56,7 +56,7 @@ class CallIdArgMarshall(Marshall):
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
         # Thread id arg is valid to pass to vector or scalar integer types.
-        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32)
+        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32, support_array=True)
 
     def resolve_dimensionality(self, context: BindContext, binding: BoundVariable, vector_target_type: 'SlangType'):
         # Thread id arg is generated for every thread and has no effect on call shape,

--- a/slangpy/types/helpers.py
+++ b/slangpy/types/helpers.py
@@ -4,18 +4,32 @@
 from slangpy.backend import TypeReflection
 from slangpy.bindings.marshall import BindContext
 from slangpy.core.utils import is_type_castable_on_host
-from slangpy.reflection.reflectiontypes import ScalarType, SlangType, VectorType
+from slangpy.reflection.reflectiontypes import ArrayType, ScalarType, SlangType, VectorType
 
 
-def resolve_vector_generator_type(context: BindContext, bound_type: SlangType, fixed_dims: int, scalar_type: TypeReflection.ScalarType):
+def resolve_vector_generator_type(context: BindContext, bound_type: SlangType, fixed_dims: int, scalar_type: TypeReflection.ScalarType, max_dims=-1, support_scalar: bool = True, support_vector: bool = True, support_array: bool = False):
     """
     General purpose helper for simple generators that can output to vector or scalar types.
     """
-    if isinstance(bound_type, VectorType):
-        # Vector type - check match+conversions before just returning the bound type
-        if bound_type.num_elements > 3:
+    if support_array and isinstance(bound_type, ArrayType):
+        # Array type - check match+conversions before just returning the bound type
+        if max_dims > 0 and bound_type.num_elements > max_dims:
             raise ValueError(
-                f"Argument must be a vector of size 1, 2 or 3. Got {bound_type.num_elements}.")
+                f"Argument can not have more than {max_dims} dims. Got {bound_type.num_elements}.")
+        if fixed_dims != -1 and fixed_dims != bound_type.num_elements:
+            raise ValueError(
+                f"Argument must be a array of size {fixed_dims}. Got {bound_type.num_elements}.")
+        resolved_type = context.layout.array_type(
+            context.layout.scalar_type(scalar_type), bound_type.shape[0])
+        if not is_type_castable_on_host(resolved_type, bound_type):
+            raise ValueError(
+                f"Unable to convert argument of type {resolved_type.full_name} to {bound_type.full_name}.")
+        return bound_type
+    if support_vector and isinstance(bound_type, VectorType):
+        # Vector type - check match+conversions before just returning the bound type
+        if max_dims > 0 and bound_type.num_elements > max_dims:
+            raise ValueError(
+                f"Argument can not have more than {max_dims} dims. Got {bound_type.num_elements}.")
         if fixed_dims != -1 and fixed_dims != bound_type.num_elements:
             raise ValueError(
                 f"Argument must be a vector of size {fixed_dims}. Got {bound_type.num_elements}.")
@@ -25,7 +39,7 @@ def resolve_vector_generator_type(context: BindContext, bound_type: SlangType, f
             raise ValueError(
                 f"Unable to convert argument of type {resolved_type.full_name} to {bound_type.full_name}.")
         return bound_type
-    elif isinstance(bound_type, ScalarType):
+    elif support_scalar and isinstance(bound_type, ScalarType):
         # Scalar type - check match+conversions before just returning the bound type
         if fixed_dims != -1 and fixed_dims != 1:
             raise ValueError(
@@ -42,4 +56,4 @@ def resolve_vector_generator_type(context: BindContext, bound_type: SlangType, f
     else:
         # Unknown type, and no explicit dimensions passed, so can't resolve to a concrete type.
         raise ValueError(
-            f"Argument must be a scalar or vector type. Got {bound_type.full_name}.")
+            f"Argument is not supported type. Got {bound_type.full_name}.")

--- a/slangpy/types/randfloatarg.py
+++ b/slangpy/types/randfloatarg.py
@@ -66,7 +66,7 @@ class RandFloatArgMarshall(Marshall):
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
         # Wang hash arg is valid to pass to vector or scalar integer types.
-        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.float32)
+        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.float32, max_dims=3)
 
     def resolve_dimensionality(self, context: BindContext, binding: BoundVariable, vector_target_type: 'SlangType'):
         # Rand float arg is generated for every thread and has no effect on call shape,

--- a/slangpy/types/threadidarg.py
+++ b/slangpy/types/threadidarg.py
@@ -49,7 +49,7 @@ class ThreadIdArgMarshall(Marshall):
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
         # Thread id arg is valid to pass to vector or scalar integer types.
-        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32)
+        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32, max_dims=3)
 
     def resolve_dimensionality(self, context: BindContext, binding: BoundVariable, vector_target_type: 'SlangType'):
         # Thread id arg is generated for every thread and has no effect on call shape,

--- a/slangpy/types/wanghasharg.py
+++ b/slangpy/types/wanghasharg.py
@@ -64,7 +64,7 @@ class WangHashArgMarshall(Marshall):
 
     def resolve_type(self, context: BindContext, bound_type: 'SlangType'):
         # Wang hash arg is valid to pass to vector or scalar integer types.
-        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32)
+        return resolve_vector_generator_type(context, bound_type, self.dims, TypeReflection.ScalarType.int32, max_dims=3)
 
     def resolve_dimensionality(self, context: BindContext, binding: BoundVariable, vector_target_type: SlangType):
         # Wang hash arg is generated for every thread and has no effect on call shape,


### PR DESCRIPTION
When a slang vector (eg int4, vector<int,4>) is used to refer to either dispatch grid coordinates or coordinates within a buffer, its dimensions are transposed, such that for a 3D space [A,B,C], v.x->C, v.y->B, c.z->A. This brings it inline with standard conventions in graphics apis using vectors to index into textures.