### PR TITLE
Fix Inconsistant `ref<NativeCallData>` Usage in `NativeFunctionNode::call`

### DIFF
--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -51,7 +51,7 @@ nb::object NativeFunctionNode::call(NativeCallDataCache* cache, nb::args args, n
     cache->get_args_signature(builder, args, kwargs);
 
     std::string sig = builder->str();
-    NativeCallData* call_data = cache->find_call_data(sig);
+    ref<NativeCallData> call_data = cache->find_call_data(sig);
 
     if (call_data) {
         return call_data->call(options, args, kwargs);


### PR DESCRIPTION
I've noticed that all the NativeCallData generated from FunctionNode are using `ref` wrapper while the one fetched from cache under `NativeFunctionNode::call` is using raw pointer. This is probably a typo and should be fixed.