### PR TITLE
Basic bindless support

### DIFF
--- a/docs/api_order.json
+++ b/docs/api_order.json
@@ -100,6 +100,7 @@
         "slangpy.DeclReflectionIndexedChildList",
         "slangpy.DepthStencilDesc",
         "slangpy.DepthStencilOpDesc",
+        "slangpy.DescriptorHandle",
         "slangpy.Device",
         "slangpy.DeviceDesc",
         "slangpy.DeviceInfo",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,13 @@ SlangPy uses a `semantic versioning <http://semver.org>`__ policy for its API.
 Version 0.27.0 (TBA)
 ----------------------------
 
+- Introduce basic support for bindless textures and samplers. Currently only supported on D3D12.
+  Add ``sgl::Feature::bindless`` (``slangpy.Feature.bindless``) to detect bindless support.
+  Add ``sgl::DescriptorHandle`` (``slangpy.DescriptorHandle``) to represent bindless descriptor handles.
+  Add ``sgl::Sampler::descriptor_handle()`` (``slangpy.Sampler.descriptor_handle``) to get the descriptor handle for a sampler.
+  Add ``sgl::Texture::descriptor_handle_ro()`` (``slangpy.Texture.descriptor_handle_ro``) to get the read-only descriptor handle for a texture.
+  Add ``sgl::Texture::descriptor_handle_rw()`` (``slangpy.Texture.descriptor_handle_rw``) to get the read-write descriptor handle for a texture.
+  (PR `#196 <https://github.com/shader-slang/slangpy/pull/196>`__).
 - Rename ``sgl::Struct`` to ``sgl::DataStruct`` to match ``slangpy.DataStruct``.
   Rename ``sgl::StructConverter`` to ``sgl::DataStructConverter``
   and ``slangpy.StructConverter`` to ``slangpy.DataStructConverter``.

--- a/src/sgl/core/object.h
+++ b/src/sgl/core/object.h
@@ -470,7 +470,7 @@ public:
     operator T*() const { return m_ptr; }
 
     /// Check if the object is defined
-    operator bool() const { return m_ptr != nullptr; }
+    explicit operator bool() const { return m_ptr != nullptr; }
 
     /// Swap this reference with another reference.
     void swap(ref& r) noexcept
@@ -602,7 +602,7 @@ public:
     T& operator*() const { return *get(); }
     operator ref<T>() const { return ref<T>(get()); }
     operator T*() const { return get(); }
-    operator bool() const { return get() != nullptr; }
+    explicit operator bool() const { return get() != nullptr; }
 
     void break_strong_reference() { m_strong_ref.reset(); }
 

--- a/src/sgl/device/buffer_cursor.cpp
+++ b/src/sgl/device/buffer_cursor.cpp
@@ -410,6 +410,18 @@ SGL_API void BufferElementCursor::get(bool4& value) const
     value = {v.x != 0, v.y != 0, v.z != 0, v.w != 0};
 }
 
+template<>
+SGL_API void BufferElementCursor::set(const DescriptorHandle& value)
+{
+    write_data(m_offset, &value.value, sizeof(value.value));
+}
+
+template<>
+SGL_API void BufferElementCursor::get(DescriptorHandle& value) const
+{
+    read_data(m_offset, &value.value, sizeof(value.value));
+}
+
 void BufferElementCursor::write_data(size_t offset, const void* data, size_t size)
 {
     m_buffer->write_data(offset, data, size);

--- a/src/sgl/device/native_handle.h
+++ b/src/sgl/device/native_handle.h
@@ -167,7 +167,7 @@ public:
 
     bool is_valid() const { return m_type != NativeHandleType::undefined; }
 
-    operator bool() const { return is_valid(); }
+    explicit operator bool() const { return is_valid(); }
 
     template<typename T>
     T as() const

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -1229,7 +1229,7 @@ public:
 
     bool is_valid() const { return m_valid; }
 
-    // operator bool() const { return is_valid(); }
+    // explicit operator bool() const { return is_valid(); }
 
     operator ref<const TypeLayoutReflection>() const { return type_layout(); }
 

--- a/src/sgl/device/resource.cpp
+++ b/src/sgl/device/resource.cpp
@@ -665,6 +665,20 @@ TextureView::TextureView(ref<Device> device, ref<Texture> texture, TextureViewDe
     );
 }
 
+DescriptorHandle TextureView::descriptor_handle() const
+{
+    rhi::DescriptorHandle rhi_handle = {};
+    m_rhi_texture_view->getDescriptorHandle(rhi::DescriptorHandleAccess::Read, &rhi_handle);
+    return DescriptorHandle(rhi_handle);
+}
+
+DescriptorHandle TextureView::rw_descriptor_handle() const
+{
+    rhi::DescriptorHandle rhi_handle = {};
+    m_rhi_texture_view->getDescriptorHandle(rhi::DescriptorHandleAccess::ReadWrite, &rhi_handle);
+    return DescriptorHandle(rhi_handle);
+}
+
 NativeHandle TextureView::native_handle() const
 {
     rhi::NativeHandle rhi_handle = {};

--- a/src/sgl/device/resource.cpp
+++ b/src/sgl/device/resource.cpp
@@ -665,14 +665,14 @@ TextureView::TextureView(ref<Device> device, ref<Texture> texture, TextureViewDe
     );
 }
 
-DescriptorHandle TextureView::descriptor_handle() const
+DescriptorHandle TextureView::descriptor_handle_ro() const
 {
     rhi::DescriptorHandle rhi_handle = {};
     m_rhi_texture_view->getDescriptorHandle(rhi::DescriptorHandleAccess::Read, &rhi_handle);
     return DescriptorHandle(rhi_handle);
 }
 
-DescriptorHandle TextureView::rw_descriptor_handle() const
+DescriptorHandle TextureView::descriptor_handle_rw() const
 {
     rhi::DescriptorHandle rhi_handle = {};
     m_rhi_texture_view->getDescriptorHandle(rhi::DescriptorHandleAccess::ReadWrite, &rhi_handle);

--- a/src/sgl/device/resource.h
+++ b/src/sgl/device/resource.h
@@ -620,6 +620,9 @@ public:
     const SubresourceRange& subresource_range() const { return m_desc.subresource_range; }
     std::string_view label() const { return m_desc.label; }
 
+    DescriptorHandle descriptor_handle() const;
+    DescriptorHandle rw_descriptor_handle() const;
+
     /// Get the native texture view handle.
     NativeHandle native_handle() const;
 

--- a/src/sgl/device/resource.h
+++ b/src/sgl/device/resource.h
@@ -620,8 +620,8 @@ public:
     const SubresourceRange& subresource_range() const { return m_desc.subresource_range; }
     std::string_view label() const { return m_desc.label; }
 
-    DescriptorHandle descriptor_handle() const;
-    DescriptorHandle rw_descriptor_handle() const;
+    DescriptorHandle descriptor_handle_ro() const;
+    DescriptorHandle descriptor_handle_rw() const;
 
     /// Get the native texture view handle.
     NativeHandle native_handle() const;

--- a/src/sgl/device/sampler.cpp
+++ b/src/sgl/device/sampler.cpp
@@ -36,6 +36,13 @@ Sampler::Sampler(ref<Device> device, SamplerDesc desc)
 
 Sampler::~Sampler() { }
 
+DescriptorHandle Sampler::descriptor_handle() const
+{
+    rhi::DescriptorHandle rhi_handle = {};
+    m_rhi_sampler->getDescriptorHandle(&rhi_handle);
+    return DescriptorHandle(rhi_handle);
+}
+
 NativeHandle Sampler::native_handle() const
 {
     rhi::NativeHandle rhi_handle = {};

--- a/src/sgl/device/sampler.h
+++ b/src/sgl/device/sampler.h
@@ -41,6 +41,8 @@ public:
 
     const SamplerDesc& desc() const { return m_desc; }
 
+    DescriptorHandle descriptor_handle() const;
+
     rhi::ISampler* rhi_sampler() const { return m_rhi_sampler; }
 
     /// Get the native sampler handle.

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -440,6 +440,13 @@ void ShaderCursor::set_acceleration_structure(const ref<AccelerationStructure>& 
     m_shader_object->set_acceleration_structure(m_offset, acceleration_structure);
 }
 
+void ShaderCursor::set_descriptor_handle(const DescriptorHandle& handle) const
+{
+    // TODO: check type
+    // currently not possible because they are reported differently depending on the backend
+    m_shader_object->set_descriptor_handle(m_offset, handle);
+}
+
 void ShaderCursor::set_data(const void* data, size_t size) const
 {
     if ((TypeReflection::ParameterCategory)m_type_layout->getParameterCategory()
@@ -612,6 +619,12 @@ template<>
 SGL_API void ShaderCursor::set(const ref<AccelerationStructure>& value) const
 {
     set_acceleration_structure(value);
+}
+
+template<>
+SGL_API void ShaderCursor::set(const DescriptorHandle& value) const
+{
+    set_descriptor_handle(value);
 }
 
 #define SET_SCALAR(type, scalar_type)                                                                                  \

--- a/src/sgl/device/shader_cursor.h
+++ b/src/sgl/device/shader_cursor.h
@@ -66,6 +66,8 @@ public:
     void set_sampler(const ref<Sampler>& sampler) const;
     void set_acceleration_structure(const ref<AccelerationStructure>& acceleration_structure) const;
 
+    void set_descriptor_handle(const DescriptorHandle& handle) const;
+
     void set_data(const void* data, size_t size) const;
 
     void set_cuda_tensor_view(const cuda::TensorView& tensor_view) const;

--- a/src/sgl/device/shader_object.cpp
+++ b/src/sgl/device/shader_object.cpp
@@ -26,7 +26,7 @@ inline rhi::DescriptorHandle rhi_descriptor_handle(const DescriptorHandle& handl
 {
     return {
         .type = static_cast<rhi::DescriptorHandleType>(handle.type),
-        .handle = handle.value,
+        .value = handle.value,
     };
 }
 

--- a/src/sgl/device/shader_object.cpp
+++ b/src/sgl/device/shader_object.cpp
@@ -22,6 +22,14 @@ inline rhi::ShaderOffset rhi_shader_offset(const ShaderOffset& offset)
     };
 }
 
+inline rhi::DescriptorHandle rhi_descriptor_handle(const DescriptorHandle& handle)
+{
+    return {
+        .type = static_cast<rhi::DescriptorHandleType>(handle.type),
+        .handle = handle.value,
+    };
+}
+
 //
 // ShaderObject
 //
@@ -129,6 +137,11 @@ void ShaderObject::set_acceleration_structure(
         rhi_shader_offset(offset),
         rhi::Binding(acceleration_structure ? acceleration_structure->rhi_acceleration_structure() : nullptr)
     ));
+}
+
+void ShaderObject::set_descriptor_handle(const ShaderOffset& offset, const DescriptorHandle& handle)
+{
+    SLANG_RHI_CALL(m_shader_object->setDescriptorHandle(rhi_shader_offset(offset), rhi_descriptor_handle(handle)));
 }
 
 void ShaderObject::set_data(const ShaderOffset& offset, const void* data, size_t size)

--- a/src/sgl/device/shader_object.h
+++ b/src/sgl/device/shader_object.h
@@ -43,6 +43,7 @@ public:
     virtual void set_sampler(const ShaderOffset& offset, const ref<Sampler>& sampler);
     virtual void
     set_acceleration_structure(const ShaderOffset& offset, const ref<AccelerationStructure>& acceleration_structure);
+    virtual void set_descriptor_handle(const ShaderOffset& offset, const DescriptorHandle& handle);
     virtual void set_data(const ShaderOffset& offset, const void* data, size_t size);
 
     virtual void set_cuda_tensor_view(const ShaderOffset& offset, const cuda::TensorView& tensor_view, bool is_uav);

--- a/src/sgl/device/types.cpp
+++ b/src/sgl/device/types.cpp
@@ -6,6 +6,11 @@
 
 namespace sgl {
 
+std::string DescriptorHandle::to_string() const
+{
+    return fmt::format("DescriptorHandle(type={}, value=0x{:08x})", type, value);
+}
+
 std::string Viewport::to_string() const
 {
     return fmt::format(

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -184,7 +184,7 @@ struct SGL_API DescriptorHandle {
     explicit DescriptorHandle(const rhi::DescriptorHandle& handle)
     {
         type = static_cast<DescriptorHandleType>(handle.type);
-        value = handle.handle;
+        value = handle.value;
     }
 
     bool is_valid() const { return type != DescriptorHandleType::undefined; }

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -153,6 +153,47 @@ SGL_ENUM_INFO(
 );
 SGL_ENUM_REGISTER(Feature);
 
+enum class DescriptorHandleType {
+    undefined = static_cast<uint32_t>(rhi::DescriptorHandleType::Undefined),
+    buffer = static_cast<uint32_t>(rhi::DescriptorHandleType::Buffer),
+    rw_buffer = static_cast<uint32_t>(rhi::DescriptorHandleType::RWBuffer),
+    texture = static_cast<uint32_t>(rhi::DescriptorHandleType::Texture),
+    rw_texture = static_cast<uint32_t>(rhi::DescriptorHandleType::RWTexture),
+    sampler = static_cast<uint32_t>(rhi::DescriptorHandleType::Sampler),
+    acceleration_structure = static_cast<uint32_t>(rhi::DescriptorHandleType::AccelerationStructure),
+};
+
+SGL_ENUM_INFO(
+    DescriptorHandleType,
+    {
+        {DescriptorHandleType::undefined, "undefined"},
+        {DescriptorHandleType::buffer, "buffer"},
+        {DescriptorHandleType::rw_buffer, "rw_buffer"},
+        {DescriptorHandleType::texture, "texture"},
+        {DescriptorHandleType::rw_texture, "rw_texture"},
+        {DescriptorHandleType::sampler, "sampler"},
+        {DescriptorHandleType::acceleration_structure, "acceleration_structure"},
+    }
+);
+SGL_ENUM_REGISTER(DescriptorHandleType);
+
+struct SGL_API DescriptorHandle {
+    DescriptorHandleType type{DescriptorHandleType::undefined};
+    uint64_t value{0};
+
+    explicit DescriptorHandle(const rhi::DescriptorHandle& handle)
+    {
+        type = static_cast<DescriptorHandleType>(handle.type);
+        value = handle.handle;
+    }
+
+    bool is_valid() const { return type != DescriptorHandleType::undefined; }
+
+    explicit operator bool() const { return is_valid(); }
+
+    std::string to_string() const;
+};
+
 enum class ShaderModel : uint32_t {
     unknown = 0,
     sm_6_0 = 60,

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -37,6 +37,7 @@ enum class Feature : uint32_t {
     hardware_device = static_cast<uint32_t>(rhi::Feature::HardwareDevice),
     software_device = static_cast<uint32_t>(rhi::Feature::SoftwareDevice),
     parameter_block = static_cast<uint32_t>(rhi::Feature::ParameterBlock),
+    bindless = static_cast<uint32_t>(rhi::Feature::Bindless),
     surface = static_cast<uint32_t>(rhi::Feature::Surface),
     // Rasterization features
     rasterization = static_cast<uint32_t>(rhi::Feature::Rasterization),
@@ -100,6 +101,7 @@ SGL_ENUM_INFO(
         {Feature::hardware_device, "hardware_device"},
         {Feature::software_device, "software_device"},
         {Feature::parameter_block, "parameter_block"},
+        {Feature::bindless, "bindless"},
         {Feature::surface, "surface"},
         {Feature::rasterization, "rasterization"},
         {Feature::barycentrics, "barycentrics"},

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -172,6 +172,7 @@ private:
     {
         if (!self.is_valid())
             return nb::none();
+
         auto type = self.type();
         if (type) {
             switch (type->kind()) {
@@ -373,6 +374,16 @@ private:
     {
         if (!self.is_valid())
             return;
+
+        // Special case for handling DescriptorHandle.
+        // These are reflected differently by slang depending on the backend.
+        // For example, in D3D12 and Vulkan, they are of type uint2.
+        // In Metal and CUDA, they are actual resource types.
+        if (nb::isinstance<DescriptorHandle>(nbval)) {
+            auto handle = nb::cast<DescriptorHandle>(nbval);
+            self.set(handle);
+            return;
+        }
 
         slang::TypeLayoutReflection* type_layout = self.slang_type_layout();
         auto kind = (TypeReflection::Kind)type_layout->getKind();

--- a/src/slangpy_ext/device/resource.cpp
+++ b/src/slangpy_ext/device/resource.cpp
@@ -529,11 +529,15 @@ SGL_PY_EXPORT(device_resource)
         .def_prop_ro("aspect", &TextureView::aspect, D(TextureView, aspect))
         .def_prop_ro("subresource_range", &TextureView::subresource_range, D(TextureView, subresource_range))
         .def_prop_ro("label", &TextureView::label, D(TextureView, label))
-        .def_prop_ro("descriptor_handle", &TextureView::descriptor_handle, D_NA(TextureView, descriptor_handle))
         .def_prop_ro(
-            "rw_descriptor_handle",
-            &TextureView::rw_descriptor_handle,
-            D_NA(TextureView, rw_descriptor_handle)
+            "descriptor_handle_ro",
+            &TextureView::descriptor_handle_ro,
+            D_NA(TextureView, descriptor_handle_ro)
+        )
+        .def_prop_ro(
+            "descriptor_handle_rw",
+            &TextureView::descriptor_handle_rw,
+            D_NA(TextureView, descriptor_handle_rw)
         )
         .def_prop_ro("native_handle", &TextureView::native_handle, D(TextureView, native_handle))
         .def("__repr__", &TextureView::to_string, D(TextureView, to_string));

--- a/src/slangpy_ext/device/resource.cpp
+++ b/src/slangpy_ext/device/resource.cpp
@@ -529,6 +529,12 @@ SGL_PY_EXPORT(device_resource)
         .def_prop_ro("aspect", &TextureView::aspect, D(TextureView, aspect))
         .def_prop_ro("subresource_range", &TextureView::subresource_range, D(TextureView, subresource_range))
         .def_prop_ro("label", &TextureView::label, D(TextureView, label))
+        .def_prop_ro("descriptor_handle", &TextureView::descriptor_handle, D_NA(TextureView, descriptor_handle))
+        .def_prop_ro(
+            "rw_descriptor_handle",
+            &TextureView::rw_descriptor_handle,
+            D_NA(TextureView, rw_descriptor_handle)
+        )
         .def_prop_ro("native_handle", &TextureView::native_handle, D(TextureView, native_handle))
         .def("__repr__", &TextureView::to_string, D(TextureView, to_string));
 }

--- a/src/slangpy_ext/device/sampler.cpp
+++ b/src/slangpy_ext/device/sampler.cpp
@@ -48,5 +48,6 @@ SGL_PY_EXPORT(device_sampler)
 
     nb::class_<Sampler, DeviceResource>(m, "Sampler", D(Sampler)) //
         .def_prop_ro("desc", &Sampler::desc, D(Sampler, desc))
+        .def_prop_ro("descriptor_handle", &Sampler::descriptor_handle, D_NA(Sampler, descriptor_handle))
         .def_prop_ro("native_handle", &Sampler::native_handle, D(Sampler, native_handle));
 }

--- a/src/slangpy_ext/device/shader_cursor.cpp
+++ b/src/slangpy_ext/device/shader_cursor.cpp
@@ -36,8 +36,12 @@ namespace detail {
             add_type(TextureView, set_texture_view);
             add_type(Sampler, set_sampler);
             add_type(AccelerationStructure, set_acceleration_structure);
+            m_write_table[typeid(DescriptorHandle)] = [](ShaderCursor& self, nb::object nbval)
+            {
+                self.set_descriptor_handle(nb::cast<DescriptorHandle>(nbval));
+                return true;
+            };
         }
-
 
         bool write_value(ShaderCursor& self, nb::object nbval) override
         {

--- a/src/slangpy_ext/device/types.cpp
+++ b/src/slangpy_ext/device/types.cpp
@@ -95,6 +95,14 @@ SGL_PY_EXPORT(device_types)
     nb::sgl_enum<CommandQueueType>(m, "CommandQueueType");
 
     nb::sgl_enum<Feature>(m, "Feature", nb::is_arithmetic());
+
+    nb::sgl_enum<DescriptorHandleType>(m, "DescriptorHandleType", nb::is_arithmetic());
+    nb::class_<DescriptorHandle>(m, "DescriptorHandle", D_NA(DescriptorHandle))
+        .def_ro("type", &DescriptorHandle::type, D_NA(DescriptorHandle, type))
+        .def_ro("value", &DescriptorHandle::value, D_NA(DescriptorHandle, value))
+        .def("__bool__", &DescriptorHandle::is_valid)
+        .def("__repr__", &DescriptorHandle::to_string);
+
     nb::sgl_enum<ShaderModel>(m, "ShaderModel", nb::is_arithmetic());
     nb::sgl_enum<ShaderStage>(m, "ShaderStage");
 

--- a/tests/slangpy/device/test_bindless.py
+++ b/tests/slangpy/device/test_bindless.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import sys
+import slangpy as spy
+import numpy as np
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent))
+import sglhelpers as helpers
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_bindless_texture(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    if not device.has_feature(spy.Feature.bindless):
+        pytest.skip("Bindless not supported on this device.")
+    if device_type == spy.DeviceType.vulkan:
+        pytest.skip("Due to a slang bug bindless samplers are currently not supported on Vulkan.")
+
+    module = device.load_module("test_bindless_texture.slang")
+    program = device.link_program(
+        modules=[module], entry_points=[module.entry_point("compute_main")]
+    )
+    kernel = device.create_compute_kernel(program)
+
+    TEXTURE_COUNT = 8
+
+    # create linear and point samplers
+    sampler_linear = device.create_sampler()
+    sampler_point = device.create_sampler(
+        min_filter=spy.TextureFilteringMode.point,
+        mag_filter=spy.TextureFilteringMode.point,
+    )
+
+    # create some 2x1 textures
+    textures = []
+    texture_views = []
+    for i in range(TEXTURE_COUNT):
+        texture = device.create_texture(
+            width=2,
+            height=1,
+            format=spy.Format.r32_float,
+            usage=spy.TextureUsage.shader_resource,
+            data=np.array([i, i + 1], dtype=np.float32),
+        )
+        textures.append(texture)
+        texture_views.append(texture.create_view())
+
+    texture_info_layout = module.layout.get_type_layout(
+        module.layout.find_type_by_name("StructuredBuffer<TextureInfo>")
+    ).element_type_layout
+
+    texture_infos_buffer = device.create_buffer(
+        size=TEXTURE_COUNT * texture_info_layout.stride,
+        usage=spy.BufferUsage.shader_resource,
+    )
+
+    results_buffer = device.create_buffer(
+        size=TEXTURE_COUNT * 4,
+        usage=spy.BufferUsage.unordered_access,
+    )
+
+    # fill texture infos for accessing bindless textures & samplers
+    # even textures are sampled with linear sampler, odd textures with point sampler
+    c = spy.BufferCursor(texture_info_layout, texture_infos_buffer, load_before_write=False)
+    for i in range(TEXTURE_COUNT):
+        c[i].texture = texture_views[i].descriptor_handle
+        c[i].sampler = [sampler_linear, sampler_point][i % 2].descriptor_handle
+        c[i].uv = spy.float2(0.5)
+    c.apply()
+
+    kernel.dispatch(
+        thread_count=[TEXTURE_COUNT, 1, 1],
+        texture_infos=texture_infos_buffer,
+        results=results_buffer,
+    )
+
+    # read back results
+    results = results_buffer.to_numpy().view(np.float32)
+    assert np.allclose(results, [0.5, 2.0, 2.5, 4.0, 4.5, 6.0, 6.5, 8.0])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/slangpy/device/test_bindless.py
+++ b/tests/slangpy/device/test_bindless.py
@@ -65,7 +65,7 @@ def test_bindless_texture(device_type: spy.DeviceType):
     # even textures are sampled with linear sampler, odd textures with point sampler
     c = spy.BufferCursor(texture_info_layout, texture_infos_buffer, load_before_write=False)
     for i in range(TEXTURE_COUNT):
-        c[i].texture = texture_views[i].descriptor_handle
+        c[i].texture = texture_views[i].descriptor_handle_ro
         c[i].sampler = [sampler_linear, sampler_point][i % 2].descriptor_handle
         c[i].uv = spy.float2(0.5)
     c.apply()

--- a/tests/slangpy/device/test_bindless_texture.slang
+++ b/tests/slangpy/device/test_bindless_texture.slang
@@ -1,0 +1,15 @@
+struct TextureInfo
+{
+    Texture2D<float>.Handle texture;
+    SamplerState.Handle sampler;
+    float2 uv;
+};
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void compute_main(uint3 tid : SV_DispatchThreadID, StructuredBuffer<TextureInfo> texture_infos, RWStructuredBuffer<float> results)
+{
+    uint index = tid.x;
+    TextureInfo info = texture_infos[index];
+    results[index] = info.texture.SampleLevel(info.sampler, info.uv, 0);
+}

--- a/tests/slangpy/device/test_bindless_texture.slang
+++ b/tests/slangpy/device/test_bindless_texture.slang
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 struct TextureInfo
 {
     Texture2D<float>.Handle texture;

--- a/tests/slangpy/device/test_print.py
+++ b/tests/slangpy/device/test_print.py
@@ -13,6 +13,8 @@ import sglhelpers as helpers
 def test_print(device_type: spy.DeviceType):
     if device_type == spy.DeviceType.metal:
         pytest.skip("Slang bug https://github.com/shader-slang/slang/issues/6764")
+    if device_type == spy.DeviceType.cuda:
+        pytest.skip("Slang crash")
 
     device = spy.Device(type=device_type, enable_print=True)
     helpers.dispatch_compute(


### PR DESCRIPTION
Introduce basic support for bindless textures and samplers. Currently only supported on D3D12.
- Add ``sgl::Feature::bindless`` (``slangpy.Feature.bindless``) to detect bindless support.
- Add ``sgl::DescriptorHandle`` (``slangpy.DescriptorHandle``) to represent bindless descriptor handles.
- Add ``sgl::Sampler::descriptor_handle()`` (``slangpy.Sampler.descriptor_handle``) to get the descriptor handle for a sampler.
- Add ``sgl::Texture::descriptor_handle_ro()`` (``slangpy.Texture.descriptor_handle_ro``) to get the read-only descriptor handle for a texture.
- Add ``sgl::Texture::descriptor_handle_rw()`` (``slangpy.Texture.descriptor_handle_rw``) to get the read-write descriptor handle for a texture.
