### PR TITLE
Added `compile_commands.json` symlink for IDEs to pick up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ docs/_build/
 .vs/
 .temp/
 .cache/clangd/index
-compile_commands.json
 
 # Python files installed into source tree
 slangpy/**/*.pyi

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ docs/_build/
 .vscode/
 .vs/
 .temp/
+.cache/clangd/index
+compile_commands.json
 
 # Python files installed into source tree
 slangpy/**/*.pyi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ if (PROJECT_IS_TOP_LEVEL AND UNIX)
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E create_symlink
             ${SGL_BINARY_DIR}/compile_commands.json
-            ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json
+            ${CMAKE_CURRENT_SOURCE_DIR}/build/compile_commands.json
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,16 @@ if(SGL_GENERATE_SETPATH_SCRIPTS)
     endif()
 endif()
 
+# Create compile_commands.json symlink.
+if (PROJECT_IS_TOP_LEVEL AND UNIX)
+    # Create symlink to compile_commands.json for IDE to pick it up
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+            ${SGL_BINARY_DIR}/compile_commands.json
+            ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json
+    )
+endif()
+
 # -----------------------------------------------------------------------------
 # install
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
clangd search compile_commands.json from the root directory and build directory by default. Generating `compile_commands.json` under `build/<target>` makes it impossible for editors like neovim to pick it up. Adding a symlink to the end of CMakeLists.txt makes it easier for neovim users to work with this repo.