### PR TITLE
Fixed missing slangpy error in jupyter

### DIFF
--- a/slangpy/core/jupyter.py
+++ b/slangpy/core/jupyter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import slangpy
 from slangpy import TextureType
 from slangpy import Module, Function, Struct
 from slangpy import (


### PR DESCRIPTION
When running the example in https://slangpy.shader-slang.org/en/latest/src/tutorials/image_io_and_manipulation.html

Displaying the bitmap directly will throw the error:

```
NameError                                 Traceback (most recent call last)
File [~/Documents/stanford/bvhgs/.venv/lib/python3.12/site-packages/IPython/core/formatters.py:402](http://localhost:8888/lab/workspaces/~/Documents/stanford/bvhgs/.venv/lib/python3.12/site-packages/IPython/core/formatters.py#line=401), in BaseFormatter.__call__(self, obj)
    400     pass
    401 else:
--> 402     return printer(obj)
    403 # Finally look for special method names
    404 method = get_real_method(obj, self.print_method)

File [~/Documents/stanford/bvhgs/.venv/lib/python3.12/site-packages/slangpy/core/jupyter.py:33](http://localhost:8888/lab/workspaces/~/Documents/stanford/bvhgs/.venv/lib/python3.12/site-packages/slangpy/core/jupyter.py#line=32), in format_bitmap_png(bmp)
     30 def format_bitmap_png(bmp: Bitmap):
     31     # Cast component to 8 bit if the source has more bits
     32     # We always do gamma correction here - is there a better way?
---> 33     if bmp.component_type != slangpy.Bitmap.ComponentType.uint8:
     34         bmp = bmp.convert(component_type=slangpy.Bitmap.ComponentType.uint8, srgb_gamma=True)
     36     # Make sure bitmap is RGB[/RGBA](http://localhost:8888/RGBA) or saving to PNG will fail

NameError: name 'slangpy' is not defined
```

This PR should fix the issue