### PR TITLE
Fix clang/gcc warnings

### DIFF
--- a/src/sgl/core/bitmap.cpp
+++ b/src/sgl/core/bitmap.cpp
@@ -146,7 +146,8 @@ Bitmap::Bitmap(
 }
 
 Bitmap::Bitmap(const Bitmap& other)
-    : m_pixel_format(other.m_pixel_format)
+    : Object() // gcc complains otherwise
+    , m_pixel_format(other.m_pixel_format)
     , m_component_type(other.m_component_type)
     , m_pixel_struct(new DataStruct(*other.m_pixel_struct))
     , m_width(other.m_width)

--- a/src/sgl/core/file_stream.cpp
+++ b/src/sgl/core/file_stream.cpp
@@ -43,7 +43,7 @@ inline std::string strerror_safe(int errnum)
         return "Unknown error";
     return buf;
 #elif
-#error "Unsupported platform
+#error "Unsupported platform"
 #endif
 }
 

--- a/src/sgl/core/file_stream.cpp
+++ b/src/sgl/core/file_stream.cpp
@@ -27,11 +27,12 @@ inline std::string strerror_safe(int errnum)
     char buf[1024];
 #if SGL_WINDOWS
     strerror_s(buf, sizeof(buf), errnum);
-    return buf;
 #else
-    strerror_r(errnum, buf, sizeof(buf));
-    return buf;
+    const char* result = strerror_r(errnum, buf, sizeof(buf));
+    SGL_UNUSED(result);
 #endif
+    buf[sizeof(buf) - 1] = '\0'; // Ensure null-termination
+    return buf;
 }
 
 FileStream::FileStream(const std::filesystem::path& path, Mode mode)

--- a/src/sgl/core/file_stream.cpp
+++ b/src/sgl/core/file_stream.cpp
@@ -27,12 +27,24 @@ inline std::string strerror_safe(int errnum)
     char buf[1024];
 #if SGL_WINDOWS
     strerror_s(buf, sizeof(buf), errnum);
-#else
-    const char* result = strerror_r(errnum, buf, sizeof(buf));
-    SGL_UNUSED(result);
-#endif
-    buf[sizeof(buf) - 1] = '\0'; // Ensure null-termination
     return buf;
+#elif SGL_LINUX
+#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE
+    // XSI strerror_r
+    if (strerror_r(errnum, buf, sizeof(buf)) != 0)
+        return "Unknown error";
+    return buf;
+#else
+    // GNU strerror_r
+    return strerror_r(errnum, buf, sizeof(buf));
+#endif
+#elif SGL_MACOS
+    if (strerror_r(errnum, buf, sizeof(buf)) != 0)
+        return "Unknown error";
+    return buf;
+#elif
+#error "Unsupported platform
+#endif
 }
 
 FileStream::FileStream(const std::filesystem::path& path, Mode mode)

--- a/src/sgl/core/platform.cpp
+++ b/src/sgl/core/platform.cpp
@@ -75,20 +75,6 @@ std::string get_extension_from_path(const std::filesystem::path& path)
     return ext;
 }
 
-std::filesystem::path get_temp_file_path()
-{
-    static std::mutex mutex;
-    std::lock_guard<std::mutex> guard(mutex);
-    SGL_DIAGNOSTIC_PUSH
-    SGL_DISABLE_MSVC_WARNING(4996)
-    SGL_DISABLE_CLANG_WARNING("-Wdeprecated-declarations")
-    char* name = std::tmpnam(nullptr);
-    SGL_DIAGNOSTIC_POP
-    if (name == nullptr)
-        SGL_THROW("Failed to create temporary file path.");
-    return name;
-}
-
 const std::filesystem::path& executable_directory()
 {
     static std::filesystem::path directory{executable_path().parent_path()};

--- a/src/sgl/core/platform.h
+++ b/src/sgl/core/platform.h
@@ -119,10 +119,6 @@ save_file_dialog(std::span<const FileDialogFilter> filters = {});
 /// Get the file extension from a path in lower-case and without the leading '.' character.
 [[nodiscard]] SGL_API std::string get_extension_from_path(const std::filesystem::path& path);
 
-/// Create a unique path to a temporary file.
-/// Note: A file with the same name could still be created by another process.
-[[nodiscard]] SGL_API std::filesystem::path get_temp_file_path();
-
 /// Create a junction (soft link).
 [[nodiscard]] SGL_API bool create_junction(const std::filesystem::path& link, const std::filesystem::path& target);
 

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -9469,10 +9469,6 @@ leading '.' character.)doc";
 
 static const char *__doc_sgl_platform_get_proc_address = R"doc(Get a function pointer from a library.)doc";
 
-static const char *__doc_sgl_platform_get_temp_file_path =
-R"doc(Create a unique path to a temporary file. Note: A file with the same
-name could still be created by another process.)doc";
-
 static const char *__doc_sgl_platform_has_extension =
 R"doc(Check if a file path has a given file extension. Does a case-
 insensitive comparison.)doc";

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -315,6 +315,8 @@ public:
     /// Default behaviour is to always cast directly to the bound type.
     virtual ref<NativeSlangType> resolve_type(nb::object context, const ref<NativeSlangType> bound_type) const
     {
+        SGL_UNUSED(context);
+        SGL_UNUSED(bound_type);
         return m_slang_type;
     }
 

--- a/src/slangpy_ext/utils/slangpybuffer.cpp
+++ b/src/slangpy_ext/utils/slangpybuffer.cpp
@@ -243,6 +243,7 @@ nb::object NativeNumpyMarshall::create_output(CallContext* context, NativeBoundV
 
 nb::object NativeNumpyMarshall::create_dispatchdata(nb::object data) const
 {
+    SGL_UNUSED(data);
     SGL_THROW("Raw dispatch is not supported for numpy arrays.");
 }
 

--- a/src/slangpy_ext/utils/slangpyresources.cpp
+++ b/src/slangpy_ext/utils/slangpyresources.cpp
@@ -57,6 +57,7 @@ void NativeTextureMarshall::write_shader_cursor_pre_dispatch(
 ) const
 {
     SGL_UNUSED(context);
+    SGL_UNUSED(read_back);
     AccessType primal_access = binding->get_access().first;
     if (primal_access != AccessType::none) {
 

--- a/src/slangpy_ext/utils/slangpyvalue.cpp
+++ b/src/slangpy_ext/utils/slangpyvalue.cpp
@@ -18,10 +18,10 @@ void NativeValueMarshall::write_shader_cursor_pre_dispatch(
     nb::list read_back
 ) const
 {
+    SGL_UNUSED(context);
+    SGL_UNUSED(read_back);
     AccessType primal_access = binding->get_access().first;
     if (!value.is_none() && (primal_access == AccessType::read || primal_access == AccessType::readwrite)) {
-        SGL_UNUSED(binding);
-        SGL_UNUSED(context);
         ShaderCursor field = cursor[binding->get_variable_name()]["value"];
         write_shader_cursor(field, value);
     }


### PR DESCRIPTION
- fix clang and gcc warnings
- remove `platform::get_temp_file_path` which uses deprecated APIs