### PR TITLE
Report correct adapter LUID

### DIFF
--- a/src/sgl/device/cuda_utils.cpp
+++ b/src/sgl/device/cuda_utils.cpp
@@ -238,7 +238,7 @@ Device::Device(const sgl::Device* device)
     SGL_CU_CHECK(cuDeviceGetName(name, sizeof(name), selected_device));
     int major = get_device_attribute(selected_device, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR);
     int minor = get_device_attribute(selected_device, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR);
-    log_info("Created CUDA device \"{}\" (architecture {}.{}).", name, major, minor);
+    log_debug("Created CUDA device \"{}\" (architecture {}.{}).", name, major, minor);
 }
 
 Device::~Device()

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -42,6 +42,15 @@ namespace sgl {
 static std::vector<Device*> s_devices;
 static std::mutex s_devices_mutex;
 
+inline AdapterLUID from_rhi(const rhi::AdapterLUID& rhi_luid)
+{
+    AdapterLUID luid;
+    for (size_t i = 0; i < 16; ++i)
+        luid[i] = rhi_luid.luid[i];
+    return luid;
+}
+
+
 Device::Device(const DeviceDesc& desc)
     : m_desc(desc)
 {
@@ -112,11 +121,11 @@ Device::Device(const DeviceDesc& desc)
         SGL_THROW("Failed to create device!");
 
     // Get device info.
-    const rhi::DeviceInfo& rhi_device_info = m_rhi_device->getDeviceInfo();
+    const rhi::DeviceInfo& rhi_device_info = m_rhi_device->getInfo();
     m_info.type = m_desc.type;
     m_info.api_name = rhi_device_info.apiName;
     m_info.adapter_name = rhi_device_info.adapterName;
-    m_info.adapter_luid = m_desc.adapter_luid ? *m_desc.adapter_luid : AdapterLUID();
+    m_info.adapter_luid = from_rhi(rhi_device_info.adapterLUID);
     m_info.timestamp_frequency = rhi_device_info.timestampFrequency;
     m_info.limits.max_texture_dimension_1d = rhi_device_info.limits.maxTextureDimension1D;
     m_info.limits.max_texture_dimension_2d = rhi_device_info.limits.maxTextureDimension2D;
@@ -751,14 +760,6 @@ std::vector<AdapterInfo> Device::enumerate_adapters(DeviceType type)
 #endif
     }
 
-    auto convert_luid = [](const rhi::AdapterLUID& rhi_luid) -> AdapterLUID
-    {
-        AdapterLUID luid;
-        for (size_t i = 0; i < 16; ++i)
-            luid[i] = rhi_luid.luid[i];
-        return luid;
-    };
-
     rhi::AdapterList rhi_adapters = rhi::getRHI()->getAdapters(static_cast<rhi::DeviceType>(type));
 
     std::vector<AdapterInfo> adapters(rhi_adapters.getCount());
@@ -768,7 +769,7 @@ std::vector<AdapterInfo> Device::enumerate_adapters(DeviceType type)
             .name = rhi_adapter.name,
             .vendor_id = rhi_adapter.vendorID,
             .device_id = rhi_adapter.deviceID,
-            .luid = convert_luid(rhi_adapter.luid),
+            .luid = from_rhi(rhi_adapter.luid),
         };
     }
 

--- a/src/slangpy_ext/slangpy_ext.cpp
+++ b/src/slangpy_ext/slangpy_ext.cpp
@@ -74,6 +74,12 @@ NB_MODULE(slangpy_ext, m_)
     nb::set_leak_warnings(false);
 #endif
 
+    // TODO: For now, we disable leak warnings even in Debug builds.
+    // The reason is that slangpy currently leaks objects because of cyclic references
+    // created in the native Python code, which uses sgl bindings for typing.
+    // We need to investigate this further and make sure Python code doesn't create cyclic references.
+    nb::set_leak_warnings(false);
+
     nb::module_ m = nb::module_::import_("slangpy");
     m.attr("__doc__") = "slangpy";
 


### PR DESCRIPTION
- update `slang-rhi` to latest (which introduces reporting adapter LUID in device info)
- report correct device LUID in `DeviceInfo`
- make CUDA interop device init less chatty
- disable nanobind leak warnings for now

fixes #167 