### PR TITLE
Support resolving generic vectors, matrices and arrays

### DIFF
--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -56,7 +56,7 @@ def specialize(
     context: BindContext,
     signature: BoundCall,
     functions: list[SlangFunction],
-    type: Optional[SlangType] = None
+    this_type: Optional[SlangType] = None
 ):
     # Handle current slang issue where init has to be found via ast, resulting in potential multiple functions
     if len(functions) > 1:
@@ -73,7 +73,7 @@ def specialize(
         function = functions[0]
 
     # Expecting 'this' argument as first parameter of none-static member functions (except for $init)
-    first_arg_is_this = type is not None and not function.static and function.name != "$init"
+    first_arg_is_this = this_type is not None and not function.static and function.name != "$init"
 
     # Require '_result' argument for derivative calls, either as '_result' named parameter or last positional argument
     last_arg_is_retval = function.return_type is not None and function.return_type.name != 'void' and not "_result" in signature.kwargs and context.call_mode != CallMode.prim
@@ -129,11 +129,11 @@ def specialize(
             if python_arg.vector_type is not None:
                 # Always take explicit vector types if provided
                 inputs.append(python_arg.vector_type)
-            elif is_generic_vector(slang_param.type.type_reflection):
-                # HACK! Let types with a 'slang_element_type' try to resolve generic vector types
+            elif isinstance(slang_param.type, (slr.VectorType, slr.MatrixType, slr.ArrayType)) and slang_param.type.is_generic:
+                # HACK! Let types with a 'slang_element_type' try to resolve known generic types
                 # Failing that, fall back to python marshall
                 sl_et = getattr(python_arg.python, 'slang_element_type', None)
-                if isinstance(sl_et, slr.VectorType):
+                if isinstance(sl_et, type(slang_param.type)):
                     inputs.append(sl_et)
                 else:
                     inputs.append(python_arg.python)
@@ -174,7 +174,7 @@ def specialize(
     if specialized is None:
         return MismatchReason("No Slang overload found that matches the provided Python argument types.")
 
-    type_reflection = None if type is None else type.type_reflection
+    type_reflection = None if this_type is None else this_type.type_reflection
 
     return context.layout.find_function(specialized, type_reflection)
 

--- a/slangpy/tests/test_generics.py
+++ b/slangpy/tests/test_generics.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import pytest
+
+import slangpy.tests.helpers as helpers
+from slangpy.backend import DeviceType
+from slangpy.types.buffer import NDBuffer
+
+import numpy as np
+
+from slangpy.types.tensor import Tensor
+
+
+def do_generic_test(device_type: DeviceType, container_type: str, slang_type_name: str, generic_args: str, buffer_type_name: str):
+    # Create function that just dumps input to output
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(device, f"""
+{slang_type_name} get{generic_args}({slang_type_name} input) {{
+    return input;
+}}
+"""
+    )
+
+    shape = (1024,)
+    buffertype = module.layout.find_type_by_name(buffer_type_name)
+
+    if container_type == 'buffer':
+        buffer = NDBuffer(device, dtype=buffertype, shape=shape)
+        buffer.copy_from_numpy(np.random.random(int(buffer.storage.size / 4)).astype(np.float32))
+        results = module.get(buffer)
+        assert results.dtype == buffer.dtype
+        assert np.all(buffer.to_numpy() == results.to_numpy())
+    elif container_type == 'tensor':
+        tensor = Tensor.empty(device, dtype=buffertype, shape=shape)
+        results = module.get(tensor, _result='tensor')
+        assert results.dtype == tensor.dtype
+        assert np.all(tensor.to_numpy() == results.to_numpy())
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("container_type", ['buffer', 'tensor'])
+@pytest.mark.parametrize("dim", [1, 2, 3, 4])
+def test_generic_vector(device_type: DeviceType, container_type: str, dim: int):
+    do_generic_test(device_type, container_type, 'vector<float,N>', "<let N: int>", f'float{dim}')
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("container_type", ['buffer', 'tensor'])
+@pytest.mark.parametrize("dim", [2])
+def test_generic_array(device_type: DeviceType, container_type: str, dim: int):
+    do_generic_test(device_type, container_type, 'float[N]', "<let N: int>", f'float[{dim}]')
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("container_type", ['buffer', 'tensor'])
+@pytest.mark.parametrize("dim", [2])
+def test_generic_2d_array(device_type: DeviceType, container_type: str, dim: int):
+    do_generic_test(device_type, container_type,
+                    'float[N][N]', "<let N: int>", f'float[{dim}][{dim}]')
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("container_type", ['buffer', 'tensor'])
+@pytest.mark.parametrize("dim", [2])
+def test_generic_matrix(device_type: DeviceType, container_type: str, dim: int):
+    do_generic_test(device_type, container_type, 'matrix<float,N,N>',
+                    "<let N: int>", f'float{dim}x{dim}')
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/test_generics.py
+++ b/slangpy/tests/test_generics.py
@@ -66,5 +66,69 @@ def test_generic_matrix(device_type: DeviceType, container_type: str, dim: int):
                     "<let N: int>", f'float{dim}x{dim}')
 
 
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("explicit", [True, False])
+def test_arithmetic_generic_arguments_bug(device_type: DeviceType, explicit: bool):
+
+    # This test reproduces a Slang issue: https://github.com/shader-slang/slang/issues/6463
+    # Attempting to resolve a generic with arithmetic arguments fails. When the test is
+    # run with 'explicit' specialization, we generate and succesfully find the function.
+    # When we rely on Slang to solve the generic, it currently fails.
+
+    CODE = """
+interface IModule<int N, int M>
+{
+    float[M] eval(float[N] x);
+}
+
+struct LinearLayer<int N, int M> : IModule<N, M>
+{
+    float[M] eval(float[N] x)
+    {
+        float[M] result;
+        [ForceUnroll]
+        for (int i = 0; i < M; ++i) result[i] = 0.f;
+        return result;
+    }
+};
+
+float trainMaterial<
+    int numLatents,
+    Encoder : IModule<12, numLatents>,
+    Decoder : IModule<numLatents+6, 3> // <---- here!
+>
+(Encoder encoder, Decoder decoder)
+{
+    return 0.f;
+}
+"""
+
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(device, CODE)
+
+    class LinearLayer():
+        def __init__(self, n: int = 0, m: int = 0):
+            super().__init__()
+            self.n = n
+            self.m = m
+
+        def get_this(self):
+            return {
+                "_type": f"LinearLayer<{self.n}, {self.m}> "
+            }
+
+    encoder = LinearLayer(12, 8)
+    decoder = LinearLayer(8+6, 3)
+
+    if explicit:
+        func_name = f"trainMaterial<{encoder.m}, {encoder.get_this()['_type']}, {decoder.get_this()['_type']}>"
+        func = module.find_function(func_name)
+        assert func is not None
+        func(encoder, decoder)
+    else:
+        pytest.skip("Fails due to https://github.com/shader-slang/slang/issues/6463")
+        module.trainMaterial(encoder, decoder)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
This expands on our existing workaround to fix/support passing buffers/tensors of vectors, matrices or arrays to a function that takes a generic vector/matrix/array. It adds:
- more concrete checks inside reflection code + handling of generic values without crashing
- specialize code now handles matrices+arrays

We did support it originally for vectors, but that seems to have decayed. I've added a load of tests for them now.
