### PR TITLE
Load PyTorch lazily

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ SlangPy uses a `semantic versioning <http://semver.org>`__ policy for its API.
 Version 0.28.0 (TBA)
 ----------------------------
 
+- Load PyTorch module lazily to avoid overhead when PyTorch is not used.
+  (PR `#184 <https://github.com/shader-slang/slangpy/pull/184>`__).
 - Improve warning when tev image viewer is not running.
   (PR `#216 <https://github.com/shader-slang/slangpy/pull/216>`__).
 - Report correct LUID in ``sgl::DeviceInfo::adapter_luid`` (``slangpy.DeviceInfo.adapter_luid``).

--- a/slangpy/__init__.py
+++ b/slangpy/__init__.py
@@ -48,10 +48,8 @@ from . import bindings
 from . import builtin as internal_marshalls
 
 # Torch integration
-from .torchintegration import TORCH_ENABLED
-
-if TORCH_ENABLED:
-    from .torchintegration import TorchModule
+# Only import things that load torch lazily here!
+from .torchintegration import TorchModule
 
 # Debug options for call data gen
 from .core.calldata import set_dump_generated_shaders, set_dump_slang_intermediates

--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -149,12 +149,9 @@ class Module:
         """
         Returns a pytorch wrapper around this module
         """
-        import slangpy.torchintegration as spytorch
+        from slangpy.torchintegration.torchmodule import TorchModule
 
-        if spytorch.TORCH_ENABLED:
-            return spytorch.TorchModule(self)
-        else:
-            raise RuntimeError("Pytorch integration is not enabled")
+        return TorchModule(self)
 
     def find_struct(self, name: str):
         """

--- a/slangpy/core/struct.py
+++ b/slangpy/core/struct.py
@@ -138,12 +138,9 @@ class Struct:
         """
         Returns a pytorch wrapper around this struct
         """
-        import slangpy.torchintegration as spytorch
+        from slangpy.torchintegration.torchstruct import TorchStruct
 
-        if spytorch.TORCH_ENABLED:
-            return spytorch.TorchStruct(self)
-        else:
-            raise RuntimeError("Pytorch integration is not enabled")
+        return TorchStruct(self)
 
     def try_get_child(self, name: str) -> Optional[Union["Struct", "Function"]]:
         """

--- a/slangpy/torchintegration/__init__.py
+++ b/slangpy/torchintegration/__init__.py
@@ -1,21 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-# pyright: reportUnusedImport=false
 
-TORCH_ENABLED = False
+# Only import things that load torch lazily here!
+from .torchmodule import TorchModule
 
-try:
-    import torch  # @IgnoreException
-    from .torchfunction import TorchFunction
-    from .torchmodule import TorchModule
-    from .torchstruct import TorchStruct
 
-    __all__ = [
-        "TorchFunction",
-        "TorchModule",
-        "TorchStruct",
-    ]
-
-    TORCH_ENABLED = True
-
-except ImportError:
-    pass
+__all__ = [
+    "TorchModule",
+]

--- a/slangpy/torchintegration/torchmodule.py
+++ b/slangpy/torchintegration/torchmodule.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-from typing import Any, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from slangpy.core.function import Function
 from slangpy.core.struct import Struct
@@ -7,8 +7,8 @@ from slangpy.core.struct import Struct
 from slangpy import SlangModule, Device
 from slangpy.core.module import Module
 
-from slangpy.torchintegration.torchfunction import TorchFunction, check_cuda_enabled
-from slangpy.torchintegration.torchstruct import TorchStruct
+if TYPE_CHECKING:
+    from slangpy.torchintegration.torchstruct import TorchStruct
 
 
 class TorchModule:
@@ -18,6 +18,8 @@ class TorchModule:
 
     def __init__(self, module: "Module"):
         super().__init__()
+        from slangpy.torchintegration.torchfunction import check_cuda_enabled
+
         check_cuda_enabled(module.device)
         self.module = module
 
@@ -88,6 +90,8 @@ class TorchModule:
         """
         spy_struct = self.module.find_struct(name)
         if spy_struct is not None:
+            from slangpy.torchintegration.torchstruct import TorchStruct
+
             return TorchStruct(spy_struct)
         return None
 
@@ -95,6 +99,8 @@ class TorchModule:
         """
         Find a struct by name, raise an error if not found.
         """
+        from slangpy.torchintegration.torchstruct import TorchStruct
+
         return TorchStruct(self.module.require_struct(name))
 
     def find_function(self, name: str):
@@ -103,6 +109,8 @@ class TorchModule:
         """
         spy_function = self.module.find_function(name)
         if spy_function is not None:
+            from slangpy.torchintegration.torchfunction import TorchFunction
+
             return TorchFunction(spy_function)
         return None
 
@@ -110,12 +118,17 @@ class TorchModule:
         """
         Find a function by name, raise an error if not found.
         """
+        from slangpy.torchintegration.torchfunction import TorchFunction
+
         return TorchFunction(self.module.require_function(name))
 
-    def find_function_in_struct(self, struct: Union[TorchStruct, Struct, str], name: str):
+    def find_function_in_struct(self, struct: Union["TorchStruct", Struct, str], name: str):
         """
         Find a function in a struct by name, return None if not found.
         """
+        from slangpy.torchintegration.torchfunction import TorchFunction
+        from slangpy.torchintegration.torchstruct import TorchStruct
+
         if isinstance(struct, TorchStruct):
             struct = struct.struct
         spy_function = self.module.find_function_in_struct(struct, name)
@@ -128,6 +141,9 @@ class TorchModule:
         Attribute accessor attempts to find either a struct or function
         with the specified attribute name.
         """
+        from slangpy.torchintegration.torchfunction import TorchFunction
+        from slangpy.torchintegration.torchstruct import TorchStruct
+
         res = self.module.__getattr__(name)
         if isinstance(res, Struct):
             return TorchStruct(res)


### PR DESCRIPTION
This implements lazy loading of the `torch` module. Before this change, `import slangpy` on an environment with torch installed takes around 2.5 seconds. After this change, `import slangpy` takes around 0.2 seconds! This is a substantial quality of life improvement when iterating.

fixes #153