### PR TITLE
Fixed StridedBufferView::to_numpy on Metal devices

### DIFF
--- a/slangpy/tests/slangpy_tests/test_buffer_views.py
+++ b/slangpy/tests/slangpy_tests/test_buffer_views.py
@@ -108,7 +108,7 @@ def test_to_numpy(
     strides = Shape(unravelled_shape).calc_contiguous_strides()
     byte_strides = tuple(s * np_dtype.itemsize for s in strides)
 
-    ndarray = buffer.to_numpy()
+    ndarray = np.ascontiguousarray(buffer.to_numpy())
     assert ndarray.shape == unravelled_shape
     assert ndarray.strides == byte_strides
     assert ndarray.dtype == np_dtype

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -14,6 +14,30 @@
 
 namespace sgl {
 
+inline size_t get_scalar_type_size(TypeReflection::ScalarType type)
+{
+    switch (type) {
+    case TypeReflection::ScalarType::int8:
+    case TypeReflection::ScalarType::uint8:
+        return 1;
+    case TypeReflection::ScalarType::int16:
+    case TypeReflection::ScalarType::uint16:
+    case TypeReflection::ScalarType::float16:
+        return 2;
+    case TypeReflection::ScalarType::bool_:
+    case TypeReflection::ScalarType::int32:
+    case TypeReflection::ScalarType::uint32:
+    case TypeReflection::ScalarType::float32:
+        return 4;
+    case TypeReflection::ScalarType::int64:
+    case TypeReflection::ScalarType::uint64:
+    case TypeReflection::ScalarType::float64:
+        return 8;
+    default:
+        return 0;
+    }
+}
+
 /// Helper to convert from numpy type mask to slang scalar type.
 inline std::optional<TypeReflection::ScalarType> dtype_to_scalar_type(nb::dlpack::dtype dtype)
 {

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -14,30 +14,6 @@
 
 namespace sgl {
 
-inline size_t get_scalar_type_size(TypeReflection::ScalarType type)
-{
-    switch (type) {
-    case TypeReflection::ScalarType::int8:
-    case TypeReflection::ScalarType::uint8:
-        return 1;
-    case TypeReflection::ScalarType::int16:
-    case TypeReflection::ScalarType::uint16:
-    case TypeReflection::ScalarType::float16:
-        return 2;
-    case TypeReflection::ScalarType::bool_:
-    case TypeReflection::ScalarType::int32:
-    case TypeReflection::ScalarType::uint32:
-    case TypeReflection::ScalarType::float32:
-        return 4;
-    case TypeReflection::ScalarType::int64:
-    case TypeReflection::ScalarType::uint64:
-    case TypeReflection::ScalarType::float64:
-        return 8;
-    default:
-        return 0;
-    }
-}
-
 /// Helper to convert from numpy type mask to slang scalar type.
 inline std::optional<TypeReflection::ScalarType> dtype_to_scalar_type(nb::dlpack::dtype dtype)
 {

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -7,7 +7,6 @@
 #include "sgl/device/command.h"
 #include "sgl/device/buffer_cursor.h"
 
-#include "sgl/device/reflection.h"
 #include "utils/slangpybuffer.h"
 
 namespace sgl::slangpy {
@@ -325,19 +324,7 @@ static nb::ndarray<Framework> to_ndarray(void* data, nb::handle owner, const Str
     //      Buffer with shape (5, ) of struct Foo { ... } -> ndarray of shape (5, sizeof(Foo)) and dtype uint8
     bool is_scalar = innermost_layout->type()->kind() == TypeReflection::Kind::scalar;
     auto dtype_shape = desc.dtype->get_shape();
-    Shape dtype_strides;
-#if SGL_MACOS
-    auto type_refl = desc.dtype->buffer_type_layout()->type();
-    bool is_matrix = type_refl->kind() == TypeReflection::Kind::matrix;
-    auto row_count = type_refl->row_count();
-    auto col_count = type_refl->col_count();
-    if (is_matrix && col_count < 4 && col_count != 2) {
-        dtype_strides = Shape({4, 1});
-    } else
-#endif
-    {
-        dtype_strides = dtype_shape.calc_contiguous_strides();
-    }
+    auto dtype_strides = dtype_shape.calc_contiguous_strides();
 
     size_t innermost_size = is_scalar ? innermost_layout->stride() : 1;
     TypeReflection::ScalarType scalar_type

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -7,6 +7,7 @@
 #include "sgl/device/command.h"
 #include "sgl/device/buffer_cursor.h"
 
+#include "sgl/device/reflection.h"
 #include "utils/slangpybuffer.h"
 
 namespace sgl::slangpy {
@@ -324,7 +325,19 @@ static nb::ndarray<Framework> to_ndarray(void* data, nb::handle owner, const Str
     //      Buffer with shape (5, ) of struct Foo { ... } -> ndarray of shape (5, sizeof(Foo)) and dtype uint8
     bool is_scalar = innermost_layout->type()->kind() == TypeReflection::Kind::scalar;
     auto dtype_shape = desc.dtype->get_shape();
-    auto dtype_strides = dtype_shape.calc_contiguous_strides();
+    Shape dtype_strides;
+#if SGL_MACOS
+    auto type_refl = desc.dtype->buffer_type_layout()->type();
+    bool is_matrix = type_refl->kind() == TypeReflection::Kind::matrix;
+    auto row_count = type_refl->row_count();
+    auto col_count = type_refl->col_count();
+    if (is_matrix && col_count < 4 && col_count != 2) {
+        dtype_strides = Shape({4, 1});
+    } else
+#endif
+    {
+        dtype_strides = dtype_shape.calc_contiguous_strides();
+    }
 
     size_t innermost_size = is_scalar ? innermost_layout->stride() : 1;
     TypeReflection::ScalarType scalar_type

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <initializer_list>
-#include "device/cursor_utils.h"
 #include "nanobind.h"
 
 #include "sgl/device/device.h"
@@ -363,26 +362,8 @@ nb::ndarray<nb::numpy> StridedBufferView::to_numpy() const
     size_t dtype_size = desc().element_layout->stride();
     size_t byte_offset = desc().offset * dtype_size;
     size_t data_size = m_storage->size() - byte_offset;
-    uint8_t* data = new uint8_t[data_size];
-#if SGL_MACOS
-    auto type = this->cursor()->element_type();
-    bool is_matrix = type->kind() == TypeReflection::Kind::matrix;
-    uint32_t num_col = type->col_count();
-    if (is_matrix && num_col < 4 && num_col != 2) {
-        auto element_count = this->element_count();
-        uint32_t num_row = type->row_count();
-        size_t scalar_size = get_scalar_type_size(type->scalar_type());
-        for (size_t i = 0; i < num_row * element_count; i++) {
-            size_t block = i / num_row;
-            size_t row = i % num_row;
-            uint8_t* target = data + block * dtype_size + num_col * row * scalar_size;
-            m_storage->get_data(target, num_col * scalar_size, byte_offset + 4 * i * scalar_size);
-        }
-    } else
-#endif
-    {
-        m_storage->get_data(data, data_size, byte_offset);
-    }
+    void* data = new uint8_t[data_size];
+    m_storage->get_data(data, data_size, byte_offset);
     nb::capsule owner(data, [](void* p) noexcept { delete[] reinterpret_cast<uint8_t*>(p); });
 
     return to_ndarray<nb::numpy>(data, owner, desc());

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cstring>
 #include <initializer_list>
-#include <vector>
 #include "nanobind.h"
 
 #include "sgl/device/device.h"
@@ -412,32 +410,7 @@ void StridedBufferView::copy_from_numpy(nb::ndarray<nb::numpy> data)
     size_t buffer_size = m_storage->size() - byte_offset;
     SGL_CHECK(data_size <= buffer_size, "Numpy array is larger than the buffer ({} > {})", data_size, buffer_size);
 
-#if SGL_MACOS
-    auto type_refl = this->desc().dtype->buffer_type_layout()->type();
-    bool is_matrix = type_refl->kind() == TypeReflection::Kind::matrix;
-    auto row_count = type_refl->row_count();
-    auto col_count = type_refl->col_count();
-    if (is_matrix && col_count < 4 && col_count != 2) {
-        // Get dlpack type from scalar type.
-        ref<NativeSlangType> innermost = innermost_type(this->desc().dtype);
-        ref<TypeLayoutReflection> innermost_layout = innermost->buffer_type_layout();
-        size_t scalar_size = innermost_layout->stride();
-        // Temporary buffer.
-        std::vector<uint8_t> buffer(data_size / col_count * 4);
-        // Copy row by row.
-        for (size_t i = 0; i < data_size / (col_count * scalar_size); i++) {
-            std::memcpy(
-                buffer.data() + i * 4 * scalar_size,
-                static_cast<uint8_t*>(data.data()) + i * col_count * scalar_size,
-                col_count * scalar_size
-            );
-        }
-        m_storage->set_data(buffer.data(), buffer.size(), byte_offset);
-    } else
-#endif
-    {
-        m_storage->set_data(data.data(), data_size, byte_offset);
-    }
+    m_storage->set_data(data.data(), data_size, byte_offset);
 }
 
 } // namespace sgl::slangpy


### PR DESCRIPTION
A draft fix for matrix buffer alignment issue mentioned in #206 

This is an extremely naive implementation and might be slow as the buffer is copied in a for loop. Fix for `copy_from_numpy` is not implemented for now. This matrix alignment issue is also impacting `BufferCursor.to_numpy` and potentially `Buffer.to_numpy()` as well. A general fix for `to_numpy` alignment issue on Metal is required in the future. I'll keep looking into this issue.

The `to_numpy()` now produce correct 3x3 matrix buffers:

```
(base) ~/Documents/stanford/bvhgs (main ✗) pytest tests --log-cli-level=DEBUG --benchmark-skip
============================================================================================================= test session starts ==============================================================================================================
platform darwin -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/fangjun/Documents/stanford/bvhgs
configfile: pyproject.toml
plugins: anyio-4.9.0, benchmark-5.1.0
collecting ...
------------------------------------------------------------------------------------------------------------- live log collection --------------------------------------------------------------------------------------------------------------
INFO     bvhgs:__init__.py:9 Slang device created: Device(
  type = metal,
  adapter_name = "default",
  adapter_luid = 00000000000000000000000000000000,
  enable_debug_layers = false,
  supported_shader_model = sm_6_0,
  shader_cache_enabled = false,
  shader_cache_path = ""
)
collected 11 items

tests/math/test_quaternion.py::test_quaternion_multiply[4] PASSED                                                                                                                                                                        [  9%]
tests/math/test_quaternion.py::test_quaternion_conjugate[4] PASSED                                                                                                                                                                       [ 18%]
tests/math/test_quaternion.py::test_quaternion_inverse[4] PASSED                                                                                                                                                                         [ 27%]
tests/math/test_quaternion.py::test_quaternion_from_axis_angle[4] PASSED                                                                                                                                                                 [ 36%]
tests/math/test_quaternion.py::test_quaternion_to_axis_angle[4] PASSED                                                                                                                                                                   [ 45%]
tests/math/test_quaternion.py::test_rotate_vector[4] PASSED                                                                                                                                                                              [ 54%]
tests/math/test_quaternion.py::test_quaternion_as_rotation_matrix[4]
---------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
DEBUG    test_quaternion:test_quaternion.py:206 [[[-0.43706563 -0.7254428   0.53170127]
  [ 0.754113    0.02661575  0.65620506]
  [-0.49019092  0.6877675   0.5354331 ]]

 [[ 0.87763655 -0.04220945  0.47746468]
  [ 0.41413367  0.5683256  -0.71098477]
  [-0.24134511  0.8217204   0.51626366]]

 [[-0.55375576 -0.4672291  -0.68923986]
  [ 0.07288799 -0.8517591   0.51883894]
  [-0.8294829   0.23707275  0.5057219 ]]

 [[ 0.03341324 -0.91043794  0.41229412]
  [ 0.9988376   0.04476     0.01789208]
  [-0.03474391  0.41121697  0.9108751 ]]]
DEBUG    test_quaternion:test_quaternion.py:207 [[[-0.43706562 -0.72544289  0.53170129]
  [ 0.75411305  0.02661575  0.65620509]
  [-0.49019094  0.68776756  0.53543312]]

 [[ 0.87763651 -0.04220944  0.47746467]
  [ 0.41413366  0.56832555 -0.7109848 ]
  [-0.2413451   0.82172041  0.5162636 ]]

 [[-0.55375578 -0.46722909 -0.68923981]
  [ 0.072888   -0.85175905  0.51883895]
  [-0.8294829   0.23707276  0.50572189]]

 [[ 0.03341322 -0.91043788  0.41229409]
  [ 0.99883753  0.04475997  0.01789208]
  [-0.0347439   0.41121698  0.9108751 ]]]
PASSED                                                                                                                                                                                                                                   [ 63%]
tests/math/test_quaternion.py::test_quaternion_as_rotation_matrix_benchmark[1024] SKIPPED (Skipping benchmark (--benchmark-skip active).)                                                                                                [ 72%]
tests/math/test_quaternion.py::test_quaternion_as_rotation_matrix_benchmark[2048] SKIPPED (Skipping benchmark (--benchmark-skip active).)                                                                                                [ 81%]
tests/math/test_quaternion.py::test_quaternion_as_rotation_matrix_benchmark[4096] SKIPPED (Skipping benchmark (--benchmark-skip active).)                                                                                                [ 90%]
tests/math/test_quaternion.py::test_quaternion_as_rotation_matrix_benchmark[8192] SKIPPED (Skipping benchmark (--benchmark-skip active).)                                                                                                [100%]

========================================================================================================= 7 passed, 4 skipped in 0.87s =========================================================================================================
```