### PR TITLE
Allow discovery of spirv-opt in slang-glslang.dll without having it in the PATH

### DIFF
--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -66,7 +66,8 @@ Device::Device(const DeviceDesc& desc)
     SLANG_CALL(slang::createGlobalSession(m_global_session.writeRef()));
 
     // Setup path for slang's downstream compilers.
-    for (SlangPassThrough pass_through : {SLANG_PASS_THROUGH_DXC, SLANG_PASS_THROUGH_GLSLANG}) {
+    for (SlangPassThrough pass_through :
+         {SLANG_PASS_THROUGH_DXC, SLANG_PASS_THROUGH_GLSLANG, SLANG_PASS_THROUGH_SPIRV_OPT}) {
         m_global_session->setDownstreamCompilerPath(pass_through, platform::runtime_directory().string().c_str());
     }
 


### PR DESCRIPTION
Solves an issue where spirv-opt isn't found without slang-glsland.dll as Slang is using LoadLibraryA which does not seem to obey the `os.add_dll_directory`. Ref: https://github.com/shader-slang/slang/issues/7342

