### PR TITLE
Minor build changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/_build/
 slangpy/**/*.pyi
 slangpy/*.pdb
 slangpy/*.pyd
+slangpy/*.pyd.manifest
 slangpy/*.ilk
 slangpy/*.so
 slangpy/.build_dir

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_policy(SET CMP0135 NEW)
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+    cmake_policy(SET CMP0135 NEW)
+endif()
 
 include(FetchContent)
 

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ with open("README.md", "r") as f:
 
 setup(
     version=version,
-    packages=find_packages(),
+    packages=['slangpy'],
     package_data={
         "slangpy": ["slang/*.slang"],
     },

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ class CMakeExtension(Extension):
 
 class CMakeBuild(build_ext):
     def build_extension(self, ext: CMakeExtension) -> None:
-        if os.environ.get('NO_CMAKE_BUILD') == '1':
+        if os.environ.get("NO_CMAKE_BUILD") == "1":
             print("Skipping CMake build as per NO_CMAKE_BUILD environment variable.")
             return
 
@@ -110,12 +110,12 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 current_ext_modules = []
-if os.environ.get('NO_CMAKE_BUILD') != '1':
+if os.environ.get("NO_CMAKE_BUILD") != "1":
     current_ext_modules = [CMakeExtension("slangpy.slangpy_ext")]
 
 setup(
     version=version,
-    packages=['slangpy'],
+    packages=["slangpy"],
     package_data={
         "slangpy": ["slang/*.slang"],
     },

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,10 @@ class CMakeExtension(Extension):
 
 class CMakeBuild(build_ext):
     def build_extension(self, ext: CMakeExtension) -> None:
+        if os.environ.get('NO_CMAKE_BUILD') == '1':
+            print("Skipping CMake build as per NO_CMAKE_BUILD environment variable.")
+            return
+
         # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
         ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
         extdir = ext_fullpath.parent.resolve()
@@ -105,6 +109,10 @@ with open("src/sgl/sgl.h") as f:
 with open("README.md", "r") as f:
     long_description = f.read()
 
+current_ext_modules = []
+if os.environ.get('NO_CMAKE_BUILD') != '1':
+    current_ext_modules = [CMakeExtension("slangpy.slangpy_ext")]
+
 setup(
     version=version,
     packages=['slangpy'],
@@ -112,7 +120,7 @@ setup(
         "slangpy": ["slang/*.slang"],
     },
     include_package_data=True,
-    ext_modules=[CMakeExtension("slangpy.slangpy_ext")],
+    ext_modules=current_ext_modules,
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
 )

--- a/src/slangpy_ext/CMakeLists.txt
+++ b/src/slangpy_ext/CMakeLists.txt
@@ -97,11 +97,13 @@ add_custom_target(
 add_dependencies(slangpy_ext slangpy_ext_build_dir)
 
 # Post processes (and overwrites) a stub file.
+# Note: The use of cached variable allows this to be called from other CMake scripts.
+set(SGL_POST_PROCESS_STUB_PY ${CMAKE_CURRENT_LIST_DIR}/../../tools/postprocess_stub.py CACHE INTERNAL "")
 function(postprocess_stub stub_file args)
     add_custom_command(
         APPEND
         OUTPUT ${stub_file}
-        COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/postprocess_stub.py --file=${stub_file} ${args} --quiet
+        COMMAND ${Python_EXECUTABLE} ${SGL_POST_PROCESS_STUB_PY} --file=${stub_file} ${args} --quiet
         COMMENT "Post-processing stub ${stub_file}"
     )
 endfunction()


### PR DESCRIPTION
- Fixed cmake policy ref so builds with older cmake versions don't fail
- Added env variable based option to disable running CMAKE on pip install
- Refer to package explicitly rather than using find_packages()  (avoids bugs when doing more than editable pip operation in a workspace)
- Made postprocess_stab cmake function usable by other cmakelists.txt files