### PR TITLE
Enable slangpy_tests on Metal and Run `test_buffer_views` on macOS

### DIFF
--- a/slangpy/tests/slangpy_tests/helpers.py
+++ b/slangpy/tests/slangpy_tests/helpers.py
@@ -34,8 +34,7 @@ elif sys.platform == "win32":
 elif sys.platform == "linux" or sys.platform == "linux2":
     DEFAULT_DEVICE_TYPES = [DeviceType.vulkan]
 elif sys.platform == "darwin":
-    # TODO: we don't run any slangpy tests on metal due to slang bugs for now
-    DEFAULT_DEVICE_TYPES = []  # [DeviceType.metal]
+    DEFAULT_DEVICE_TYPES = [DeviceType.metal]
 else:
     raise RuntimeError("Unsupported platform")
 

--- a/slangpy/tests/slangpy_tests/test_buffer_views.py
+++ b/slangpy/tests/slangpy_tests/test_buffer_views.py
@@ -18,10 +18,6 @@ try:
 except ImportError:
     pytest.skip("Pytorch not installed", allow_module_level=True)
 
-# Skip all tests in this file if running on MacOS
-if sys.platform == "darwin":
-    pytest.skip("PyTorch requires CUDA, that is not available on macOS", allow_module_level=True)
-
 MODULE = r"""
 struct RGB {
     float x;
@@ -123,7 +119,8 @@ def test_to_torch(
     buffer_type: Union[Type[Tensor], Type[NDBuffer]],
     test_dtype: tuple[str, Optional[torch.dtype], Type[Any], tuple[int, ...]],
 ):
-
+    if sys.platform == "darwin":
+        pytest.skip("PyTorch requires CUDA, that is not available on macOS", allow_module_level=True)
     device = helpers.get_device(device_type, cuda_interop=True)
     module = helpers.create_module(device, MODULE)
 


### PR DESCRIPTION
This expose `NDBuffer.to_numpy` issue for dtype `float3` and `float3[2]` on metal and help test #206 

I'm also thinking about adding matrix dtype like `float2x2` and `float3x3` to the test.

All the other tests are passed currently on my machine as mentioned in https://github.com/shader-slang/slangpy/issues/151#issuecomment-2873185894. I'm not sure if #151 is resolved now.