### PR TITLE
Better errors for missing functions + made struct look like slang type

### DIFF
--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -225,7 +225,7 @@ class Module:
             return slang_struct
 
         raise AttributeError(
-            f"Type '{self.device_module.name}' has no attribute '{name}'")
+            f"Module '{self.device_module.name}' has no function or type named '{name}'")
 
     def __getitem__(self, name: str):
         """

--- a/slangpy/core/struct.py
+++ b/slangpy/core/struct.py
@@ -23,11 +23,87 @@ class Struct:
         self.slangpy_signature = self.struct.full_name
 
     @property
+    def program(self):
+        """
+        Program layout struct is part of.
+        """
+        return self.struct.program
+
+    @property
     def name(self) -> str:
         """
         The name of the struct.
         """
+        return self.struct.name
+
+    @property
+    def full_name(self) -> str:
+        """
+        The name of the struct.
+        """
         return self.struct.full_name
+
+    @property
+    def element_type(self):
+        """
+        The element type of the struct.
+        """
+        e = self.struct.element_type
+        if e is None:
+            return None
+        return Struct(self.module, e, options=self.options)
+
+    @property
+    def fields(self):
+        """
+        The fields of the struct.
+        """
+        return self.struct.fields
+
+    @property
+    def differentiable(self):
+        """
+        The differentiable of the struct.
+        """
+        return self.struct.differentiable
+
+    @property
+    def derivative(self):
+        """
+        The derivative of the struct.
+        """
+        d = self.struct.derivative
+        if d is None:
+            return None
+        return Struct(self.module, d, options=self.options)
+
+    @property
+    def num_dims(self):
+        """
+        The number of dimensions of the struct.
+        """
+        return self.struct.num_dims
+
+    @property
+    def shape(self):
+        """
+        The shape of the struct.
+        """
+        return self.struct.shape
+
+    @property
+    def uniform_layout(self):
+        """
+        The uniform layout of the struct.
+        """
+        return self.struct.uniform_layout
+
+    @property
+    def buffer_layout(self):
+        """
+        The buffer layout of the struct.
+        """
+        return self.struct.buffer_layout
 
     @property
     def session(self):
@@ -35,6 +111,13 @@ class Struct:
         The Slang session the struct's module belongs to.
         """
         return self.module.device_module.session
+
+    @property
+    def type_reflection(self):
+        """
+        The type reflection of the struct.
+        """
+        return self.struct.type_reflection
 
     @property
     def device(self):
@@ -92,7 +175,9 @@ class Struct:
         child = self.try_get_child(name)
         if child is not None:
             return child
-        raise AttributeError(f"Type '{self.name}' has no attribute '{name}'")
+
+        raise AttributeError(
+            f"Struct '{self.name}' has no method or sub-type named '{name}'")
 
     def __getitem__(self, name: str):
         """

--- a/slangpy/tests/test_errors.py
+++ b/slangpy/tests/test_errors.py
@@ -144,5 +144,27 @@ def test_invalid_broadcast_during_dispatch(device_type: DeviceType):
         function(buffer, buffer2)
 
 
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_missing_function(device_type: DeviceType):
+
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(device, """void hello() {}""")
+
+    with pytest.raises(AttributeError, match=r'has no function or type named'):
+        func = module.foo
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_missing_child_function(device_type: DeviceType):
+
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(device, """
+                                   struct Foo {}
+                                   void hello() {}""")
+
+    with pytest.raises(AttributeError, match=r'has no method or sub-type named'):
+        func = module.Foo.foo
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Improved some error reporting, and added properties to Struct so it can duck type with SlangType. 

Main contentious change in terms of old code is that Struct.name now returns the same value as SlangType.name, where previously it returned SlangType.full_name. 