### PR TITLE
Fixes to hot reload

### DIFF
--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -106,17 +106,17 @@ class CallData(NativeCallData):
 
             # Perform specialization to get a concrete function reflection
             slang_function = specialize(
-                context, bindings, build_info.reflections, build_info.type_reflection)
+                context, bindings, build_info.functions, build_info.this_type)
             if isinstance(slang_function, MismatchReason):
                 raise ResolveException(
                     f"Function signature mismatch: {slang_function.reason}\n\n"
-                    f"{mismatch_info(bindings, build_info.reflections)}\n")
+                    f"{mismatch_info(bindings, build_info.functions)}\n")
 
             # Check for differentiability error
             if not slang_function.differentiable and self.call_mode != CallMode.prim:
                 raise ResolveException(
                     f"Could not call function '{function.name}': Function is not differentiable\n\n"
-                    f"{mismatch_info(bindings, build_info.reflections)}\n")
+                    f"{mismatch_info(bindings, build_info.functions)}\n")
 
             # Inject a dummy node into the Python signature if we need a result back
             if self.call_mode == CallMode.prim and not "_result" in kwargs and slang_function.return_type is not None and slang_function.return_type.full_name != 'void':
@@ -216,8 +216,8 @@ class CallData(NativeCallData):
 
         except BoundVariableException as e:
             if bindings is not None:
-                ref = slang_function.reflection if isinstance(
-                    slang_function, SlangFunction) else build_info.reflections[0]
+                ref = slang_function if isinstance(
+                    slang_function, SlangFunction) else build_info.functions[0]
                 raise ValueError(
                     f"{e.message}\n\n"
                     f"{bound_exception_info(bindings, ref, e.variable)}\n") from e
@@ -225,8 +225,8 @@ class CallData(NativeCallData):
                 raise
         except SlangCompileError as e:
             if bindings is not None:
-                ref = slang_function.reflection if isinstance(
-                    slang_function, SlangFunction) else build_info.reflections[0]
+                ref = slang_function if isinstance(
+                    slang_function, SlangFunction) else build_info.functions[0]
                 raise ValueError(
                     f"Slang compilation error: {e}\n. Use set_dump_generated_shaders to enable dump generated shader to .temp.\n"
                     f"This most commonly occurs as a result of an invalid explicit type cast, or bug in implicit casting logic.\n\n"
@@ -235,8 +235,8 @@ class CallData(NativeCallData):
                 raise e
         except KernelGenException as e:
             if bindings is not None:
-                ref = slang_function.reflection if isinstance(
-                    slang_function, SlangFunction) else build_info.reflections[0]
+                ref = slang_function if isinstance(
+                    slang_function, SlangFunction) else build_info.functions[0]
                 raise ValueError(
                     f"Exception in kernel generation: {e.message}.\n\n"
                     f"{bound_exception_info(bindings, ref, None)}\n") from e
@@ -247,8 +247,8 @@ class CallData(NativeCallData):
             raise e
         except Exception as e:
             if bindings is not None:
-                ref = slang_function.reflection if isinstance(
-                    slang_function, SlangFunction) else build_info.reflections[0]
+                ref = slang_function if isinstance(
+                    slang_function, SlangFunction) else build_info.functions[0]
                 raise ValueError(
                     f"Exception in kernel generation: {e}.\n"
                     f"{bound_exception_info(bindings, ref, None)}\n") from e

--- a/slangpy/core/dispatchdata.py
+++ b/slangpy/core/dispatchdata.py
@@ -53,12 +53,12 @@ class DispatchData:
             self.runtime = BoundCallRuntime(bindings)
 
             # Verify and get reflection data.
-            if len(build_info.reflections) > 1 or build_info.reflections[0].is_overloaded:
+            if len(build_info.functions) > 1 or build_info.functions[0].reflection.is_overloaded:
                 raise ValueError("Cannot use raw dispatch on overloaded functions.")
-            if build_info.type_reflection is not None:
+            if build_info.this_type is not None:
                 raise ValueError("Cannot use raw dispatch on type methods.")
 
-            reflection = build_info.reflections[0]
+            reflection = build_info.functions[0].reflection
             slang_function = build_info.module.layout.find_function(reflection, None)
 
             # Ensure the function has no out or inout parameters, and no return value.

--- a/slangpy/core/logging.py
+++ b/slangpy/core/logging.py
@@ -2,6 +2,7 @@
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 from slangpy.backend import FunctionReflection, ModifierID, VariableReflection
+from slangpy.reflection import SlangFunction
 
 if TYPE_CHECKING:
     from slangpy.bindings.marshall import Marshall
@@ -195,14 +196,16 @@ def function_reflection(slang_function: Optional[FunctionReflection]):
     return "".join(text)
 
 
-def mismatch_info(call: 'BoundCall', reflections: list[FunctionReflection]):
+def mismatch_info(call: 'BoundCall', functions: list[SlangFunction]):
     text: list[str] = []
 
     text.append(f"Possible overloads:")
-    if len(reflections) == 1 and reflections[0].is_overloaded:
-        reflections = [x for x in reflections[0].overloads]
-    for r in reflections:
-        text.append(f"  {function_reflection(r)}")
+    if len(functions) == 1 and functions[0].reflection.is_overloaded:
+        for r in functions[0].reflection.overloads:
+            text.append(f"  {function_reflection(r)}")
+    else:
+        for f in functions:
+            text.append(f"  {function_reflection(f.reflection)}")
     text.append("")
     text.append(f"Python arguments:")
     text.append(f"{bound_call_table(call)}")
@@ -211,11 +214,11 @@ def mismatch_info(call: 'BoundCall', reflections: list[FunctionReflection]):
     return "\n".join(text)
 
 
-def bound_exception_info(call: 'BoundCall', concrete_reflection: FunctionReflection, variable: Optional['BoundVariable']):
+def bound_exception_info(call: 'BoundCall', concrete_function: SlangFunction, variable: Optional['BoundVariable']):
     text: list[str] = []
 
     text.append(f"Selected overload:")
-    text.append(f"  {function_reflection(concrete_reflection)}")
+    text.append(f"  {function_reflection(concrete_function.reflection)}")
     text.append("")
     if variable is not None and variable.name != "":
         text.append(f"Error caused by argument: {variable.name}")

--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -62,9 +62,7 @@ class Module:
         # This should be solved by the combined object API in the future
         module_list = [self.slangpy_device_module, self.device_module]
         combined_program = device_module.session.link_program(module_list, [])
-        # Do we still need the device_module layout here if the modules are linked?
-        self.layout = SlangProgramLayout(combined_program.layout,
-                                         self.slangpy_device_module.layout)
+        self.layout = SlangProgramLayout(combined_program.layout)
 
         self.call_data_cache = CallDataCache()
         self.dispatch_data_cache: dict[str, 'DispatchData'] = {}

--- a/slangpy/core/struct.py
+++ b/slangpy/core/struct.py
@@ -89,7 +89,10 @@ class Struct:
             (type, funcs) = try_find_function_overloads_via_ast(
                 self.device_module.module_decl, self.name, name)
             if funcs is not None and len(funcs) > 0:
-                res = Function(module=self.module, func=funcs,
+                slang_funcs = []
+                for func in funcs:
+                    slang_funcs.append(self.module.layout.find_function(func, type))
+                res = Function(module=self.module, func=slang_funcs,
                                struct=self, options=self.options)
                 return res
 

--- a/slangpy/reflection/reflectiontypes.py
+++ b/slangpy/reflection/reflectiontypes.py
@@ -882,10 +882,10 @@ class SlangProgramLayout:
         # Re-lookup all types.
         for name, type in self._types_by_name.items():
             trefl = program_layout.find_type_by_name(name)
-            assert trefl is not None
-            type.on_hot_reload(trefl)
-            new_types_by_name[name] = type
-            new_types_by_reflection[trefl] = type
+            if trefl is not None:
+                type.on_hot_reload(trefl)
+                new_types_by_name[name] = type
+                new_types_by_reflection[trefl] = type
 
         self._types_by_name = new_types_by_name
         self._types_by_reflection = new_types_by_reflection
@@ -900,17 +900,17 @@ class SlangProgramLayout:
                 type_name = name[:idx]
                 func_name = name[idx+2:]
                 type = self.find_type_by_name(type_name)
-                assert type is not None
-                frefl = program_layout.find_function_by_name_in_type(
-                    type.type_reflection, func_name)
-                assert frefl is not None
-                func.on_hot_reload(frefl)
+                if type is not None:
+                    frefl = program_layout.find_function_by_name_in_type(
+                        type.type_reflection, func_name)
+                else:
+                    frefl = None
             else:
                 frefl = program_layout.find_function_by_name(name)
-                assert frefl is not None
+            if frefl is not None:
                 func.on_hot_reload(frefl)
-            new_functions_by_name[name] = func
-            new_functions_by_reflection[frefl] = func
+                new_functions_by_name[name] = func
+                new_functions_by_reflection[frefl] = func
 
         self._functions_by_name = new_functions_by_name
         self._functions_by_reflection = new_functions_by_reflection

--- a/slangpy/reflection/reflectiontypes.py
+++ b/slangpy/reflection/reflectiontypes.py
@@ -702,6 +702,13 @@ class SlangFunction:
         """
         return self.reflection.has_modifier(ModifierID.mutating)
 
+    @property
+    def static(self) -> bool:
+        """
+        Whether this function is static. Only relevant for type methods.
+        """
+        return self.reflection.has_modifier(ModifierID.static)
+
 
 class BaseSlangVariable:
     """

--- a/slangpy/reflection/reflectiontypes.py
+++ b/slangpy/reflection/reflectiontypes.py
@@ -862,11 +862,10 @@ class SlangProgramLayout:
     from an sgl ProgramLayout.
     """
 
-    def __init__(self, program_layout: ProgramLayout, slangpy_program_layout: Optional[ProgramLayout] = None):
+    def __init__(self, program_layout: ProgramLayout):
         super().__init__()
         assert isinstance(program_layout, ProgramLayout)
         self.program_layout = program_layout
-        self.slangpy_program_layout = slangpy_program_layout
         self._types_by_name: dict[str, SlangType] = {}
         self._types_by_reflection: dict[TypeReflection, SlangType] = {}
         self._functions_by_name: dict[str, SlangFunction] = {}
@@ -939,8 +938,6 @@ class SlangProgramLayout:
         if existing is not None:
             return existing
         type_refl = self.program_layout.find_type_by_name(name)
-        if type_refl is None and self.slangpy_program_layout is not None:
-            type_refl = self.slangpy_program_layout.find_type_by_name(name)
         if type_refl is None:
             return None
         res = self._get_or_create_type(type_refl)


### PR DESCRIPTION
This fixes a bunch of places in the codebase that break with hot reload.

Generally, we can't store raw TypeReflection/FunctionReflections, since those will go stale under reload. Instead, we have to use SlangFunction/SlangType, which will get updated during the hot reload hook.

This patch is being conservative and clears all caches during a hot reload. Some cached data might be salvageable, but I saw weird behavior when caches were left untouched, and it's better to take the performance hit on a reload which is already expensive.
