### PR TITLE
SlangPy NDBuffer/Tensor cleanup 

### DIFF
--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -260,14 +260,15 @@ public struct RWValueRef<T>
 public struct NDBuffer<T, let N : int>
 {
     public StructuredBuffer<T> buffer;
+    public int offset;
     public int[N] strides;
     public int[N] shape;
 
-    public T get(int[N] index) { return buffer[_idx(index, strides)]; }
-    //public T get(vector<int,N> index) { return buffer[_idx(index, strides)]; }
+    public T get(int[N] index) { return buffer[offset + _idx(index, strides)]; }
+    //public T get(vector<int,N> index) { return buffer[offset + _idx(index, strides)]; }
 
     //public __subscript(int[N] index)->T { get { return get(index); } }
-    public __subscript(vector<int,N> index)->T { get { return buffer[_idx_vec(index, strides)]; } }
+    public __subscript(vector<int,N> index)->T { get { return buffer[offset + _idx_vec(index, strides)]; } }
 
     public void load(ContextND<N> context, out T value) { value = get(context.call_id); }
     public void store(ContextND<N> context, in T value) {};
@@ -289,7 +290,7 @@ public struct NDBuffer<T, let N : int>
 
         for (int vi = 0; vi < VD; vi++) {
             call_id[N - 1] = vi;
-            value[vi] = buffer[_idx(call_id, strides)];
+            value[vi] = buffer[offset + _idx(call_id, strides)];
         }
     }
 
@@ -299,14 +300,15 @@ public struct NDBuffer<T, let N : int>
 public struct RWNDBuffer<T, let N : int>
 {
     public RWStructuredBuffer<T> buffer;
+    public int offset;
     public int[N] strides;
     public int[N] shape;
 
-    public T get(int[N] index) { return buffer[_idx(index, strides)]; }
-    //public T get(vector<int,N> index) { return buffer[_idx(index, strides)]; }
+    public T get(int[N] index) { return buffer[offset + _idx(index, strides)]; }
+    //public T get(vector<int,N> index) { return buffer[offset + _idx(index, strides)]; }
 
-    public void set(int[N] index, T value) { buffer[_idx(index, strides)] = value; }
-    //public void set(vector<int,N> index, T value) { buffer[_idx(index, strides)] = value; }
+    public void set(int[N] index, T value) { buffer[offset + _idx(index, strides)] = value; }
+    //public void set(vector<int,N> index, T value) { buffer[offset + _idx(index, strides)] = value; }
 
     //public __subscript(int[N] index)->T {
     //    get { return get(index); }
@@ -315,9 +317,9 @@ public struct RWNDBuffer<T, let N : int>
     //}
 
     public __subscript(vector<int,N> index)->T {
-        get { return buffer[_idx_vec(index, strides)]; }
+        get { return buffer[offset + _idx_vec(index, strides)]; }
         [nonmutating]
-        set { buffer[_idx_vec(index, strides)] = newValue; }
+        set { buffer[offset + _idx_vec(index, strides)] = newValue; }
     }
 
     public void load(ContextND<N> context, out T value) { value = get(context.call_id); }
@@ -364,7 +366,7 @@ namespace impl
     // e.g. [1, 2, 3] to uint16_t[3] would fail if the ValueType picks the default
     // of int[3] to pass to slang. We could attempt to check this in python, but
     // this would require deep slang type inspection and would inevitably be brittle
-    // 
+    //
     // To solve this, we check if the python type (e.g. float[3]) type can be converted
     // safely to the slang type using slang generic constraints.
     // If type B implements IConvertibleFrom<A>, then we can safely convert from A to B

--- a/slangpy/tests/test_buffer_views.py
+++ b/slangpy/tests/test_buffer_views.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import pytest
+
+from slangpy import Struct
+from slangpy.core.native import Shape
+from slangpy.backend import DeviceType, ResourceUsage
+from slangpy.tests import helpers
+from slangpy.types import NDBuffer, Tensor
+
+from typing import Any, Optional, Union, Type, cast
+
+import numpy as np
+import torch
+import math
+
+MODULE = r"""
+struct RGB {
+    float x;
+    float y;
+    float z;
+};
+"""
+
+TEST_DTYPES = [
+    ("half", torch.half, np.float16, ()),
+    ("float", torch.float, np.float32, ()),
+    ("double", torch.double, np.float64, ()),
+    ("uint8_t", torch.uint8, np.uint8, ()),
+    ("uint16_t", None, np.uint16, ()),
+    ("uint32_t", None, np.uint32, ()),
+    ("uint64_t", None, np.uint64, ()),
+    ("int8_t", torch.int8, np.int8, ()),
+    ("int16_t", torch.int16, np.int16, ()),
+    ("int32_t", torch.int32, np.int32, ()),
+    ("int64_t", torch.int64, np.int64, ()),
+    ("float2", torch.float, np.float32, (2, )),
+    ("float3", torch.float, np.float32, (3, )),
+    ("float[3]", torch.float, np.float32, (3, )),
+    ("float[2][3]", torch.float, np.float32, (3, 2)),
+    ("float3[2]", torch.float, np.float32, (2, 3)),
+    ("RGB", torch.uint8, np.uint8, (12, )),
+]
+
+
+TEST_INDICES = [
+    # Partial indexing
+    (3, ),
+    (3, 4, 2, 1),
+    # Ellipses
+    (3, 4, ...),
+    (..., 1),
+    (3, ..., 1),
+    # Singleton dimension
+    (None, ),
+    (2, 6, None, None, 2, None),
+    # Slices
+    (2, slice(4, None, None)),
+    (1, slice(None, -3, None)),
+    (slice(None, None, 2), ..., 3),
+    (slice(4, None, 3), ),
+    # Full indexing
+    (0, 0, 0, 0, 0)
+]
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+@pytest.mark.parametrize("test_dtype", TEST_DTYPES)
+def test_to_numpy(device_type: DeviceType,
+                  buffer_type: Union[Type[Tensor], Type[NDBuffer]],
+                  test_dtype: tuple[str, Optional[torch.dtype], Type[Any], tuple[int, ...]]):
+
+    device = helpers.get_device(device_type)
+    module = helpers.create_module(device, MODULE)
+
+    slang_dtype, _, np_type, dtype_shape = test_dtype
+
+    np_dtype = np.dtype(np_type)
+    shape = (5, 4)
+    unravelled_shape = shape + dtype_shape
+
+    rng = np.random.default_rng()
+    if np_type in (np.float16, np.float32, np.float64):
+        numpy_ref = rng.random(unravelled_shape, np.double).astype(np_dtype)
+    else:
+        iinfo = np.iinfo(np_type)
+        numpy_ref = rng.integers(iinfo.min, iinfo.max, unravelled_shape, np_dtype)
+
+    buffer = buffer_type.zeros(device, dtype=module[slang_dtype], shape=shape)
+
+    assert buffer.shape == shape
+    assert buffer.strides == Shape(shape).calc_contiguous_strides()
+    assert buffer.offset == 0
+
+    buffer.copy_from_numpy(numpy_ref)
+
+    strides = Shape(unravelled_shape).calc_contiguous_strides()
+    byte_strides = tuple(s * np_dtype.itemsize for s in strides)
+
+    ndarray = buffer.to_numpy()
+    assert ndarray.shape == unravelled_shape
+    assert ndarray.strides == byte_strides
+    assert ndarray.dtype == np_dtype
+    assert (ndarray == numpy_ref).all()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+@pytest.mark.parametrize("test_dtype", TEST_DTYPES)
+def test_to_torch(device_type: DeviceType,
+                  buffer_type: Union[Type[Tensor], Type[NDBuffer]],
+                  test_dtype: tuple[str, Optional[torch.dtype], Type[Any], tuple[int, ...]]):
+
+    device = helpers.get_device(device_type, cuda_interop=True)
+    module = helpers.create_module(device, MODULE)
+
+    slang_dtype, torch_dtype, _, dtype_shape = test_dtype
+    if torch_dtype is None:
+        pytest.skip()
+    slang_type = cast(Struct, module[slang_dtype]).struct
+
+    shape = (5, 4)
+    unravelled_shape = shape + dtype_shape
+
+    rng = np.random.default_rng()
+    if torch_dtype.is_floating_point:
+        torch_ref = torch.randn(unravelled_shape, dtype=torch_dtype).cuda()
+    else:
+        iinfo = torch.iinfo(torch_dtype)
+        torch_ref = torch.randint(iinfo.min, iinfo.max, unravelled_shape, dtype=torch_dtype).cuda()
+
+    usage = ResourceUsage.shader_resource | ResourceUsage.unordered_access | ResourceUsage.shared
+    if buffer_type == Tensor:
+        storage = device.create_buffer(
+            element_count=math.prod(shape),
+            struct_size=slang_type.buffer_layout.reflection.size,
+            usage=usage
+        )
+        buffer = Tensor(storage, slang_type, shape)
+    else:
+        buffer = NDBuffer(device, dtype=slang_type, shape=shape, usage=usage)
+    buffer.clear()
+
+    assert buffer.shape == shape
+    assert buffer.strides == Shape(shape).calc_contiguous_strides()
+    assert buffer.offset == 0
+
+    buffer.copy_from_numpy(torch_ref.cpu().numpy())
+
+    strides = Shape(unravelled_shape).calc_contiguous_strides()
+
+    tensor = buffer.to_torch()
+    assert tensor.shape == unravelled_shape
+    assert tensor.stride() == strides.as_tuple()
+    assert tensor.dtype == torch_dtype
+    assert (tensor == torch_ref).all().item()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+@pytest.mark.parametrize("index", TEST_INDICES)
+def test_indexing(device_type: DeviceType,
+                  buffer_type: Union[Type[Tensor], Type[NDBuffer]],
+                  index: tuple[Any, ...]):
+
+    device = helpers.get_device(device_type)
+
+    shape = (10, 8, 5, 3, 5)
+    rng = np.random.default_rng()
+    numpy_ref = rng.random(shape, np.float32)
+    buffer = buffer_type.zeros(device, dtype='float', shape=shape)
+    buffer.copy_from_numpy(numpy_ref)
+
+    indexed_buffer = buffer.__getitem__(*index)
+    indexed_ndarray = numpy_ref.__getitem__(index)
+
+    if isinstance(indexed_ndarray, np.number):
+        # Result is a scalar
+        assert indexed_buffer.shape.as_tuple() == (1, )
+        assert indexed_buffer.strides.as_tuple() == (1, )
+    else:
+        # Result is an array slice
+        spy_byte_strides = tuple(numpy_ref.itemsize * s for s in indexed_buffer.strides)
+        spy_byte_offset = numpy_ref.itemsize * indexed_buffer.offset
+        np_byte_offset = indexed_ndarray.ctypes.data - numpy_ref.ctypes.data
+        assert indexed_buffer.shape.as_tuple() == indexed_ndarray.shape
+        assert spy_byte_strides == indexed_ndarray.strides
+        assert spy_byte_offset == np_byte_offset
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+def test_view(device_type: DeviceType,
+              buffer_type: Union[Type[Tensor], Type[NDBuffer]]):
+
+    device = helpers.get_device(device_type)
+    buffer = buffer_type.zeros(device, dtype='float', shape=(32 * 32 * 32, ))
+
+    # Transposed view of the 3rd 32x32 slice
+    view_offset = 64
+    view_size = (32, 32)
+    view_strides = (1, 32)
+    view = buffer.view(view_size, view_strides, view_offset)
+    assert view.offset == view_offset
+    assert view.shape.as_tuple() == view_size
+    assert view.strides.as_tuple() == view_strides
+
+    # Adjust view to original buffer
+    reversed_view = view.view(buffer.shape, offset=-view_offset)
+    assert reversed_view.offset == buffer.offset
+    assert reversed_view.shape.as_tuple() == buffer.shape.as_tuple()
+    assert reversed_view.strides.as_tuple() == buffer.strides.as_tuple()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+def test_view_errors(device_type: DeviceType,
+                     buffer_type: Union[Type[Tensor], Type[NDBuffer]]):
+
+    device = helpers.get_device(device_type)
+    buffer = buffer_type.zeros(device, dtype='float', shape=(32 * 32 * 32, ))
+
+    with pytest.raises(Exception, match=r'Shape dimensions \([0-9]\) must match stride dimensions'):
+        buffer.view((5, 4), (5, ))
+
+    with pytest.raises(Exception, match=r'Strides must be positive'):
+        buffer.view((5, 4), (-5, 1))
+
+    with pytest.raises(Exception, match=r'Buffer view offset is negative'):
+        buffer.view((5, 4), offset=-100)
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+def test_broadcast_to(device_type: DeviceType,
+                      buffer_type: Union[Type[Tensor], Type[NDBuffer]]):
+
+    device = helpers.get_device(device_type)
+    buffer = buffer_type.zeros(device, dtype='float', shape=(32, 1, 1, ))
+
+    new_shape = (64, 64, 32, 54, 5)
+    broadcast_buffer = buffer.broadcast_to(new_shape)
+    assert broadcast_buffer.shape == new_shape
+
+    with pytest.raises(Exception, match=r'Broadcast shape must be larger than tensor shape'):
+        buffer.broadcast_to((32, ))
+
+    with pytest.raises(Exception, match=r'Current dimension'):
+        buffer.broadcast_to((16, 5, 5))
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+def test_full_numpy_copy(device_type: DeviceType,
+                         buffer_type: Union[Type[Tensor], Type[NDBuffer]]):
+
+    device = helpers.get_device(device_type)
+    shape = (5, 4)
+
+    numpy_ref = np.random.default_rng().random(shape, np.float32)
+    buffer = buffer_type.zeros(device, dtype='float', shape=shape)
+
+    buffer.copy_from_numpy(numpy_ref)
+    buffer_to_np = buffer.to_numpy()
+    assert (buffer_to_np == numpy_ref).all()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+def test_partial_numpy_copy(device_type: DeviceType,
+                            buffer_type: Union[Type[Tensor], Type[NDBuffer]]):
+
+    device = helpers.get_device(device_type)
+    shape = (5, 4)
+
+    numpy_ref = np.random.default_rng().random(shape, np.float32)
+    buffer = buffer_type.zeros(device, dtype='float', shape=shape)
+
+    for i in range(shape[0]):
+        buffer[i].copy_from_numpy(numpy_ref[i])
+
+    buffer_to_np = buffer.to_numpy()
+    assert (buffer_to_np == numpy_ref).all()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
+def test_numpy_copy_errors(device_type: DeviceType,
+                           buffer_type: Union[Type[Tensor], Type[NDBuffer]]):
+
+    device = helpers.get_device(device_type)
+    shape = (5, 4)
+
+    buffer = buffer_type.zeros(device, dtype='float', shape=shape)
+
+    with pytest.raises(Exception, match=r'Numpy array is larger'):
+        ndarray = np.zeros((shape[0], shape[1] + 1), dtype=np.float32)
+        buffer.copy_from_numpy(ndarray)
+
+    buffer_view = buffer.view(shape, (1, shape[0]))
+    with pytest.raises(Exception, match=r'Destination buffer view must be contiguous'):
+        ndarray = np.zeros(shape, dtype=np.float32)
+        buffer_view.copy_from_numpy(ndarray)

--- a/slangpy/types/buffer.py
+++ b/slangpy/types/buffer.py
@@ -179,12 +179,7 @@ class NDBuffer(NativeNDBuffer):
         immediately submitted. If a command buffer is provided the clear is simply appended to it
         but not automatically submitted.
         """
-        if command_buffer:
-            command_buffer.clear_resource_view(self.storage.get_uav(), uint4(0, 0, 0, 0))
-        else:
-            cmd = self.storage.device.create_command_buffer()
-            cmd.clear_resource_view(self.storage.get_uav(), uint4(0, 0, 0, 0))
-            cmd.submit()
+        super().clear()
 
     @staticmethod
     def zeros(device: Device,

--- a/slangpy/types/buffer.py
+++ b/slangpy/types/buffer.py
@@ -137,18 +137,11 @@ class NDBuffer(NativeNDBuffer):
         else:
             raise ValueError("element_count or shape must be provided")
 
-        strides = []
-        total = 1
-        for dim in reversed(shape):
-            strides.append(total)
-            total *= dim
-        strides = Shape(tuple(reversed(strides)))
-
         desc = NativeNDBufferDesc()
         desc.usage = usage
         desc.memory_type = memory_type
         desc.shape = shape
-        desc.strides = strides
+        desc.strides = shape.calc_contiguous_strides()
         desc.dtype = dtype
         desc.element_layout = dtype.buffer_layout.reflection
 

--- a/slangpy/types/buffer.py
+++ b/slangpy/types/buffer.py
@@ -163,6 +163,19 @@ class NDBuffer(NativeNDBuffer):
         """
         return (self.usage & ResourceUsage.unordered_access) != 0
 
+    def broadcast_to(self, shape: TShapeOrTuple):
+        """
+        Returns a new view of the buffer with the requested shape, following standard broadcasting rules.
+        """
+        return super().broadcast_to(Shape(shape))
+
+    def view(self, shape: TShapeOrTuple, strides: TShapeOrTuple = Shape(), offset: int = 0):
+        """
+        Returns a new view of the tensor with the requested shape, strides and offset
+        The offset is in elements (not bytes) and is specified relative to the current offset
+        """
+        return super().view(Shape(shape), Shape(strides), offset)
+
     def to_numpy(self) -> np.ndarray[Any, Any]:
         """
         Copies buffer data into a numpy array with the same shape and strides. If the element type

--- a/slangpy/types/tensor.py
+++ b/slangpy/types/tensor.py
@@ -94,9 +94,16 @@ class Tensor(NativeTensor):
 
     def broadcast_to(self, shape: TShapeOrTuple):
         """
-        Returns a new tensor view of the same buffer with the requested shape, following standard broadcasting rules.
+        Returns a new view of the tensor with the requested shape, following standard broadcasting rules.
         """
         return super().broadcast_to(Shape(shape))
+
+    def view(self, shape: TShapeOrTuple, strides: TShapeOrTuple = Shape(), offset: int = 0):
+        """
+        Returns a new view of the tensor with the requested shape, strides and offset
+        The offset is in elements (not bytes) and is specified relative to the current offset
+        """
+        return super().view(Shape(shape), Shape(strides), offset)
 
     def __str__(self):
         return str(self.to_numpy())

--- a/slangpy/types/tensor.py
+++ b/slangpy/types/tensor.py
@@ -10,7 +10,8 @@ from slangpy.core.shapes import TShapeOrTuple
 from slangpy.types.buffer import get_lookup_module, resolve_element_type, resolve_program_layout
 from slangpy.core.native import Shape, NativeTensor, NativeTensorDesc
 
-from typing import Optional, Any, cast
+from warnings import warn
+
 import numpy as np
 import math
 
@@ -148,6 +149,12 @@ class Tensor(NativeTensor):
 
     @staticmethod
     def numpy(device: Device, ndarray: np.ndarray[Any, Any]) -> Tensor:
+        warn('Tensor.numpy is deprecated. Use Tensor.from_numpy instead.',
+             DeprecationWarning, stacklevel=2)
+        return Tensor.from_numpy(device, ndarray)
+
+    @staticmethod
+    def from_numpy(device: Device, ndarray: np.ndarray[Any, Any]) -> Tensor:
         """
         Creates a new tensor with the same contents, shape and strides as the given numpy array.
         """

--- a/slangpy/types/tensor.py
+++ b/slangpy/types/tensor.py
@@ -88,21 +88,6 @@ class Tensor(NativeTensor):
         self.grad_in: Optional[Tensor]
         self.grad_out: Optional[Tensor]
 
-    # flatten_dtype Not used anywhere - do we need it? If so, need to make native implementation
-    """
-    def flatten_dtype(self) -> Tensor:
-        new_dtype = innermost_type(self.dtype)
-        dtype_shape = self.dtype.shape.as_tuple()
-        dtype_strides = shape_to_contiguous_strides(dtype_shape)
-        stride_multiplier = math.prod(dtype_shape)
-
-        new_shape = self.shape.as_tuple() + dtype_shape
-        new_strides = tuple(s * stride_multiplier for s in self.strides) + dtype_strides
-        new_offset = self.offset * stride_multiplier
-
-        return Tensor(self.storage, new_dtype, new_shape, new_strides, new_offset)
-    """
-
     def broadcast_to(self, shape: TShapeOrTuple):
         """
         Returns a new tensor view of the same buffer with the requested shape, following standard broadcasting rules.

--- a/slangpy/types/tensor.py
+++ b/slangpy/types/tensor.py
@@ -68,7 +68,7 @@ class Tensor(NativeTensor):
         # Setup shape and stride.
         shape = Shape(shape)
         if strides is None:
-            strides = shape_to_contiguous_strides(shape.as_tuple())
+            strides = shape.calc_contiguous_strides()
         if len(strides) != len(shape):
             raise ValueError("Number of strides must match number of dimensions")
 


### PR DESCRIPTION
This is the SlangPy side of changes for the cleanup of `NDBuffer`/`Tensor`.

Currently, `NDBuffer` and `Tensor` offer similar functionality, but often subtly different, or supported in one but not the other. This PR takes a step towards cleaning this up and aligning the two. This also fixes some latent bugs in the code and adds missing functionality of indexing and views.

This depends on [SGL PR 244](https://github.com/shader-slang/sgl/pull/244)

Overview of changes:

* New `StridedBufferView` base class that represents an SGL buffer with strides/view/offset applied.
* `to_numpy` now behaves identically between `NDBuffer` and Tensor. Before, `NDBuffer.to_numpy` would return a flat buffer of bytes. `Tensor.to_numpy` would try to return a buffer of scalars and return `None` on failure
  
  * The new `to_numpy` always returns a valid ndarray, with behavior depending on the slang dtype.
  * If the dtype is an array/vector (possible nested), its shape is appended to the shape of the `NDBuffer`/`Tensor`
  * If the innermost dtype is a scalar compatible with numpy, it is mapped to the equivalent numpy dtype
  * If the innermost dtype is not a scalar, it is converted to a 1D array of bytes and appended to the result shape
  * Examples:
    `NDBuffer` of dtype `float3` with shape `(4, 5)` -ndarray of dtype `np.float32` with shape `(4, 5, 3)`
    `NDBuffer` of dtype `struct Foo {...}` with shape `(5, )` -ndarray of dtype `np.uint8` with shape `(5, sizeof(Foo))`
  * `to_numpy` respects offsets and strides
* `to_torch` is now supported by both `NDBuffer` and `Tensor`, and its behavior now matches that of `to_numpy` (just in a different framework)
* `NDBuffer`/`Tensor` now support indexing. E.g. for an `NDBuffer` of shape `(64, 32)`, indexing `buffer[4]` will return an `NDBuffer` of shape `(32, )`, representing a 1D view of a slice of the original `NDBuffer`. Partial indexing, slicing and ellipses are supported.
* `Tensor`/`NDBuffer` now have a .view() method for creating new views of the same storage. This can be used to implement currently unimplemented operations
* `broadcast_to` is now supported by NDBuffer as well
* `Tensor.numpy` is deprecated in favor of `Tensor.from_numpy`

