### PR TITLE
Move away from AST lookups for constructor reflection

### DIFF
--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -106,17 +106,17 @@ class CallData(NativeCallData):
 
             # Perform specialization to get a concrete function reflection
             slang_function = specialize(
-                context, bindings, build_info.functions, build_info.this_type)
+                context, bindings, build_info.function, build_info.this_type)
             if isinstance(slang_function, MismatchReason):
                 raise ResolveException(
                     f"Function signature mismatch: {slang_function.reason}\n\n"
-                    f"{mismatch_info(bindings, build_info.functions)}\n")
+                    f"{mismatch_info(bindings, build_info.function)}\n")
 
             # Check for differentiability error
             if not slang_function.differentiable and self.call_mode != CallMode.prim:
                 raise ResolveException(
                     f"Could not call function '{function.name}': Function is not differentiable\n\n"
-                    f"{mismatch_info(bindings, build_info.functions)}\n")
+                    f"{mismatch_info(bindings, build_info.function)}\n")
 
             # Inject a dummy node into the Python signature if we need a result back
             if self.call_mode == CallMode.prim and not "_result" in kwargs and slang_function.return_type is not None and slang_function.return_type.full_name != 'void':
@@ -217,7 +217,7 @@ class CallData(NativeCallData):
         except BoundVariableException as e:
             if bindings is not None:
                 ref = slang_function if isinstance(
-                    slang_function, SlangFunction) else build_info.functions[0]
+                    slang_function, SlangFunction) else build_info.function
                 raise ValueError(
                     f"{e.message}\n\n"
                     f"{bound_exception_info(bindings, ref, e.variable)}\n") from e
@@ -226,7 +226,7 @@ class CallData(NativeCallData):
         except SlangCompileError as e:
             if bindings is not None:
                 ref = slang_function if isinstance(
-                    slang_function, SlangFunction) else build_info.functions[0]
+                    slang_function, SlangFunction) else build_info.function
                 raise ValueError(
                     f"Slang compilation error: {e}\n. Use set_dump_generated_shaders to enable dump generated shader to .temp.\n"
                     f"This most commonly occurs as a result of an invalid explicit type cast, or bug in implicit casting logic.\n\n"
@@ -236,7 +236,7 @@ class CallData(NativeCallData):
         except KernelGenException as e:
             if bindings is not None:
                 ref = slang_function if isinstance(
-                    slang_function, SlangFunction) else build_info.functions[0]
+                    slang_function, SlangFunction) else build_info.function
                 raise ValueError(
                     f"Exception in kernel generation: {e.message}.\n\n"
                     f"{bound_exception_info(bindings, ref, None)}\n") from e
@@ -248,7 +248,7 @@ class CallData(NativeCallData):
         except Exception as e:
             if bindings is not None:
                 ref = slang_function if isinstance(
-                    slang_function, SlangFunction) else build_info.functions[0]
+                    slang_function, SlangFunction) else build_info.function
                 raise ValueError(
                     f"Exception in kernel generation: {e}.\n"
                     f"{bound_exception_info(bindings, ref, None)}\n") from e

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -58,9 +58,16 @@ def specialize(
     function: SlangFunction,
     type: Optional[SlangType] = None
 ):
+    # Special case for constructors
+    if function.is_overloaded and function.is_constructor:
+        matches = [x for x in function.overloads if len(
+            x.parameters) == signature.num_function_args]
+        if len(matches) != 1:
+            return MismatchReason("Overloaded functions are currently only supported if they have different argument counts.")
+        function = matches[0]
 
-    # Expecting 'this' argument as first parameter of none-static member functions (except for $init)
-    first_arg_is_this = type is not None and not function.static and function.name != "$init"
+    # Expecting 'this' argument as first parameter of none-static member functions (except for constructors)
+    first_arg_is_this = type is not None and not function.static and not function.is_constructor
 
     # Require '_result' argument for derivative calls, either as '_result' named parameter or last positional argument
     last_arg_is_retval = function.return_type is not None and function.return_type.name != 'void' and not "_result" in signature.kwargs and context.call_mode != CallMode.prim
@@ -75,8 +82,8 @@ def specialize(
         signature_args = signature_args[:-1]
 
     if signature.num_function_kwargs > 0 or signature.has_implicit_args:
-        if function.reflection.is_overloaded:
-            return MismatchReason("Calling an overloaded function with named or implicit arguments is not currently supported.")
+        if function.is_overloaded:
+            return MismatchReason(f"Calling an overloaded function with named or implicit arguments is not currently supported.")
 
         function_parameters = [x for x in function.parameters]
 

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -55,22 +55,9 @@ def is_generic_vector(type: TypeReflection) -> bool:
 def specialize(
     context: BindContext,
     signature: BoundCall,
-    functions: list[SlangFunction],
+    function: SlangFunction,
     type: Optional[SlangType] = None
 ):
-    # Handle current slang issue where init has to be found via ast, resulting in potential multiple functions
-    if len(functions) > 1:
-        if functions[0].name == "$init":
-            matches = [x for x in functions if len(
-                x.parameters) == signature.num_function_args]
-            if len(matches) != 1:
-                return MismatchReason("Overloaded $init functions are currently only supported if they have different argument counts.")
-            function = matches[0]
-        else:
-            raise ValueError(
-                "Internal error - Multiple function reflections provided, which should only happen with $init.")
-    else:
-        function = functions[0]
 
     # Expecting 'this' argument as first parameter of none-static member functions (except for $init)
     first_arg_is_this = type is not None and not function.static and function.name != "$init"

--- a/slangpy/core/dispatchdata.py
+++ b/slangpy/core/dispatchdata.py
@@ -53,12 +53,12 @@ class DispatchData:
             self.runtime = BoundCallRuntime(bindings)
 
             # Verify and get reflection data.
-            if len(build_info.functions) > 1 or build_info.functions[0].reflection.is_overloaded:
+            if build_info.function.is_overloaded:
                 raise ValueError("Cannot use raw dispatch on overloaded functions.")
             if build_info.this_type is not None:
                 raise ValueError("Cannot use raw dispatch on type methods.")
 
-            reflection = build_info.functions[0].reflection
+            reflection = build_info.function.reflection
             slang_function = build_info.module.layout.find_function(reflection, None)
 
             # Ensure the function has no out or inout parameters, and no return value.

--- a/slangpy/core/function.py
+++ b/slangpy/core/function.py
@@ -43,7 +43,7 @@ class FunctionBuildInfo:
         # Will always be populated by the root
         self.name: str
         self.module: 'Module'
-        self.functions: list[SlangFunction]
+        self.function: SlangFunction
         self.this_type: Optional[SlangType]
 
         # Optional value that will be set depending on the chain.
@@ -410,7 +410,7 @@ class FunctionNodeThreadGroupSize(FunctionNode):
 
 
 class Function(FunctionNode):
-    def __init__(self, module: 'Module', func: Union[str, SlangFunction, list[SlangFunction]], struct: Optional['Struct'] = None, options: dict[str, Any] = {}) -> None:
+    def __init__(self, module: 'Module', func: Union[str, SlangFunction], struct: Optional['Struct'] = None, options: dict[str, Any] = {}) -> None:
         super().__init__(None, FunctionNodeType.kernelgen, None)
 
         self._module = module
@@ -424,16 +424,10 @@ class Function(FunctionNode):
                 raise ValueError(f"Function '{func}' not found")
             func = sf
 
-        if isinstance(func, SlangFunction):
-            slang_funcs = [func]
-            # Track fully specialized name where available
-            self._name = func.full_name
-        else:
-            slang_funcs = func
-            self._name = func[0].name
-
-        # Store function reflections (should normally be 1 unless forced to do AST based search)
-        self._slang_funcs = slang_funcs
+        # Track fully specialized name
+        self._name = func.full_name
+        # Store function reflection
+        self._slang_func = func
 
         # Store type parent name if found
         if struct is not None:
@@ -463,5 +457,5 @@ class Function(FunctionNode):
         info.name = self.name
         info.module = self.module
         info.options.update(self._options)
-        info.functions = self._slang_funcs
+        info.function = self._slang_func
         info.this_type = self._this_type

--- a/slangpy/core/logging.py
+++ b/slangpy/core/logging.py
@@ -196,16 +196,16 @@ def function_reflection(slang_function: Optional[FunctionReflection]):
     return "".join(text)
 
 
-def mismatch_info(call: 'BoundCall', functions: list[SlangFunction]):
+def mismatch_info(call: 'BoundCall', function: SlangFunction):
     text: list[str] = []
 
-    text.append(f"Possible overloads:")
-    if len(functions) == 1 and functions[0].reflection.is_overloaded:
-        for r in functions[0].reflection.overloads:
-            text.append(f"  {function_reflection(r)}")
-    else:
-        for f in functions:
+    if function.is_overloaded:
+        text.append(f"Possible overloads:")
+        for f in function.overloads:
             text.append(f"  {function_reflection(f.reflection)}")
+    else:
+        text.append(f"Slang function:")
+        text.append(f"  {function_reflection(function.reflection)}")
     text.append("")
     text.append(f"Python arguments:")
     text.append(f"{bound_call_table(call)}")

--- a/slangpy/core/struct.py
+++ b/slangpy/core/struct.py
@@ -78,7 +78,7 @@ class Struct:
             name = "$init"
         slang_function = self.module.layout.find_function_by_name_in_type(
             self.struct, name)
-        if slang_function is not None and name != "$init":  # FIXME: Workaround to preserve current lookup behavior
+        if slang_function is not None:
             res = Function(module=self.module, func=slang_function,
                            struct=self, options=self.options)
             return res

--- a/slangpy/core/struct.py
+++ b/slangpy/core/struct.py
@@ -83,19 +83,6 @@ class Struct:
                            struct=self, options=self.options)
             return res
 
-        # Currently have Slang issue finding the init function, so for none-generic classes,
-        # try to find it via the AST.
-        if not '<' in self.name and name == "$init":
-            (type, funcs) = try_find_function_overloads_via_ast(
-                self.device_module.module_decl, self.name, name)
-            if funcs is not None and len(funcs) > 0:
-                slang_funcs = []
-                for func in funcs:
-                    slang_funcs.append(self.module.layout.find_function(func, type))
-                res = Function(module=self.module, func=slang_funcs,
-                               struct=self, options=self.options)
-                return res
-
         return None
 
     def __getattr__(self, name: str) -> Union['Struct', 'Function']:

--- a/slangpy/reflection/reflectiontypes.py
+++ b/slangpy/reflection/reflectiontypes.py
@@ -709,6 +709,15 @@ class SlangFunction:
         """
         return self.reflection.has_modifier(ModifierID.static)
 
+    @property
+    def is_constructor(self) -> bool:
+        """
+        Returns True if this function is a class constructor
+        """
+        # .name currently returns None for constructors (slang issue 6406).
+        # Check the full name instead
+        return self._full_name.startswith("$init")
+
 
 class BaseSlangVariable:
     """

--- a/slangpy/reflection/reflectiontypes.py
+++ b/slangpy/reflection/reflectiontypes.py
@@ -620,6 +620,7 @@ class SlangFunction:
         self._program = program
         self._cached_parameters: Optional[tuple[SlangParameter, ...]] = None
         self._cached_return_type: Optional[SlangType] = None
+        self._cached_overloads: Optional[tuple[SlangFunction]] = None
 
         if full_name is None:
             full_name = refl.name
@@ -629,6 +630,7 @@ class SlangFunction:
         self._reflection = refl
         self._cached_parameters = None
         self._cached_return_type = None
+        self._cached_overloads = None
 
     @property
     def reflection(self) -> FunctionReflection:
@@ -708,6 +710,25 @@ class SlangFunction:
         Whether this function is static. Only relevant for type methods.
         """
         return self.reflection.has_modifier(ModifierID.static)
+
+    @property
+    def is_overloaded(self) -> bool:
+        """
+        Whether this function is overloaded. Individual overloads can be retrieved with the overloads property
+        """
+        return self.reflection.is_overloaded
+
+    @property
+    def overloads(self) -> tuple[SlangFunction]:
+        """
+        Returns a tuple of the overloads of this function
+        """
+        if self._cached_overloads is None:
+            overloads = []
+            for refl in self.reflection.overloads:
+                overloads.append(SlangFunction(self._program, refl, self._this, self._full_name))
+            self._cached_overloads = tuple(overloads)
+        return self._cached_overloads
 
     @property
     def is_constructor(self) -> bool:


### PR DESCRIPTION
Slang 2025.5.1 now supports looking up constructors via function reflection. This MR removes obsolete code that did this via AST lookups instead. This gets rid of the lists of `SlangFunction` in a lot of places, and can instead use a single `SlangFunction` that may be overloaded.

The last vestige is the special casing of overloaded constructors in `callsignature.py:specialize`, which tries to narrow down the overloads based on the number of arguments. Now that constructors can use `.map`, can this code go away?

Right now, removing this will break tests, as some code relies on e.g. using kwargs with overloaded constructors, which is not allowed for regular functions. slangpy's behavior here is a bit weird, and we should probably deprecate this or allow implicit/keyword args for all overloaded functions.