### PR TITLE
update slang-rhi

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 
 SlangPy uses a `semantic versioning <http://semver.org>`__ policy for its API.
 
+Version 0.30.0 (TBA)
+----------------------------
+
+- Update `slang-rhi` to latest version. Improve CUDA error reporting. Improve debug marker support and add WinPixRuntime.
+  (PR `#236 <https://github.com/shader-slang/slangpy/pull/236>`__).
+
 Version 0.29.0 (May 22, 2025)
 ----------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,10 @@ SlangPy uses a `semantic versioning <http://semver.org>`__ policy for its API.
 Version 0.30.0 (TBA)
 ----------------------------
 
-- Update `slang-rhi` to latest version. Improve CUDA error reporting. Improve debug marker support and add WinPixRuntime.
+- Update `slang-rhi` to latest version.
+  Improve CUDA error reporting.
+  Improve debug marker support and add `WinPixEventRuntime`.
+  Fix resource lifetime tracking for entry point arguments.
   (PR `#236 <https://github.com/shader-slang/slangpy/pull/236>`__).
 
 Version 0.29.0 (May 22, 2025)

--- a/src/sgl/device/command.cpp
+++ b/src/sgl/device/command.cpp
@@ -71,7 +71,7 @@ namespace detail {
 
 void PassEncoder::push_debug_group(const char* name, float3 color)
 {
-    m_rhi_pass_encoder->pushDebugGroup(name, &color[0]);
+    m_rhi_pass_encoder->pushDebugGroup(name, rhi::MarkerColor{color.r, color.g, color.b});
 }
 
 void PassEncoder::pop_debug_group()
@@ -81,7 +81,7 @@ void PassEncoder::pop_debug_group()
 
 void PassEncoder::insert_debug_marker(const char* name, float3 color)
 {
-    m_rhi_pass_encoder->insertDebugMarker(name, &color[0]);
+    m_rhi_pass_encoder->insertDebugMarker(name, rhi::MarkerColor{color.r, color.g, color.b});
 }
 
 void PassEncoder::end()
@@ -792,7 +792,7 @@ void CommandEncoder::push_debug_group(const char* name, float3 color)
 {
     SGL_CHECK(m_open, "Command encoder is finished");
 
-    m_rhi_command_encoder->pushDebugGroup(name, &color[0]);
+    m_rhi_command_encoder->pushDebugGroup(name, rhi::MarkerColor{color.r, color.g, color.b});
 }
 
 void CommandEncoder::pop_debug_group()
@@ -806,7 +806,7 @@ void CommandEncoder::insert_debug_marker(const char* name, float3 color)
 {
     SGL_CHECK(m_open, "Command encoder is finished");
 
-    m_rhi_command_encoder->insertDebugMarker(name, &color[0]);
+    m_rhi_command_encoder->insertDebugMarker(name, rhi::MarkerColor{color.r, color.g, color.b});
 }
 
 void CommandEncoder::write_timestamp(QueryPool* query_pool, uint32_t index)

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -237,12 +237,11 @@ Device::~Device()
 
 ShaderCacheStats Device::shader_cache_stats() const
 {
-    size_t hit_count, miss_count, cache_size;
-    m_rhi_device->getShaderCacheStats(&hit_count, &miss_count, &cache_size);
+    // TODO: revisit when we add a shader cache.
     return {
-        .entry_count = cache_size,
-        .hit_count = hit_count,
-        .miss_count = miss_count,
+        .entry_count = 0,
+        .hit_count = 0,
+        .miss_count = 0,
     };
 }
 


### PR DESCRIPTION
- Improve CUDA error reporting.
- Improve debug marker support and add `WinPixEventRuntime`.
- Fix resource lifetime tracking for entry point arguments.

fixes #240 