### PR TITLE
metal support

### DIFF
--- a/examples/broadcasting/main.py
+++ b/examples/broadcasting/main.py
@@ -91,9 +91,9 @@ print("")
 
 # Create a sampler and texture
 sampler = device.create_sampler()
-tex = device.create_texture(width=32, height=32, format=sgl.Format.rgb32_float,
+tex = device.create_texture(width=32, height=32, format=sgl.Format.rgba32_float,
                             usage=sgl.ResourceUsage.shader_resource)
-tex.copy_from_numpy(np.random.rand(32, 32, 3).astype(np.float32))
+tex.copy_from_numpy(np.random.rand(32, 32, 4).astype(np.float32))
 
 # Sample the texture at a single UV coordinate. Results in 1 thread,
 # as the uv coordinate input is a single float 2.

--- a/examples/buffers/main.py
+++ b/examples/buffers/main.py
@@ -47,5 +47,5 @@ for x in range(16):
 
 # Or if installed, we can use tev to show the result (https://github.com/Tom94/tev)
 tex = device.create_texture(data=result.to_numpy(), width=16,
-                            height=16, format=sgl.Format.rgb32_float)
+                            height=16, format=sgl.Format.rgba32_float)
 sgl.tev.show(tex)

--- a/examples/toy-restir/app.py
+++ b/examples/toy-restir/app.py
@@ -4,10 +4,10 @@ from typing import Callable, Optional
 import sgl
 import slangpy
 from pathlib import Path
-
+from slangpy.backend import DeviceType
 
 class App:
-    def __init__(self, title="BRDF Example", width=1024, height=1024, device_type=sgl.DeviceType.d3d12):
+    def __init__(self, title="BRDF Example", width=1024, height=1024, device_type=DeviceType.automatic):
         super().__init__()
 
         # Create SGL window

--- a/examples/type_methods/main.py
+++ b/examples/type_methods/main.py
@@ -31,7 +31,7 @@ result_cursor = particles.buffer.cursor()
 
 for i in range(particles.shape[0]):
     instance = result_cursor[i].read()
-    print('{} {}'.format(instance['position'], instance['velocity']))
+    print(f"{instance['position']} {instance['velocity']}")
 
 # Update the particles
 particles.update(0.1)
@@ -40,4 +40,4 @@ result_cursor = particles.buffer.cursor()
 # Print all the particles by breaking them down into groups of 6 floats
 for i in range(particles.shape[0]):
     instance = result_cursor[i].read()
-    print('{} {}'.format(instance['position'], instance['velocity']))
+    print(f"{instance['position']} {instance['velocity']}")

--- a/examples/type_methods/main.py
+++ b/examples/type_methods/main.py
@@ -27,10 +27,17 @@ particles.construct(
 )
 
 # Print all the particles by breaking them down into groups of 6 floats
-print(particles.to_numpy().view(dtype=np.float32).reshape(-1, 6))
+result_cursor = particles.buffer.cursor()
+
+for i in range(particles.shape[0]):
+    instance = result_cursor[i].read()
+    print('{} {}'.format(instance['position'], instance['velocity']))
 
 # Update the particles
 particles.update(0.1)
 
+result_cursor = particles.buffer.cursor()
 # Print all the particles by breaking them down into groups of 6 floats
-print(particles.to_numpy().view(dtype=np.float32).reshape(-1, 6))
+for i in range(particles.shape[0]):
+    instance = result_cursor[i].read()
+    print('{} {}'.format(instance['position'], instance['velocity']))

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -200,7 +200,7 @@ class CallData(NativeCallData):
                 session = build_info.module.session
                 device = session.device
                 module = session.load_module_from_source(hash, code)
-                ep = module.entry_point(f"main", type_conformances)
+                ep = module.entry_point(f"computeMain", type_conformances)
                 opts = SlangLinkOptions()
                 opts.dump_intermediates = _DUMP_SLANG_INTERMEDIATES
                 opts.dump_intermediates_prefix = sanitized

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -200,7 +200,7 @@ class CallData(NativeCallData):
                 session = build_info.module.session
                 device = session.device
                 module = session.load_module_from_source(hash, code)
-                ep = module.entry_point(f"computeMain", type_conformances)
+                ep = module.entry_point(f"compute_main", type_conformances)
                 opts = SlangLinkOptions()
                 opts.dump_intermediates = _DUMP_SLANG_INTERMEDIATES
                 opts.dump_intermediates_prefix = sanitized

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -428,7 +428,7 @@ def generate_code(context: BindContext, build_info: 'FunctionBuildInfo', signatu
     # Generate the main function
     cg.kernel.append_line('[shader("compute")]')
     cg.kernel.append_line("[numthreads(32, 1, 1)]")
-    cg.kernel.append_line("void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)")
+    cg.kernel.append_line("void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)")
     cg.kernel.begin_block()
     cg.kernel.append_statement(
         "if (any(dispatchThreadID >= call_data._thread_count)) return")

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -428,7 +428,7 @@ def generate_code(context: BindContext, build_info: 'FunctionBuildInfo', signatu
     # Generate the main function
     cg.kernel.append_line('[shader("compute")]')
     cg.kernel.append_line("[numthreads(32, 1, 1)]")
-    cg.kernel.append_line("void main(uint3 dispatchThreadID: SV_DispatchThreadID)")
+    cg.kernel.append_line("void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)")
     cg.kernel.begin_block()
     cg.kernel.append_statement(
         "if (any(dispatchThreadID >= call_data._thread_count)) return")

--- a/slangpy/core/utils.py
+++ b/slangpy/core/utils.py
@@ -8,7 +8,7 @@ from slangpy.backend import (DeclReflection, ProgramLayout,
                              DeviceType, Device)
 from slangpy.reflection import SlangType
 import builtins
-
+import sys
 
 def create_device(type: DeviceType = DeviceType.automatic, enable_debug_layers: bool = False,
                   adapter_luid: Optional[Sequence[int]] = None,
@@ -28,7 +28,8 @@ def create_device(type: DeviceType = DeviceType.automatic, enable_debug_layers: 
                 shaderpath,
             ]+list(include_paths),
         },
-        enable_cuda_interop=True,
+
+        enable_cuda_interop=sys.platform != "darwin",  # Disable CUDA interop on macOS
         enable_debug_layers=enable_debug_layers,
         adapter_luid=adapter_luid)
 

--- a/slangpy/core/utils.py
+++ b/slangpy/core/utils.py
@@ -12,7 +12,8 @@ import sys
 
 def create_device(type: DeviceType = DeviceType.automatic, enable_debug_layers: bool = False,
                   adapter_luid: Optional[Sequence[int]] = None,
-                  include_paths: Sequence[Union[str, PathLike]] = []):
+                  include_paths: Sequence[Union[str, PathLike]] = [],
+                  enable_cuda_interop: bool = False):
     """
     Create an SGL device with basic settings for SlangPy. For full control over device init, 
     use sgl.create_device directly, being sure to add slangpy.SHADER_PATH
@@ -29,7 +30,6 @@ def create_device(type: DeviceType = DeviceType.automatic, enable_debug_layers: 
             ]+list(include_paths),
         },
 
-        enable_cuda_interop=sys.platform != "darwin",  # Disable CUDA interop on macOS
         enable_debug_layers=enable_debug_layers,
         adapter_luid=adapter_luid)
 

--- a/slangpy/tests/generated_tests/polynomial_soa.slang
+++ b/slangpy/tests/generated_tests/polynomial_soa.slang
@@ -102,7 +102,7 @@ void _trampoline(out vector<float,3> _result, in vector<float,3> a, in vector<fl
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id;

--- a/slangpy/tests/generated_tests/polynomial_soa.slang
+++ b/slangpy/tests/generated_tests/polynomial_soa.slang
@@ -102,7 +102,7 @@ void _trampoline(out vector<float,3> _result, in vector<float,3> a, in vector<fl
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void main(uint3 dispatchThreadID: SV_DispatchThreadID)
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id;

--- a/slangpy/tests/generated_tests/polynomial_soa_backwards.slang
+++ b/slangpy/tests/generated_tests/polynomial_soa_backwards.slang
@@ -125,7 +125,7 @@ void _trampoline(out vector<float,3> _result, in vector<float,3> a, in vector<fl
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id;

--- a/slangpy/tests/generated_tests/polynomial_soa_backwards.slang
+++ b/slangpy/tests/generated_tests/polynomial_soa_backwards.slang
@@ -125,7 +125,7 @@ void _trampoline(out vector<float,3> _result, in vector<float,3> a, in vector<fl
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void main(uint3 dispatchThreadID: SV_DispatchThreadID)
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id;

--- a/slangpy/tests/generated_tests/read_slice_generic_error.slang
+++ b/slangpy/tests/generated_tests/read_slice_generic_error.slang
@@ -56,7 +56,7 @@ void _trampoline(no_diff in vector<int,2> index, no_diff in NDBuffer<float,2> te
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id = {

--- a/slangpy/tests/generated_tests/read_slice_generic_error.slang
+++ b/slangpy/tests/generated_tests/read_slice_generic_error.slang
@@ -56,7 +56,7 @@ void _trampoline(no_diff in vector<int,2> index, no_diff in NDBuffer<float,2> te
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void main(uint3 dispatchThreadID: SV_DispatchThreadID)
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id = {

--- a/slangpy/tests/helpers.py
+++ b/slangpy/tests/helpers.py
@@ -7,13 +7,15 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import numpy as np
 
 from slangpy.core.calldata import SLANG_PATH
 
 import slangpy
 from slangpy import Module
 from slangpy.backend import (Device, DeviceType, SlangCompilerOptions,
-                             SlangDebugInfoLevel)
+                             SlangDebugInfoLevel, TypeReflection)
+from slangpy.types.buffer import NDBuffer
 
 SHADER_DIR = Path(__file__).parent
 
@@ -24,7 +26,7 @@ elif sys.platform == "win32":
 elif sys.platform == "linux" or sys.platform == "linux2":
     DEFAULT_DEVICE_TYPES = [DeviceType.vulkan]
 elif sys.platform == "darwin":
-    DEFAULT_DEVICE_TYPES = [DeviceType.vulkan]
+    DEFAULT_DEVICE_TYPES = [DeviceType.metal]
 else:
     raise RuntimeError("Unsupported platform")
 
@@ -105,3 +107,30 @@ def create_function_from_module(
     if function is None:
         raise ValueError(f"Could not find function {func_name}")
     return function
+
+def read_ndbuffer_from_numpy(buffer: NDBuffer) -> np.ndarray:
+    cursor = buffer.cursor()
+    data = np.array([])
+    shape = np.prod(np.array(buffer.shape))
+    for i in range(shape):
+        data = np.append(data, cursor[i].read())
+
+    return data
+
+def write_ndbuffer_from_numpy(buffer: NDBuffer, data: np.ndarray, element_count: int = 0):
+    cursor = buffer.cursor()
+    shape = np.prod(np.array(buffer.shape))
+
+    if element_count == 0:
+        if (cursor.element_type_layout.kind == TypeReflection.Kind.scalar):
+            element_count = 1
+        elif (cursor.element_type_layout.kind == TypeReflection.Kind.vector):
+            element_count = cursor.element_type.col_count
+        else:
+            raise ValueError(f"element_count not set and type is not scalar or vector: {cursor.element_type_layout.kind}")
+
+    for i in range(shape):
+        buffer_data = np.array(data[i*element_count : (i+1)*element_count])
+        cursor[i].write(buffer_data)
+
+    cursor.apply()

--- a/slangpy/tests/nested_types.slang
+++ b/slangpy/tests/nested_types.slang
@@ -105,7 +105,7 @@ void _trampoline(in float3 a, in float3 b, no_diff out float3 _result)
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     Context context;

--- a/slangpy/tests/nested_types.slang
+++ b/slangpy/tests/nested_types.slang
@@ -105,7 +105,7 @@ void _trampoline(in float3 a, in float3 b, no_diff out float3 _result)
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void main(uint3 dispatchThreadID: SV_DispatchThreadID)
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     Context context;

--- a/slangpy/tests/nested_types_generics.slang
+++ b/slangpy/tests/nested_types_generics.slang
@@ -52,7 +52,7 @@ void _trampoline(in float3 a, in float3 b, no_diff out float3 _result)
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void main(uint3 dispatchThreadID: SV_DispatchThreadID)
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id = {

--- a/slangpy/tests/nested_types_generics.slang
+++ b/slangpy/tests/nested_types_generics.slang
@@ -52,7 +52,7 @@ void _trampoline(in float3 a, in float3 b, no_diff out float3 _result)
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)
 {
     if (any(dispatchThreadID >= call_data._thread_count)) return;
     int[1] call_id = {

--- a/slangpy/tests/test_command_buffer.py
+++ b/slangpy/tests/test_command_buffer.py
@@ -30,21 +30,21 @@ def test_command_buffer(device_type: DeviceType):
     b_data = np.random.rand(10, 3).astype(np.float32)
     res_data = np.zeros((10, 3), dtype=np.float32)
 
-    a.copy_from_numpy(a_data)
-    b.copy_from_numpy(b_data)
-    res.copy_from_numpy(res_data)
-    res.grad_from_numpy(np.ones_like(res_data))
+    helpers.write_ndbuffer_from_numpy(a, a_data.flatten(), 3)
+    helpers.write_ndbuffer_from_numpy(b, b_data.flatten(), 3)
+    helpers.write_ndbuffer_from_numpy(res, res_data.flatten(), 3)
+    helpers.write_ndbuffer_from_numpy(res.grad, np.ones_like(res_data).flatten(), 3)
 
     polynomial.append_to(command_buffer, a, b, _result=res)
     polynomial.bwds.append_to(command_buffer, a, b, _result=res)
 
     command_buffer.submit()
 
-    res_data = res.to_numpy().view(dtype=np.float32).reshape(-1, 3)
+    res_data = helpers.read_ndbuffer_from_numpy(res).reshape(-1, 3)
     assert np.allclose(res_data, a_data * a_data + b_data + 1)
 
-    a_grad = a.grad_to_numpy().view(dtype=np.float32).reshape(-1, 3)
-    b_grad = b.grad_to_numpy().view(dtype=np.float32).reshape(-1, 3)
+    a_grad = helpers.read_ndbuffer_from_numpy(a.grad).reshape(-1, 3)
+    b_grad = helpers.read_ndbuffer_from_numpy(b.grad).reshape(-1, 3)
 
     assert np.allclose(a_grad, 2 * a_data)
     assert np.allclose(b_grad, np.ones_like(b_data))

--- a/slangpy/tests/test_custom_types.py
+++ b/slangpy/tests/test_custom_types.py
@@ -58,7 +58,8 @@ def test_thread_id(device_type: DeviceType, dimensions: int, signed: bool):
     kernel_output_values(thread_id(dims), _result=results)
 
     # Should get out the thread ids
-    data = results.storage.to_numpy().view("int32").reshape((-1, elements))
+    data = helpers.read_ndbuffer_from_numpy(results).reshape((-1, elements))
+
     if elements == 1:
         expected = [[i] for i in range(128)]
     elif elements == 2:
@@ -117,7 +118,7 @@ def test_call_id(device_type: DeviceType, dimensions: int, signed: bool, array: 
     kernel_output_values(call_id(dims), _result=results)
 
     # Should get out the thread ids
-    data = results.storage.to_numpy().view("int32").reshape((-1, elements))
+    data = helpers.read_ndbuffer_from_numpy(results).reshape((-1, elements))
     expected = np.indices((16,)*elements).reshape(elements, -1).T
 
     # Reverse order of components in last dimension of expected
@@ -180,7 +181,7 @@ uint3 wang_hashes(uint3 input) {
     expected = np.stack((expected_d0, expected_d1, expected_d2), axis=-1)
 
     # Should get out the following precalculated wang hashes
-    data = results.storage.to_numpy().view("uint32").reshape((-1, 3))
+    data = helpers.read_ndbuffer_from_numpy(results).reshape((-1, 3))
     assert np.allclose(data, expected)
 
 
@@ -221,7 +222,7 @@ uint wang_hashes(uint input) {
     expected = calc_wang_hash_numpy(thread_hash ^ np_seeds)
 
     # Should get out matching hashes
-    data = results.storage.to_numpy().view("uint32")
+    data = helpers.read_ndbuffer_from_numpy(results)
     assert np.allclose(data, expected)
 
 # Dumb test just to make sure hashes aren't completely broken!
@@ -332,7 +333,7 @@ float3 rand_float(float3 input) {
     values = 1.0 + 2.0 * u
 
     # Should get random numbers
-    data = results.storage.to_numpy().view("float32").reshape((-1, 3))
+    data = helpers.read_ndbuffer_from_numpy(results).reshape((-1, 3))
     assert np.allclose(data, values)
 
 
@@ -409,8 +410,11 @@ Particle rand_float_soa(Particle input) {
     }, _result=results)
 
     # Should get random numbers
-    data = results.storage.to_numpy().view("float32")[0:16*6].reshape((-1, 6))
-    (pos, dir) = np.split(data, 2, axis=1)
+    data = helpers.read_ndbuffer_from_numpy(results)
+    print(data)
+
+    pos = np.array([item['pos'] for item in data])
+    dir = np.array([item['vel'] for item in data])
     assert np.all(pos >= -100.0) and np.all(pos <= 100.0)
     assert np.all(dir >= 0) and np.all(dir <= np.pi*2)
 

--- a/slangpy/tests/test_differential_function_call.py
+++ b/slangpy/tests/test_differential_function_call.py
@@ -198,30 +198,32 @@ def test_vec3_call_with_buffers(device_type: DeviceType):
         device=device,
         dtype=float3,
     ).with_grads()
-    a.storage.copy_from_numpy(np.random.rand(32*3).astype(np.float32))
+    helpers.write_ndbuffer_from_numpy(a, np.random.rand(32*3).astype(np.float32), 3)
 
     b = Tensor.empty(
         shape=(32,),
         device=device,
         dtype=float3,
     ).with_grads()
-    b.storage.copy_from_numpy(np.random.rand(32*3).astype(np.float32))
+    helpers.write_ndbuffer_from_numpy(b, np.random.rand(32*3).astype(np.float32), 3)
 
     res: Tensor = kernel_eval_polynomial(a, b)
+    a_data = helpers.read_ndbuffer_from_numpy(a).reshape(-1, 3)
+    b_data = helpers.read_ndbuffer_from_numpy(b).reshape(-1, 3)
 
-    a_data = a.storage.to_numpy().view(np.float32).reshape(-1, 3)
-    b_data = b.storage.to_numpy().view(np.float32).reshape(-1, 3)
     expected = python_eval_polynomial(a_data, b_data)
-    res_data = res.storage.to_numpy().view(np.float32).reshape(-1, 3)
+    res_data = helpers.read_ndbuffer_from_numpy(res).reshape(-1, 3)
 
     assert np.allclose(res_data, expected)
 
     res = res.with_grads()
-    res.grad.storage.copy_from_numpy(np.ones(32*3, dtype=np.float32))
+    helpers.write_ndbuffer_from_numpy(res.grad, np.ones(32*3).astype(np.float32), 3)
 
     kernel_eval_polynomial.bwds(a, b, res)
-    a_grad_data = a.grad.storage.to_numpy().view(np.float32).reshape(-1, 3)
-    b_grad_data = b.grad.storage.to_numpy().view(np.float32).reshape(-1, 3)
+
+    # TODO: Somehow the grads are not layout the same as input tensors.
+    a_grad_data = a.grad.storage.to_numpy().view(np.float32)[0:32*3].reshape(-1, 3)
+    b_grad_data = b.grad.storage.to_numpy().view(np.float32)[0:32*3].reshape(-1, 3)
 
     exprected_grad = python_eval_polynomial_a_deriv(a_data, b_data)
     assert np.allclose(a_grad_data, exprected_grad)
@@ -276,14 +278,14 @@ def test_vec3_call_with_buffers_soa(device_type: DeviceType):
     a_y_data = a_y.storage.to_numpy().view(np.float32).reshape(-1, 1)
     a_z_data = a_z.storage.to_numpy().view(np.float32).reshape(-1, 1)
     a_data = np.column_stack((a_x_data, a_y_data, a_z_data))
-    b_data = b.storage.to_numpy().view(np.float32).reshape(-1, 3)
+    b_data = helpers.read_ndbuffer_from_numpy(b).reshape(-1, 3)
     expected = python_eval_polynomial(a_data, b_data)
-    res_data = res.storage.to_numpy().view(np.float32).reshape(-1, 3)
+    res_data = helpers.read_ndbuffer_from_numpy(res).reshape(-1, 3)
 
     assert np.allclose(res_data, expected)
 
     res = res.with_grads()
-    res.grad.storage.copy_from_numpy(np.ones(32*3, dtype=np.float32))
+    helpers.write_ndbuffer_from_numpy(res.grad, np.ones(32*3).astype(np.float32), 3)
 
     kernel_eval_polynomial.bwds({
         'x': a_x,
@@ -293,8 +295,11 @@ def test_vec3_call_with_buffers_soa(device_type: DeviceType):
     a_x_grad_data = a_x.grad.storage.to_numpy().view(np.float32).reshape(-1, 1)
     a_y_grad_data = a_y.grad.storage.to_numpy().view(np.float32).reshape(-1, 1)
     a_z_grad_data = a_z.grad.storage.to_numpy().view(np.float32).reshape(-1, 1)
+
     a_grad_data = np.column_stack((a_x_grad_data, a_y_grad_data, a_z_grad_data))
-    b_grad_data = b.grad.storage.to_numpy().view(np.float32).reshape(-1, 3)
+
+    # TODO: Somehow the grads are not layout the same as input tensors.
+    b_grad_data = b.grad.storage.to_numpy().view(np.float32)[0:32*3]
 
     exprected_grad = python_eval_polynomial_a_deriv(a_data, b_data)
     assert np.allclose(a_grad_data, exprected_grad)

--- a/slangpy/tests/test_differential_function_call.py
+++ b/slangpy/tests/test_differential_function_call.py
@@ -221,7 +221,12 @@ def test_vec3_call_with_buffers(device_type: DeviceType):
 
     kernel_eval_polynomial.bwds(a, b, res)
 
-    # TODO: Somehow the grads are not layout the same as input tensors.
+    # TODO: https://github.com/shader-slang/slangpy/issues/118
+    # We use ByteAddressBuffer to store the out grads, however, in the shader code, we use
+    # `sizeof(T)` to calculate the offset of each element, which is wrong because sizeof(T)
+    # is not guaranteed to be aligned on metal target. So we will just read the raw data back.
+    # The WAR solution is to provide a element_stride to shader. Slang will add intrinsic to
+    # calculate the aligned stride in shader code.
     a_grad_data = a.grad.storage.to_numpy().view(np.float32)[0:32*3].reshape(-1, 3)
     b_grad_data = b.grad.storage.to_numpy().view(np.float32)[0:32*3].reshape(-1, 3)
 
@@ -298,7 +303,12 @@ def test_vec3_call_with_buffers_soa(device_type: DeviceType):
 
     a_grad_data = np.column_stack((a_x_grad_data, a_y_grad_data, a_z_grad_data))
 
-    # TODO: Somehow the grads are not layout the same as input tensors.
+    # TODO: https://github.com/shader-slang/slangpy/issues/118
+    # We use ByteAddressBuffer to store the out grads, however, in the shader code, we use
+    # `sizeof(T)` to calculate the offset of each element, which is wrong because sizeof(T)
+    # is not guaranteed to be aligned on metal target. So we will just read the raw data back.
+    # The WAR solution is to provide a element_stride to shader. Slang will add intrinsic to
+    # calculate the aligned stride in shader code.
     b_grad_data = b.grad.storage.to_numpy().view(np.float32)[0:32*3]
 
     exprected_grad = python_eval_polynomial_a_deriv(a_data, b_data)

--- a/slangpy/tests/test_example_kernel_scalar.slang
+++ b/slangpy/tests/test_example_kernel_scalar.slang
@@ -37,7 +37,7 @@ void get_c_index(uint3 dispatchThreadID, out int[] index) {
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void main(uint3 dispatchThreadID: SV_DispatchThreadID) {
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID) {
     if (any(dispatchThreadID >= TOTAL_THREADS))
         return;
 
@@ -54,7 +54,7 @@ void main(uint3 dispatchThreadID: SV_DispatchThreadID) {
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void main_backwards(uint3 dispatchThreadID: SV_DispatchThreadID) {
+void computeMain_backwards(uint3 dispatchThreadID: SV_DispatchThreadID) {
     if (any(dispatchThreadID >= TOTAL_THREADS))
         return;
 

--- a/slangpy/tests/test_example_kernel_scalar.slang
+++ b/slangpy/tests/test_example_kernel_scalar.slang
@@ -37,7 +37,7 @@ void get_c_index(uint3 dispatchThreadID, out int[] index) {
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID) {
+void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID) {
     if (any(dispatchThreadID >= TOTAL_THREADS))
         return;
 
@@ -54,7 +54,7 @@ void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID) {
 
 [shader("compute")]
 [numthreads(32, 1, 1)]
-void computeMain_backwards(uint3 dispatchThreadID: SV_DispatchThreadID) {
+void compute_main_backwards(uint3 dispatchThreadID: SV_DispatchThreadID) {
     if (any(dispatchThreadID >= TOTAL_THREADS))
         return;
 

--- a/slangpy/tests/test_example_kernels.py
+++ b/slangpy/tests/test_example_kernels.py
@@ -27,7 +27,7 @@ def test_read_slice_error(test_id: str, device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "generated_tests/read_slice_generic_error.slang"), ["computeMain"])
+        str(Path(__file__).parent / "generated_tests/read_slice_generic_error.slang"), ["compute_main"])
 
     assert prim_program is not None
 
@@ -58,10 +58,10 @@ void user_func(float a, float b, out float c) {
     )
 
     # Create the forward and backward kernels.
-    ep = generated_module.entry_point("computeMain")
+    ep = generated_module.entry_point("compute_main")
     program = device.link_program([generated_module, user_func_module], [ep])
     kernel = device.create_compute_kernel(program)
-    backwards_ep = generated_module.entry_point("computeMain_backwards")
+    backwards_ep = generated_module.entry_point("compute_main_backwards")
     backwards_program = device.link_program(
         [generated_module, user_func_module], [backwards_ep]
     )
@@ -142,11 +142,11 @@ def test_vec3_call_with_buffers_soa(device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "generated_tests/polynomial_soa.slang"), ["computeMain"])
+        str(Path(__file__).parent / "generated_tests/polynomial_soa.slang"), ["compute_main"])
     kernel_eval_polynomial = device.create_compute_kernel(prim_program)
 
     bwds_program = device.load_program(
-        str(Path(__file__).parent / "generated_tests/polynomial_soa_backwards.slang"), ["computeMain"])
+        str(Path(__file__).parent / "generated_tests/polynomial_soa_backwards.slang"), ["compute_main"])
     kernel_eval_polynomial_backwards = device.create_compute_kernel(bwds_program)
 
     a_x = NDDifferentiableBuffer(
@@ -254,7 +254,7 @@ def test_vec3_nested_calldata_soa(device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "nested_types.slang"), ["computeMain"])
+        str(Path(__file__).parent / "nested_types.slang"), ["compute_main"])
     kernel_eval_polynomial = device.create_compute_kernel(prim_program)
 
     a_x = NDDifferentiableBuffer(
@@ -331,7 +331,7 @@ def test_vec3_nested_calldata_soa_generics(device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "nested_types_generics.slang"), ["computeMain"])
+        str(Path(__file__).parent / "nested_types_generics.slang"), ["compute_main"])
     kernel_eval_polynomial = device.create_compute_kernel(prim_program)
 
     a_x = NDDifferentiableBuffer(

--- a/slangpy/tests/test_example_kernels.py
+++ b/slangpy/tests/test_example_kernels.py
@@ -27,7 +27,7 @@ def test_read_slice_error(test_id: str, device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "generated_tests/read_slice_generic_error.slang"), ["main"])
+        str(Path(__file__).parent / "generated_tests/read_slice_generic_error.slang"), ["computeMain"])
 
     assert prim_program is not None
 
@@ -58,10 +58,10 @@ void user_func(float a, float b, out float c) {
     )
 
     # Create the forward and backward kernels.
-    ep = generated_module.entry_point("main")
+    ep = generated_module.entry_point("computeMain")
     program = device.link_program([generated_module, user_func_module], [ep])
     kernel = device.create_compute_kernel(program)
-    backwards_ep = generated_module.entry_point("main_backwards")
+    backwards_ep = generated_module.entry_point("computeMain_backwards")
     backwards_program = device.link_program(
         [generated_module, user_func_module], [backwards_ep]
     )
@@ -142,11 +142,11 @@ def test_vec3_call_with_buffers_soa(device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "generated_tests/polynomial_soa.slang"), ["main"])
+        str(Path(__file__).parent / "generated_tests/polynomial_soa.slang"), ["computeMain"])
     kernel_eval_polynomial = device.create_compute_kernel(prim_program)
 
     bwds_program = device.load_program(
-        str(Path(__file__).parent / "generated_tests/polynomial_soa_backwards.slang"), ["main"])
+        str(Path(__file__).parent / "generated_tests/polynomial_soa_backwards.slang"), ["computeMain"])
     kernel_eval_polynomial_backwards = device.create_compute_kernel(bwds_program)
 
     a_x = NDDifferentiableBuffer(
@@ -254,7 +254,7 @@ def test_vec3_nested_calldata_soa(device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "nested_types.slang"), ["main"])
+        str(Path(__file__).parent / "nested_types.slang"), ["computeMain"])
     kernel_eval_polynomial = device.create_compute_kernel(prim_program)
 
     a_x = NDDifferentiableBuffer(
@@ -331,7 +331,7 @@ def test_vec3_nested_calldata_soa_generics(device_type: DeviceType):
     device = helpers.get_device(device_type)
 
     prim_program = device.load_program(
-        str(Path(__file__).parent / "nested_types_generics.slang"), ["main"])
+        str(Path(__file__).parent / "nested_types_generics.slang"), ["computeMain"])
     kernel_eval_polynomial = device.create_compute_kernel(prim_program)
 
     a_x = NDDifferentiableBuffer(
@@ -395,9 +395,9 @@ def test_vec3_nested_calldata_soa_generics(device_type: DeviceType):
     a_y_data = a_y.storage.to_numpy().view(np.float32).reshape(-1, 1)
     a_z_data = a_z.storage.to_numpy().view(np.float32).reshape(-1, 1)
     a_data = np.column_stack((a_x_data, a_y_data, a_z_data))
-    b_data = b.storage.to_numpy().view(np.float32).reshape(-1, 3)
+    b_data = helpers.read_ndbuffer_from_numpy(b).reshape(-1, 3)
     expected = python_eval_polynomial(a_data, b_data)
-    res_data = res.storage.to_numpy().view(np.float32).reshape(-1, 3)
+    res_data = helpers.read_ndbuffer_from_numpy(res).reshape(-1, 3)
 
     assert np.allclose(res_data, expected)
 

--- a/slangpy/tests/test_generics.py
+++ b/slangpy/tests/test_generics.py
@@ -2,7 +2,7 @@
 import pytest
 
 import slangpy.tests.helpers as helpers
-from slangpy.backend import DeviceType
+from slangpy.backend import (DeviceType, TypeReflection)
 from slangpy.types.buffer import NDBuffer
 
 import numpy as np
@@ -25,7 +25,11 @@ def do_generic_test(device_type: DeviceType, container_type: str, slang_type_nam
 
     if container_type == 'buffer':
         buffer = NDBuffer(device, dtype=buffertype, shape=shape)
-        buffer.copy_from_numpy(np.random.random(int(buffer.storage.size / 4)).astype(np.float32))
+        if (buffer.cursor().element_type_layout.kind == TypeReflection.Kind.vector):
+            helpers.write_ndbuffer_from_numpy(buffer, np.random.random(int(buffer.storage.size / 4)).astype(np.float32))
+        else:
+            buffer.copy_from_numpy(np.random.random(int(buffer.storage.size / 4)).astype(np.float32))
+
         results = module.get(buffer)
         assert results.dtype == buffer.dtype
         assert np.all(buffer.to_numpy() == results.to_numpy())

--- a/slangpy/tests/test_grid.py
+++ b/slangpy/tests/test_grid.py
@@ -65,7 +65,7 @@ def grid_test(device_type: DeviceType, dims: int = 2, datatype: str = 'array', s
             module.get(grid(len(shape), stride=strides, offset=offsets), _result=res)
 
     # Should get random numbers
-    resdata = res.to_numpy().view(np.int32).reshape(shape + (dims,))
+    resdata = helpers.read_ndbuffer_from_numpy(res).reshape(shape + (dims,))
     expected = np.indices(shape).transpose(*transpose) * stride + offset
 
     if datatype == 'vector':

--- a/slangpy/tests/test_instances.py
+++ b/slangpy/tests/test_instances.py
@@ -37,7 +37,7 @@ class ThisType:
     def update_this(self, value: Any) -> None:
         self.update_called += 1
 
-def faltten_ndarray(data: np.ndarray) -> np.ndarray:
+def flatten_ndarray(data: np.ndarray) -> np.ndarray:
     # Flatten the structure using list comprehensions
     flattened = np.array([
         list(item['position']) +                  # Convert set to list
@@ -74,16 +74,16 @@ def test_this_interface(device_type: DeviceType):
 
     # position
     positions = np.array([item['position'] for item in data])
-    assert np.allclose(positions, [1.0, 2.0])
+    assert np.all(positions == [1.0, 2.0])
     # velocity
     velocity = np.array([item['velocity'] for item in data])
-    assert np.allclose(velocity, [3.0, 4.0])
+    assert np.all(velocity == [3.0, 4.0])
     # size
     sizes = np.array([item['size'] for item in data])
-    assert np.allclose(sizes, [0.5])
+    assert np.all(sizes == [0.5])
     # mat.color
     colors = np.array([item['material']['color'] for item in data])
-    assert np.allclose(colors, [1.0, 1.0, 1.0])
+    assert np.all(colors == [1.0, 1.0, 1.0])
 
     # Check the this interface has been called
     # Get should have been called 3 times - once for hash, once during setup, and once during call
@@ -144,9 +144,9 @@ def test_loose_instance_as_buffer(device_type: DeviceType):
     # Check the buffer has been correctly populated
     data = helpers.read_ndbuffer_from_numpy(buffer)
     positions = np.array([item['position'] for item in data])
-    assert np.allclose(positions, [1.0, 2.0])
+    assert np.all(positions == [1.0, 2.0])
     velocity = np.array([item['velocity'] for item in data])
-    assert np.allclose(velocity, [3.0, 4.0])
+    assert np.all(velocity == [3.0, 4.0])
 
 
     # Reset particle to be moving up
@@ -158,9 +158,9 @@ def test_loose_instance_as_buffer(device_type: DeviceType):
     # Check the buffer has been correctly updated
     data = helpers.read_ndbuffer_from_numpy(buffer)
     positions = np.array([item['position'] for item in data])
-    assert np.allclose(positions, [0.0, 1.0])
+    assert np.all(positions == [0.0, 1.0])
     velocity = np.array([item['velocity'] for item in data])
-    assert np.allclose(velocity, [0.0, 1.0])
+    assert np.all(velocity == [0.0, 1.0])
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
@@ -253,7 +253,7 @@ def test_pass_instance_to_function(device_type: DeviceType):
                         velocity=RandFloatArg(min=-1, max=1, dim=2))
     
     expected_particles = helpers.read_ndbuffer_from_numpy(particles._data)
-    expected_particles = faltten_ndarray(expected_particles)
+    expected_particles = flatten_ndarray(expected_particles)
 
     # Call the slang function 'Particle::update_position' to update them
     # and do the same for the python version
@@ -262,7 +262,7 @@ def test_pass_instance_to_function(device_type: DeviceType):
 
     # Check the numpy buffer and the slang buffer are the same
     particle_data = helpers.read_ndbuffer_from_numpy(particles._data)
-    particle_data = faltten_ndarray(particle_data)
+    particle_data = flatten_ndarray(particle_data)
     assert np.allclose(particle_data, expected_particles)
 
     # Define a 'Quad' type which is just an array of float2s, and make a buffer for them
@@ -439,10 +439,10 @@ def test_backwards_diff(device_type: DeviceType):
 
     # Read back all primals and gradients we ended up with into numpy arrays
     particle_primals = helpers.read_ndbuffer_from_numpy(particles.buffer)
-    particle_primals = faltten_ndarray(particle_primals).reshape(-1, 11)
+    particle_primals = flatten_ndarray(particle_primals).reshape(-1, 11)
 
     particle_grads = helpers.read_ndbuffer_from_numpy(particles.buffer.grad)
-    particle_grads = faltten_ndarray(particle_grads).reshape(-1, 11)
+    particle_grads = flatten_ndarray(particle_grads).reshape(-1, 11)
 
     dt_grads = helpers.read_ndbuffer_from_numpy(dts.grad)
     next_positions = helpers.read_ndbuffer_from_numpy(next_positions).reshape(-1, 2)
@@ -459,7 +459,7 @@ def test_backwards_diff(device_type: DeviceType):
 
         # dq/dp = 10
         pos_grad = particle_grads[particle_idx][0:2]
-        assert np.allclose(pos_grad, [1, 1])
+        assert np.all(pos_grad == [1, 1])
 
         # dq/dv = dt
         vel_grad = particle_grads[particle_idx][2:4]

--- a/slangpy/tests/test_intances.py
+++ b/slangpy/tests/test_intances.py
@@ -37,6 +37,17 @@ class ThisType:
     def update_this(self, value: Any) -> None:
         self.update_called += 1
 
+def faltten_ndarray(data: np.ndarray) -> np.ndarray:
+    # Flatten the structure using list comprehensions
+    flattened = np.array([
+        list(item['position']) +                  # Convert set to list
+        list(item['velocity']) +                  # Convert set to list
+        [item['size']] +                          # Wrap float in a list
+        list(item['material']['color']) +         # Convert set to list
+        list(item['material']['emission'])        # Convert set to list
+        for item in data
+    ])
+    return flattened
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_this_interface(device_type: DeviceType):
@@ -59,14 +70,20 @@ def test_this_interface(device_type: DeviceType):
     Particle_reset(float2(1, 2), float2(3, 4))
 
     # Check the buffer has been correctly populated
-    data = buffer.storage.to_numpy().view(dtype=np.float32)
-    assert len(data) == 11
+    data = helpers.read_ndbuffer_from_numpy(buffer)
+
     # position
-    assert data[0] == 1.0
-    assert data[1] == 2.0
-    # direction
-    assert data[2] == 3.0
-    assert data[3] == 4.0
+    positions = np.array([item['position'] for item in data])
+    assert np.allclose(positions, [1.0, 2.0])
+    # velocity
+    velocity = np.array([item['velocity'] for item in data])
+    assert np.allclose(velocity, [3.0, 4.0])
+    # size
+    sizes = np.array([item['size'] for item in data])
+    assert np.allclose(sizes, [0.5])
+    # mat.color
+    colors = np.array([item['material']['color'] for item in data])
+    assert np.allclose(colors, [1.0, 1.0, 1.0])
 
     # Check the this interface has been called
     # Get should have been called 3 times - once for hash, once during setup, and once during call
@@ -125,12 +142,12 @@ def test_loose_instance_as_buffer(device_type: DeviceType):
     instance.construct(float2(1, 2), float2(3, 4))
 
     # Check the buffer has been correctly populated
-    data = buffer.storage.to_numpy().view(dtype=np.float32)
-    assert len(data) == 11
-    assert data[0] == 1.0
-    assert data[1] == 2.0
-    assert data[2] == 3.0
-    assert data[3] == 4.0
+    data = helpers.read_ndbuffer_from_numpy(buffer)
+    positions = np.array([item['position'] for item in data])
+    assert np.allclose(positions, [1.0, 2.0])
+    velocity = np.array([item['velocity'] for item in data])
+    assert np.allclose(velocity, [3.0, 4.0])
+
 
     # Reset particle to be moving up
     instance.reset(float2(0, 0), float2(0, 1))
@@ -139,12 +156,11 @@ def test_loose_instance_as_buffer(device_type: DeviceType):
     instance.update_position(1.0)
 
     # Check the buffer has been correctly updated
-    data = buffer.storage.to_numpy().view(dtype=np.float32)
-    assert len(data) == 11
-    assert data[0] == 0.0
-    assert data[1] == 1.0
-    assert data[2] == 0.0
-    assert data[3] == 1.0
+    data = helpers.read_ndbuffer_from_numpy(buffer)
+    positions = np.array([item['position'] for item in data])
+    assert np.allclose(positions, [0.0, 1.0])
+    velocity = np.array([item['velocity'] for item in data])
+    assert np.allclose(velocity, [0.0, 1.0])
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
@@ -188,7 +204,7 @@ def test_loose_instance_soa(device_type: DeviceType):
     assert data[1] == 1.0
 
 
-def particle_update_positions(data: npt.NDArray[np.float32], dt: float):
+def particle_update_positions(data: npt.NDArray, dt: float):
     for i in range(0, len(data)):
         data[i][0] += data[i][2] * dt
         data[i][1] += data[i][3] * dt
@@ -235,7 +251,9 @@ def test_pass_instance_to_function(device_type: DeviceType):
     # assigning each a constant starting position and a random velocity
     particles.construct(position=float2(10, 10),
                         velocity=RandFloatArg(min=-1, max=1, dim=2))
-    expected_particles = particles._data.storage.to_numpy().view(dtype=np.float32).reshape(-1, 11)
+    
+    expected_particles = helpers.read_ndbuffer_from_numpy(particles._data)
+    expected_particles = faltten_ndarray(expected_particles)
 
     # Call the slang function 'Particle::update_position' to update them
     # and do the same for the python version
@@ -243,7 +261,8 @@ def test_pass_instance_to_function(device_type: DeviceType):
     particle_update_positions(expected_particles, 1.0/60.0)
 
     # Check the numpy buffer and the slang buffer are the same
-    particle_data = particles._data.storage.to_numpy().view(dtype=np.float32).reshape(-1, 11)
+    particle_data = helpers.read_ndbuffer_from_numpy(particles._data)
+    particle_data = faltten_ndarray(particle_data)
     assert np.allclose(particle_data, expected_particles)
 
     # Define a 'Quad' type which is just an array of float2s, and make a buffer for them
@@ -287,8 +306,13 @@ def test_pass_nested_instance_to_function(device_type: DeviceType):
     particles.construct(position=float2(10, 10), velocity=float2(0, 0))
 
     # Check colors are white and emission is black!
-    material_data = particles._data['material']._data.storage.to_numpy().view(
-        dtype=np.float32).reshape(-1, 6)
+    material_data = helpers.read_ndbuffer_from_numpy(particles._data['material']._data)
+    material_data = np.array([
+        list(item['color']) + list(item['emission'])
+        for item in material_data
+    ])
+    material_data = material_data.reshape(-1, 6)
+    
     for i in range(0, len(material_data)):
         material_data[i][0] = 1
         material_data[i][1] = 1
@@ -389,9 +413,10 @@ def test_backwards_diff(device_type: DeviceType):
     # Get particle struct
     Particle = m.Particle
     assert isinstance(Particle, Struct)
+    particle_count = 1000
 
     # Create storage for particles in a simple buffer
-    particles = InstanceDifferentiableBuffer(Particle, shape=(1000,))
+    particles = InstanceDifferentiableBuffer(Particle, shape=(particle_count,))
 
     # Call the slang constructor on all particles in the buffer,
     # assigning each a constant starting position and a random velocity
@@ -403,20 +428,24 @@ def test_backwards_diff(device_type: DeviceType):
     next_positions = next_positions.with_grads()
 
     # Init the gradients of next positions to 1 for the backwards pass
-    next_positions.grad.storage.copy_from_numpy(np.ones((1000, 2), dtype=np.float32))
+    helpers.write_ndbuffer_from_numpy(next_positions.grad, np.ones((particle_count * 2), dtype=np.float32), 2)
 
     # Make a buffer of 1000 identical dts, so we can get back the unique grads for each one
-    dts = Tensor.empty(m.device, shape=(1000,), dtype=float).with_grads()
-    dts.storage.copy_from_numpy(np.full((1000,), 1.0/60.0, dtype=np.float32))
+    dts = Tensor.empty(m.device, shape=(particle_count,), dtype=float).with_grads()
+    dts.storage.copy_from_numpy(np.full((particle_count,), 1.0/60.0, dtype=np.float32))
 
     # Backwards pass
     particles.calc_next_position.bwds(dt=dts, _result=next_positions)
 
     # Read back all primals and gradients we ended up with into numpy arrays
-    particle_primals = particles.primal_to_numpy().view(dtype=np.float32).reshape(-1, 11)
-    particle_grads = particles.grad_to_numpy().view(dtype=np.float32).reshape(-1, 11)
-    dt_grads = dts.grad.storage.to_numpy().view(dtype=np.float32)
-    next_positions = next_positions.storage.to_numpy().view(dtype=np.float32).reshape(-1, 2)
+    particle_primals = helpers.read_ndbuffer_from_numpy(particles.buffer)
+    particle_primals = faltten_ndarray(particle_primals).reshape(-1, 11)
+
+    particle_grads = helpers.read_ndbuffer_from_numpy(particles.buffer.grad)
+    particle_grads = faltten_ndarray(particle_grads).reshape(-1, 11)
+
+    dt_grads = helpers.read_ndbuffer_from_numpy(dts.grad)
+    next_positions = helpers.read_ndbuffer_from_numpy(next_positions).reshape(-1, 2)
 
     for particle_idx in range(0, len(particle_primals)):
         pos = particle_primals[particle_idx][0:2]

--- a/slangpy/tests/test_modules.py
+++ b/slangpy/tests/test_modules.py
@@ -61,24 +61,24 @@ def test_init_particle(device_type: DeviceType):
     # Call constructor, which returns particles
     Particle.__init(float2(1.0, 2.0), float2(3.0, 4.0), _result=buffer)
 
-    data = buffer.storage.to_numpy().view(dtype=np.float32)
-    assert len(data) == 11
+    data = helpers.read_ndbuffer_from_numpy(buffer)
+    print(data)
+
     # position
-    assert data[0] == 1.0
-    assert data[1] == 2.0
-    # direction
-    assert data[2] == 3.0
-    assert data[3] == 4.0
+    positions = np.array([item['position'] for item in data])
+    assert np.allclose(positions, [1.0, 2.0])
+    # velocity
+    velocity = np.array([item['velocity'] for item in data])
+    assert np.allclose(velocity, [3.0, 4.0])
     # size
-    assert data[4] == 0.5
+    sizes = np.array([item['size'] for item in data])
+    assert np.allclose(sizes, [0.5])
     # mat.color
-    assert data[5] == 1
-    assert data[6] == 1
-    assert data[7] == 1
+    colors = np.array([item['material']['color'] for item in data])
+    assert np.allclose(colors, [1.0, 1.0, 1.0])
     # mat.emission
-    assert data[8] == 0
-    assert data[9] == 0
-    assert data[10] == 0
+    emissions = np.array([item['material']['emission'] for item in data])
+    assert np.allclose(emissions, [0.0, 0.0, 0.0])
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)

--- a/slangpy/tests/test_pytorch.py
+++ b/slangpy/tests/test_pytorch.py
@@ -12,12 +12,8 @@ try:
 except ImportError:
     pytest.skip("Pytorch not installed", allow_module_level=True)
 
-# Skip all tests in this file if running on MacOS
-@pytest.fixture(autouse=True)
-def skip_macos():
-    """Skip tests on macOS."""
-    if sys.platform == "darwin":
-        pytest.skip("PyTorch requires CUDA, that is not available on macOS")
+if sys.platform == "darwin":
+    pytest.skip("PyTorch requires CUDA, that is not available on macOS", allow_module_level=True)
 
 TEST_CODE = """
 [Differentiable]

--- a/slangpy/tests/test_pytorch.py
+++ b/slangpy/tests/test_pytorch.py
@@ -5,11 +5,19 @@ from slangpy.bindings.boundvariable import BoundVariableException
 import slangpy.tests.helpers as helpers
 import hashlib
 import os
+import sys
 
 try:
     import torch
 except ImportError:
     pytest.skip("Pytorch not installed", allow_module_level=True)
+
+# Skip all tests in this file if running on MacOS
+@pytest.fixture(autouse=True)
+def skip_macos():
+    """Skip tests on macOS."""
+    if sys.platform == "darwin":
+        pytest.skip("PyTorch requires CUDA, that is not available on macOS")
 
 TEST_CODE = """
 [Differentiable]

--- a/slangpy/tests/test_raw_dispatch.py
+++ b/slangpy/tests/test_raw_dispatch.py
@@ -61,13 +61,13 @@ def load_test_module(device_type: DeviceType, link: list[Any] = [], options: dic
     device = helpers.get_device(device_type)
     return helpers.create_module(device, MODULE, link=link, options=options)
 
-
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_dispatch_entrypoint(device_type: DeviceType):
     mod = load_test_module(device_type)
     buffer = NDBuffer(mod.device, mod.uint3, 32)
     mod.func_entrypoint.dispatch(uint3(32, 1, 1), buffer=buffer.storage)
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
+
     expected = np.array([[i, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -77,7 +77,7 @@ def test_dispatch_ndbuffer_entrypoint(device_type: DeviceType):
     mod = load_test_module(device_type)
     buffer = NDBuffer(mod.device, mod.uint3, 32)
     mod.ndbuffer_entrypoint.dispatch(uint3(32, 1, 1), buffer=buffer)
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -87,7 +87,7 @@ def test_dispatch_func(device_type: DeviceType):
     mod = load_test_module(device_type)
     buffer = NDBuffer(mod.device, mod.uint3, 32)
     mod.func_threadparam.dispatch(uint3(32, 1, 1), buffer=buffer.storage)
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -97,7 +97,7 @@ def test_dispatch_ndbuffer_func(device_type: DeviceType):
     mod = load_test_module(device_type)
     buffer = NDBuffer(mod.device, mod.uint3, 32)
     mod.ndbuffer_threadparam.dispatch(uint3(32, 1, 1), buffer=buffer)
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -108,7 +108,7 @@ def test_override_threadgroup(device_type: DeviceType):
     buffer = NDBuffer(mod.device, mod.uint3, 32)
     mod.func_threadparam.thread_group_size(uint3(1, 1, 1)).dispatch(
         uint3(32, 1, 1), buffer=buffer.storage)
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -118,7 +118,7 @@ def test_multiply_scalar(device_type: DeviceType):
     mod = load_test_module(device_type)
     buffer = NDBuffer(mod.device, mod.uint3, 32)
     mod.ndbuffer_multiply.dispatch(uint3(32, 1, 1), buffer=buffer, amount=10)
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i*10, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -129,7 +129,7 @@ def test_multiply_const(device_type: DeviceType):
     buffer = NDBuffer(mod.device, mod.uint3, 32)
     mod.ndbuffer_multiply_const.constants({"VAL": 5}).dispatch(
         uint3(32, 1, 1), buffer=buffer, amount=10)
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i*5, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -147,7 +147,7 @@ def test_set(device_type: DeviceType):
     }})
     func.dispatch(uint3(32, 1, 1), buffer=buffer)
 
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i*20, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -165,7 +165,7 @@ def test_set_with_callback(device_type: DeviceType):
     }})
     func.dispatch(uint3(32, 1, 1), buffer=buffer)
 
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = helpers.read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i*30, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 
@@ -197,7 +197,7 @@ def test_hook(device_type: DeviceType):
 
     func.dispatch(uint3(32, 1, 1), buffer=buffer)
 
-    data = buffer.to_numpy().view(np.uint32).reshape(-1, 3)
+    data = read_ndbuffer_from_numpy(buffer).reshape(-1, 3)
     expected = np.array([[i*10, 0, 0] for i in range(32)])
     assert np.all(data == expected)
 

--- a/slangpy/tests/test_simple_function_call.py
+++ b/slangpy/tests/test_simple_function_call.py
@@ -420,6 +420,9 @@ Foo create_foo(int x) { return { x }; }
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 @pytest.mark.parametrize("scalar_type", ["float", "half", "double"])
 def test_pass_float_array(device_type: DeviceType, scalar_type: str):
+    if device_type == DeviceType.metal and scalar_type == "double":
+        pytest.skip("Double precision is unsupported on Metal")
+
     device = helpers.get_device(device_type)
     module = helpers.create_module(
         device, f"{scalar_type} first({scalar_type} x[3]) {{ return x[0]; }}")
@@ -448,6 +451,9 @@ def test_pass_int_array(device_type: DeviceType, scalar_type: str):
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 @pytest.mark.parametrize("scalar_type", ["float", "half", "double"])
 def test_pass_float_field(device_type: DeviceType, scalar_type: str):
+    if device_type == DeviceType.metal and scalar_type == "double":
+        pytest.skip("Double precision is unsupported on Metal")
+
     device = helpers.get_device(device_type)
     module = helpers.create_module(
         device,

--- a/slangpy/tests/test_tensor_with_grads.py
+++ b/slangpy/tests/test_tensor_with_grads.py
@@ -5,6 +5,7 @@ from slangpy.types import Tensor
 import slangpy.tests.helpers as helpers
 import numpy as np
 from typing import Any
+import os
 import sys
 
 

--- a/slangpy/tests/test_tensor_with_grads.py
+++ b/slangpy/tests/test_tensor_with_grads.py
@@ -5,7 +5,13 @@ from slangpy.types import Tensor
 import slangpy.tests.helpers as helpers
 import numpy as np
 from typing import Any
-import os
+import sys
+
+
+@pytest.fixture(autouse=True)
+def skip_for_macos():
+    if sys.platform == "darwin":
+        pytest.skip("Skipping on macOS: Waiting for slang-gfx fix for resource clear API")
 
 
 def get_test_tensors(device: Device, N: int = 4):

--- a/slangpy/tests/test_tensor_with_grads.py
+++ b/slangpy/tests/test_tensor_with_grads.py
@@ -9,10 +9,8 @@ import os
 import sys
 
 
-@pytest.fixture(autouse=True)
-def skip_for_macos():
-    if sys.platform == "darwin":
-        pytest.skip("Skipping on macOS: Waiting for slang-gfx fix for resource clear API")
+if sys.platform == "darwin":
+    pytest.skip("Skipping on macOS: Waiting for slang-gfx fix for resource clear API https://github.com/shader-slang/slang/issues/6640", allow_module_level=True)
 
 
 def get_test_tensors(device: Device, N: int = 4):

--- a/slangpy/tests/test_textures.py
+++ b/slangpy/tests/test_textures.py
@@ -11,10 +11,8 @@ from slangpy.builtin.texture import SCALARTYPE_TO_TEXTURE_FORMAT
 from slangpy.types.tensor import _slang_to_numpy
 import sys
 
-@pytest.fixture(autouse=True)
-def skip_for_macos():
-    if sys.platform == "darwin":
-        pytest.skip("Skipping on macOS: Waiting for slang-gfx fix for resource clear API")
+if sys.platform == "darwin":
+    pytest.skip("Skipping on macOS: Waiting for slang-gfx fix for resource clear API https://github.com/shader-slang/slang/issues/6640", allow_module_level=True)
 
 
 def load_test_module(device_type: DeviceType):

--- a/slangpy/tests/test_textures.py
+++ b/slangpy/tests/test_textures.py
@@ -9,6 +9,12 @@ from slangpy.types import NDBuffer
 from slangpy.reflection import ScalarType
 from slangpy.builtin.texture import SCALARTYPE_TO_TEXTURE_FORMAT
 from slangpy.types.tensor import _slang_to_numpy
+import sys
+
+@pytest.fixture(autouse=True)
+def skip_for_macos():
+    if sys.platform == "darwin":
+        pytest.skip("Skipping on macOS: Waiting for slang-gfx fix for resource clear API")
 
 
 def load_test_module(device_type: DeviceType):

--- a/slangpy/tests/test_torchintegration.py
+++ b/slangpy/tests/test_torchintegration.py
@@ -9,6 +9,10 @@ try:
 except ImportError:
     pytest.skip("Pytorch not installed", allow_module_level=True)
 
+# Skip all tests in this file if running on MacOS
+if sys.platform == "darwin":
+    pytest.skip("PyTorch requires CUDA, that is not available on macOS", allow_module_level=True)
+
 TEST_CODE = """
 import tensor;
 [Differentiable]
@@ -23,13 +27,6 @@ float square(float x) {
 if DeviceType.d3d12 in helpers.DEFAULT_DEVICE_TYPES:
     pytest.skip("Skipping pytorch tests as not in D3D", allow_module_level=True)
 DEVICE_TYPES = [DeviceType.d3d12]
-
-# Skip all tests in this file if running on MacOS
-@pytest.fixture(autouse=True)
-def skip_macos():
-    """Skip tests on macOS."""
-    if sys.platform == "darwin":
-        pytest.skip("PyTorch requires CUDA, that is not available on macOS")
 
 def get_test_tensors(device: Device, N: int = 4):
     weights = torch.randn((5, 8), dtype=torch.float32,

--- a/slangpy/tests/test_torchintegration.py
+++ b/slangpy/tests/test_torchintegration.py
@@ -2,6 +2,7 @@
 import pytest
 from slangpy.backend import DeviceType, Device
 import slangpy.tests.helpers as helpers
+import sys
 
 try:
     import torch
@@ -23,6 +24,12 @@ if DeviceType.d3d12 in helpers.DEFAULT_DEVICE_TYPES:
     pytest.skip("Skipping pytorch tests as not in D3D", allow_module_level=True)
 DEVICE_TYPES = [DeviceType.d3d12]
 
+# Skip all tests in this file if running on MacOS
+@pytest.fixture(autouse=True)
+def skip_macos():
+    """Skip tests on macOS."""
+    if sys.platform == "darwin":
+        pytest.skip("PyTorch requires CUDA, that is not available on macOS")
 
 def get_test_tensors(device: Device, N: int = 4):
     weights = torch.randn((5, 8), dtype=torch.float32,


### PR DESCRIPTION
Add support for Metal platform.

1. Change the entry point name from main->computeMain, because Metal doesn't support "main" as entry point name.
2. Change the way of copying data between GPU and CPU for structured data, because Metal has different alignment requirement then glsl/hlsl.
3. Change texture format from rgb to rgba because metal doesn't support rgb format texture.