### PR TITLE
Enhanced Kernel Dispatch Flexibility in SlangPy

### DIFF
--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -88,6 +88,8 @@ class CallData(NativeCallData):
             positional_mapping = build_info.map_args
             keyword_mapping = build_info.map_kwargs
             type_conformances = build_info.type_conformances
+            if build_info.call_group_shape is not None:
+                self.call_group_shape = build_info.call_group_shape
 
             # Store logger from either function or module
             if build_info.logger is not None:

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -88,8 +88,7 @@ class CallData(NativeCallData):
             positional_mapping = build_info.map_args
             keyword_mapping = build_info.map_kwargs
             type_conformances = build_info.type_conformances
-            if build_info.call_group_shape is not None:
-                self.call_group_shape = build_info.call_group_shape
+            self.call_group_shape = build_info.call_group_shape
 
             # Store logger from either function or module
             if build_info.logger is not None:

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -396,16 +396,100 @@ def generate_code(
 
     # Generate the header
     cg.add_import("slangpy")
+
+    call_data_len = context.call_dimensionality
+
+    # Get the call group size so we can see about using it when generating the
+    # [numthreads(...)] attribute. We use 1 as the default size if a call
+    # group shape has not been set, as we can use that to make things "linear".
+    # Note that when size is 1, we will still launch a group of 32 threads,
+    # but each thread is conceptually in its own group of size 1. This then
+    # leads to a linearly calculated call_id based on threadID.x and the call
+    # shape's size and strides.
+    call_group_size = 1
+    call_group_shape = build_info.call_group_shape
+    if call_group_shape is not None:
+        call_group_shape_vector = call_group_shape.as_list()
+
+        # Validate call_group_shape dimensions and values before using them
+        if len(call_group_shape_vector) > context.call_dimensionality:
+            raise KernelGenException(
+                f"call_group_shape dimension ({len(call_group_shape_vector)}) must be <= "
+                f"call_shape dimension ({context.call_dimensionality}). "
+                f"call_group_shape cannot have more dimensions than call_shape."
+            )
+
+        # Validate that all call_group_shape values are >= 1
+        for i, dim in enumerate(call_group_shape_vector):
+            if dim < 1:
+                raise KernelGenException(
+                    f"call_group_shape[{i}] = {dim} is invalid. "
+                    f"All call_group_shape elements must be >= 1."
+                )
+
+        # Calculate call group size as product of all dimensions
+        for dim in call_group_shape_vector:
+            call_group_size *= dim
+        # Check if call_group_size exceeds hardware limits
+        if call_group_size > 1024:
+            raise KernelGenException(
+                f"call_group_size ({call_group_size}) exceeds the typical 1024 maximum "
+                f"enforced by most APIs. Consider reducing your call_group_shape dimensions."
+            )
+
+    # Specify some global-scope static variables here to allow users to make calls
+    # to functions like get_call_id<N>() etc in order to access call_id,
+    # call_group_id, and call_group_thread_id.
+
+    # Note: Support for static global variables should be seen as a legacy feature
+    #       and its use is discouraged. As such, this may need to be reworked in
+    #       the future.
+    if call_data_len > 0:
+        # Context wants call_id as an int for some reason, so respect that here
+        # for now
+        cg.add_snippet("call_id", f"static int[{call_data_len}] call_id;\n")
+        cg.add_snippet("call_group_id", f"static uint[{call_data_len}] call_group_id;\n")
+        cg.add_snippet(
+            "call_group_thread_id", f"static uint[{call_data_len}] call_group_thread_id;\n"
+        )
+
+        # TODO: Ideally there would be a way to just return call_id here so we could avoid wasted effort itterating.
+        #       Not enough of a slang expert at the moment to know what that could/should look like.
+        cg.add_snippet(
+            "get_call_id",
+            f"export public static int[N] get_call_id<let N: int>() {{ int[N] ret;  for(int i=0; i<{call_data_len}; i++) {{ ret[i] = call_id[i]; }} return ret; }};\n",
+        )
+        cg.add_snippet(
+            "get_call_group_id",
+            f"export public static uint[N] get_call_group_id<let N: int>() {{ uint[N] ret;  for(int i=0; i<{call_data_len}; i++) {{ ret[i] = call_group_id[i]; }} return ret; }};\n",
+        )
+        cg.add_snippet(
+            "get_call_group_thread_id",
+            f"export public static uint[N] get_call_group_thread_id<let N: int>() {{ uint[N] ret;  for(int i=0; i<{call_data_len}; i++) {{ ret[i] = call_group_thread_id[i]; }} return ret; }};\n",
+        )
+
     cg.add_import(build_info.module.name)
 
     # Generate constants if specified
     generate_constants(build_info, cg)
 
     # Generate call data inputs if vector call
-    call_data_len = context.call_dimensionality
     if call_data_len > 0:
-        cg.call_data.append_statement(f"int[{call_data_len}] _call_stride")
+        # We use the call shape dimensions to detect cases when the call shape
+        # and the call group shape are not aligned. When a thread's call id
+        # falls outside the call shape, we need it to return early. This is
+        # similar to the default linear case when the call shape size is not
+        # 32 thread aligned.
         cg.call_data.append_statement(f"int[{call_data_len}] _call_dim")
+        # A group can be thought of as a "window" looking at a
+        # portion of the entire call shape. Grid here refers to the
+        # N dimensional call shape being broken up into some number of N
+        # dimensional "window"s / groups.
+        cg.call_data.append_statement(f"uint[{call_data_len}] _grid_stride")
+        cg.call_data.append_statement(f"uint[{call_data_len}] _grid_dim")
+        cg.call_data.append_statement(f"uint[{call_data_len}] _group_stride")
+        cg.call_data.append_statement(f"uint[{call_data_len}] _group_dim")
+
     cg.call_data.append_statement(f"uint3 _thread_count")
 
     # Generate the context structure
@@ -483,23 +567,69 @@ def generate_code(
 
     # Generate the main function
     cg.kernel.append_line('[shader("compute")]')
-    cg.kernel.append_line("[numthreads(32, 1, 1)]")
-    cg.kernel.append_line("void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)")
+    if call_group_size != 1:
+        cg.kernel.append_line(f"[numthreads({call_group_size}, 1, 1)]")
+    else:
+        cg.kernel.append_line("[numthreads(32, 1, 1)]")
+
+    # Note: While flat_call_thread_id is 3-dimensional, we consider it "flat" and 1-dimensional because of the
+    #       true call group shape of [x, 1, 1] and only use the first dimension for the call thread id.
+    cg.kernel.append_line("void compute_main(uint3 flat_call_thread_id: SV_DispatchThreadID)")
     cg.kernel.begin_block()
-    cg.kernel.append_statement("if (any(dispatchThreadID >= call_data._thread_count)) return")
+    cg.kernel.append_statement("if (any(flat_call_thread_id >= call_data._thread_count)) return")
+
+    # Calculate the ids that we'll use to compute the call id. We'll also store the
+    # N-dimensional call_*_id's as global-scope static variables such that they can
+    # be "queried" in user shaders via getters provided by the slangpy module.
+    if call_data_len > 0:
+        # Calculate flattened id's that will be used to determine the N-dimensional
+        # id's.
+        cg.kernel.append_statement(f"uint flat_call_id = flat_call_thread_id.x")
+        # We use call_group_size here, which can be 1, because we want to allow for
+        # a default linear dispatch when the call group shape is not specified. When
+        # call_group_size is 1, each thread conceptually has its own group (even though
+        # they will stil be dispatched in groups of 32), where the call_group_id will match
+        # the call_id. This results in linear mapping from the flat thread id to the
+        # call id where call_id[i] = flat_call_id/call_stride[i] % call_dim[i].
+        cg.kernel.append_statement(
+            f"uint flat_call_group_id = flat_call_thread_id.x / {call_group_size}"
+        )
+        # Again, we want to use flat_call_thread_id.x for calcualting flat_call_group_thread_id
+        # rather than something like SV_GroupIndex because we want to be able to force
+        # flat_call_group_thread_id == flat_call_thread_id.x in the default case using
+        # linear dispatches. The same could be accomplished with SV_GroupIndex and
+        # [numthreads(1, 1, 1)], but this would likely be less performant.
+        cg.kernel.append_statement(
+            f"uint flat_call_group_thread_id = flat_call_thread_id.x % {call_group_size}"
+        )
 
     # Loads / initializes call id
-    context_args = "dispatchThreadID"
+    context_args = "flat_call_thread_id"
     if call_data_len > 0:
-        cg.kernel.append_line(f"int[{call_data_len}] call_id = {{")
+        cg.kernel.append_line(f"for (int i=0; i<{call_data_len}; i++)")
+        cg.kernel.append_line("{")
         cg.kernel.inc_indent()
-        for i in range(call_data_len):
-            cg.kernel.append_line(
-                f"(dispatchThreadID.x/call_data._call_stride[{i}]) % call_data._call_dim[{i}],"
-            )
+
+        # Calculate the N-dimensional id's
+        cg.kernel.append_statement(
+            "call_group_thread_id[i] = (flat_call_group_thread_id/call_data._group_stride[i]) % call_data._group_dim[i]"
+        )
+        cg.kernel.append_statement(
+            "call_group_id[i] = (flat_call_group_id/call_data._grid_stride[i]) % call_data._grid_dim[i]"
+        )
+        cg.kernel.append_statement(
+            f"call_id[i] = call_group_id[i] * call_data._group_dim[i] + call_group_thread_id[i]"
+        )
+        # In the event that the call shape is not aligned to the call group shape,
+        # we use an aligned call shape to calculate the number of threads that we
+        # need. However, that means that some threads will fall outside the call shape
+        # and as a result will need to return early and be wasted.
+        cg.kernel.append_statement("if (call_id[i] >= call_data._call_dim[i]) return")
         cg.kernel.dec_indent()
         cg.kernel.append_statement("}")
-        context_args += ", call_id"
+
+        context_args += f", call_id"
+
     cg.kernel.append_statement(f"Context context = {{{context_args}}}")
 
     # Call the trampoline function

--- a/slangpy/slang/callidarg.slang
+++ b/slangpy/slang/callidarg.slang
@@ -3,6 +3,8 @@ implementing slangpy;
 
 public struct CallIdArg {
 
+    int dummy;
+
     // Array load
     public void load<let N : int, T: __BuiltinIntegerType>(ContextND<N> context, out Array<T, N> value) {
         var t = context.call_id;
@@ -59,14 +61,3 @@ extension<T : __BuiltinIntegerType> VectorizeCallidArgTo<T, -1> {
 extension<T : __BuiltinIntegerType> VectorizeCallidArgTo<T, 1> {
     typealias VectorType = T;
 }
-
-// Functions provided for use in user's shaders
-// Note: In the returned arrays, the first component represents the dimension with the highest stride,
-// the second component the dimension with the next highest stride, and so on. This aligns with
-// behavior described at https://slangpy.shader-slang.org/en/latest/src/generators/generator_ids.html
-// but could be confusing to a user using these and expecting [x, y, z, ...] formatting common
-// with graphics.
-
-extern public int[N] get_call_id<let N: int>();
-extern public int[N] get_call_group_id<let N: int>();
-extern public int[N] get_call_group_thread_id<let N: int>();

--- a/slangpy/slang/callidarg.slang
+++ b/slangpy/slang/callidarg.slang
@@ -59,3 +59,12 @@ extension<T : __BuiltinIntegerType> VectorizeCallidArgTo<T, -1> {
 extension<T : __BuiltinIntegerType> VectorizeCallidArgTo<T, 1> {
     typealias VectorType = T;
 }
+
+// Functions provided for use in user's shaders
+// Note: In the returned arrays, the first component represents the right-most dimension,
+// the second component the next dimension to the left, and so on. This aligns with
+// behavior described at https://slangpy.shader-slang.org/en/latest/src/generators/generator_ids.html
+// but could be confusing to a user using these and expecting [x, y, z, ...] formatting.
+export public int[N] get_call_id<let N: int>();
+export public uint[N] get_call_group_id<let N: int>();
+export public uint[N] get_call_group_thread_id<let N: int>();

--- a/slangpy/slang/callidarg.slang
+++ b/slangpy/slang/callidarg.slang
@@ -61,10 +61,12 @@ extension<T : __BuiltinIntegerType> VectorizeCallidArgTo<T, 1> {
 }
 
 // Functions provided for use in user's shaders
-// Note: In the returned arrays, the first component represents the right-most dimension,
-// the second component the next dimension to the left, and so on. This aligns with
+// Note: In the returned arrays, the first component represents the dimension with the highest stride,
+// the second component the dimension with the next highest stride, and so on. This aligns with
 // behavior described at https://slangpy.shader-slang.org/en/latest/src/generators/generator_ids.html
-// but could be confusing to a user using these and expecting [x, y, z, ...] formatting.
-export public int[N] get_call_id<let N: int>();
-export public uint[N] get_call_group_id<let N: int>();
-export public uint[N] get_call_group_thread_id<let N: int>();
+// but could be confusing to a user using these and expecting [x, y, z, ...] formatting common
+// with graphics.
+
+extern public int[N] get_call_id<let N: int>();
+extern public int[N] get_call_group_id<let N: int>();
+extern public int[N] get_call_group_thread_id<let N: int>();

--- a/slangpy/slang/callshape.slang
+++ b/slangpy/slang/callshape.slang
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+implementing slangpy;
+
+// Those are link-time constants, this constant can be generated during run-time
+public extern static const int call_data_len;
+public extern static const int call_group_size;
+public extern static const int[call_data_len] call_group_strides;
+public extern static const int[call_data_len] call_group_shape_vector;
+
+static int[call_data_len] call_id;
+static int[call_data_len] call_group_id;
+static int[call_data_len] call_group_thread_id;
+
+// The reason we design the struct this way is because user will have no idea
+// about the value of the `call_data_len` when they are writing the code. Therefore,
+// if they try to use the `call_id`, `call_group_id`, or `call_group_thread_id` directly,
+// they will not know the type. So we use the interface to hide the details, so they will
+// query the length and access the shape data from the interface.
+internal enum CallShapeInfoFlag
+{
+    CallId,
+    CallGroupId,
+    CallGroupThreadId
+}
+
+public struct CallShapeInfo
+{
+    private int m_flag;
+
+    // We don't want to expose the constructor to the user, so we make it internal.
+    // External users should use the static methods to get the CallShapeInfo.
+    internal __init(int flag)
+    {
+        m_flag = flag;
+    }
+
+    public property int dimensionality
+    {
+        get { return call_data_len; }
+    }
+
+    public property int[call_data_len] shape
+    {
+        get
+        {
+            switch (m_flag)
+            {
+                case CallShapeInfoFlag::CallId:
+                    return call_id;
+                case CallShapeInfoFlag::CallGroupId:
+                    return call_group_id;
+                case CallShapeInfoFlag::CallGroupThreadId:
+                    return call_group_thread_id;
+                default:
+                    return {};
+            }
+        }
+    }
+
+    public static CallShapeInfo get_call_id()
+    {
+        CallShapeInfo call_shape_info = CallShapeInfo(CallShapeInfoFlag::CallId);
+        return call_shape_info;
+    }
+
+    public static CallShapeInfo get_call_group_id()
+    {
+        CallShapeInfo call_shape_info = CallShapeInfo(CallShapeInfoFlag::CallGroupId);
+        return call_shape_info;
+    }
+
+    public static CallShapeInfo get_call_group_thread_id()
+    {
+        CallShapeInfo call_shape_info = CallShapeInfo(CallShapeInfoFlag::CallGroupThreadId);
+        return call_shape_info;
+    }
+}
+
+// This function is used to initialize the thread local call shape info.
+// If the call shape is not aligned to the call group shape, we will return false,
+// Otherwise, it will return true.
+// TODO: The reason we have to use generic here is because grid_stride/grid_dim/call_dim
+// are the shader parameters and they cannot use link-time constant as array size because
+// of the reflection doesn't support that (https://github.com/shader-slang/slang/pull/7067).
+// Therefore we cannot use "const int[call_data_len]",  instead we have to use generic
+// as generic parameter is also a link-time constant here.
+public bool init_thread_local_call_shape_info<let N: int = call_data_len>(
+    int flat_call_group_thread_id,
+    int3 flat_call_group_id,
+    int3 flat_call_thread_id,
+    const int[N] grid_stride,
+    const int[N] grid_dim,
+    const int[N] call_dim)
+{
+    if (call_group_size != 1)
+    {
+        [unroll]
+        for (int i = 0; i < N; i++)
+        {
+            call_group_thread_id[i] = (flat_call_group_thread_id / call_group_strides[i]) % call_group_shape_vector[i];
+            call_group_id[i]        = (flat_call_group_id.x      / grid_stride[i])        % grid_dim[i];
+            call_id[i]              = call_group_id[i] * call_group_shape_vector[i] + call_group_thread_id[i];
+        }
+
+        // The Slang compiler seems to have trouble unrolling the for loop above when it
+        // contains the if statement in the below. Separate the if checks into a separate
+        // loop for now to better facilitate unrolling and improve perf.
+        [unroll]
+        for (int i = 0; i < N; i++)
+        {
+
+            // In the event that the call shape is not aligned to the call group shape,
+            // we use an aligned call shape to calculate the number of threads that we
+            // need. However, that means that some threads will fall outside the call shape
+            // and as a result will need to return early and be wasted.
+            if (call_id[i] >= call_dim[i])
+            {
+                return false;
+            }
+        }
+    }
+    else
+    {
+        [unroll]
+        for (int i = 0; i < N; i++)
+        {
+            call_id[i] = (flat_call_thread_id.x / grid_stride[i]) % grid_dim[i];
+            call_group_thread_id[i] = 0;
+            call_group_id[i] = call_id[i];
+        }
+    }
+    return true;
+}

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -39,6 +39,9 @@ public typealias Context3D = ContextND<3>;
 public typealias Context4D = ContextND<4>;
 public typealias Context5D = ContextND<5>;
 
+// call_data_len is a link-time constant declared in callshape.slang
+public typealias Context = ContextND<call_data_len>;
+
 public struct Unknown {}
 
 int _idx<let N : int>(int[N] index, int[N] stride) {

--- a/slangpy/slang/slangpy.slang
+++ b/slangpy/slang/slangpy.slang
@@ -10,3 +10,4 @@ __include "atomics.slang";
 __include "staticarray.slang";
 __include "tensor.slang";
 __include "gridarg.slang";
+__include "callshape.slang";

--- a/slangpy/slang/threadidarg.slang
+++ b/slangpy/slang/threadidarg.slang
@@ -2,6 +2,7 @@
 implementing slangpy;
 
 public struct ThreadIdArg {
+    int dummy;
 
     public void load(Context0D context, out uint3 value) {
         value = context.thread_id;

--- a/slangpy/tests/device/test_buffer.py
+++ b/slangpy/tests/device/test_buffer.py
@@ -147,6 +147,15 @@ def test_buffer(device_type: spy.DeviceType, type: str, size_MB: int):
         readback = read_buffer.to_numpy().view(np.uint32)
         assert np.all(data == readback)
 
+    # Set allocated resources to None and have the device wait
+    # to ensure resources are cleaned up. Running the tests on devices with lower
+    # amounts of available GPU memory can result in failures without clean up.
+    device_buffer = None
+    write_buffer = None
+    read_buffer = None
+    copy_kernel = None
+    device.wait_for_idle()
+
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_upload_buffer(device_type: spy.DeviceType):

--- a/slangpy/tests/slangpy_tests/generated_tests/read_slice_generic_error.slang
+++ b/slangpy/tests/slangpy_tests/generated_tests/read_slice_generic_error.slang
@@ -62,7 +62,7 @@ void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)
     int[1] call_id = {
         (dispatchThreadID.x / call_data._call_stride[0]) % call_data._call_dim[0],
     };
-    Context context = { dispatchThreadID, call_id };
+    Context1D context = { dispatchThreadID, call_id };
     vector<int,2> index;
     call_data.index.load(context.map(0),index);
     NDBuffer<float,2> texture;

--- a/slangpy/tests/slangpy_tests/nested_types_generics.slang
+++ b/slangpy/tests/slangpy_tests/nested_types_generics.slang
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import "slangpy";
 
-typealias Context = ContextND<1>;
-
 typealias _a__x = NDBuffer<float, 1>;
 typealias _a__y = NDBuffer<float, 1>;
 typealias _a__z = NDBuffer<float, 1>;
@@ -58,7 +56,7 @@ void compute_main(uint3 dispatchThreadID: SV_DispatchThreadID)
     int[1] call_id = {
         (dispatchThreadID.x / call_data._call_stride[0]) % call_data._call_dim[0],
     };
-    Context context = { dispatchThreadID, call_id };
+    Context1D context = { dispatchThreadID, call_id };
     float3 a;
     call_data.a.load(context, a);
     float3 b;

--- a/slangpy/tests/slangpy_tests/test_call_group_integrations.py
+++ b/slangpy/tests/slangpy_tests/test_call_group_integrations.py
@@ -1,0 +1,906 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Integration Tests for call_group_shape Functionality
+
+## Overview
+The call_group_shape feature allows organizing compute kernels into logical groups
+that can coordinate execution patterns. These tests verify that this functionality
+works with major SlangPy components.
+
+## Test Coverage
+
+### 1. Autodiff/Tensor Integration
+- **Purpose**: Validates call groups work with differentiable computation
+- **Features**: Forward/backward passes, gradient computation, tensor operations
+- **Tests**:
+  - Differentiable tensor addition with call group scaling
+  - Matrix multiplication with call group-based transformations
+  - Tensor aggregation operations across different call group configurations
+
+### 2. NDBuffer Integration
+- **Purpose**: Ensures call groups work with structured data buffers
+- **Features**: 2D/3D buffer processing, vector operations, data transformations
+- **Tests**:
+  - 2D buffer processing with call group coordinate mapping
+  - Vector operations (float3) with call group offsets
+  - 3D reduction operations using call group information
+
+### 3. Texture Integration
+- **Purpose**: Validates call groups with texture read/write operations
+- **Features**: 2D/3D textures, sampling, filtering, format handling
+- **Tests**:
+  - 2D texture sampling with call group-based UV offsets
+  - Single-channel texture reduction operations
+  - 3D texture processing with call group coordinate transformation
+
+### 4. Transform/Mapping Integration
+- **Purpose**: Tests call groups with SlangPy's transformation system
+- **Features**: Dimension mapping (.map()), coordinate transformations
+- **Tests**:
+  - Basic transform operations with call groups
+  - Complex dimension mapping with transposed inputs and call groups
+  - Large buffer performance testing
+  - Edge cases with misaligned buffer shapes
+
+## Technical Implementation Details
+
+### Call Group API Usage
+All tests properly utilize the call group intrinsic functions:
+- `get_call_group_id<N>()` - Gets the call group index in N dimensions
+- `get_call_group_thread_id<N>()` - Gets thread position within call group
+- `get_call_id<N>()` - Gets absolute thread position
+
+### Multi-Device Support
+All tests are parameterized to run on multiple backend devices:
+- D3D12 (DirectX 12)
+- Vulkan
+- Automatic device detection and fallback
+"""
+
+import numpy as np
+import pytest
+import slangpy as spy
+from slangpy import DeviceType, Device, TextureDesc, TextureUsage, Format, TextureType
+from slangpy.slangpy import Shape
+from slangpy.types import NDBuffer, Tensor
+from . import helpers
+import sys
+import os
+
+
+def get_tensor_test_module(device: Device):
+    """
+    Create a SlangPy module for tensor autodiff integration tests.
+
+    This module contains differentiable Slang functions that demonstrate
+    call group functionality working correctly with SlangPy's autodiff system.
+
+    Functions provided:
+    - tensor_add_with_call_groups: Differentiable tensor addition with call group scaling
+    - tensor_matrix_multiply_with_groups: Element-wise matrix operations with call group factors
+    - tensor_aggregation_with_groups: Tensor aggregation using call group coordinates
+
+    All functions are marked [Differentiable] and support both forward and backward passes.
+    Call group information is used to introduce spatial variation in computations.
+
+    Args:
+        device: SlangPy device to create the module on
+
+    Returns:
+        Compiled SlangPy module ready for testing
+    """
+    kernel_source = """
+import "slangpy";
+
+[Differentiable]
+float tensor_add_with_call_groups(
+    float a,
+    float b,
+    uint2 grid_cell
+) {
+    // Use call group functions in differentiable context
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+
+    // Simple operation that can be differentiated
+    // Scale the result by call group position for variety
+    float scale = 1.0f + 0.1f * float(call_group_id[0] + call_group_id[1]);
+    return (a + b) * scale;
+}
+
+[Differentiable]
+float tensor_matrix_multiply_with_groups(
+    float weight_element,
+    float x_element,
+    uint2 grid_cell
+) {
+    uint[2] call_group_id = get_call_group_id<2>();
+
+    // Simple operation with call group scaling
+    float scale = 1.0f + 0.05f * float(call_group_id[0] * call_group_id[1]);
+
+    return weight_element * x_element * scale;
+}
+
+float tensor_aggregation_with_groups(
+    float input_element,
+    uint2 grid_cell
+) {
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+
+    // Transform input based on call group information
+    float group_factor = 1.0f + 0.1f * float(call_group_id[0]);
+    float thread_factor = 1.0f + 0.05f * float(call_group_thread_id[1]);
+
+    return input_element * group_factor * thread_factor;
+}
+"""
+    return helpers.create_module(device, kernel_source)
+
+
+def get_ndbuffer_test_module(device: Device):
+    """
+    Create a SlangPy module for NDBuffer integration tests.
+
+    This module contains Slang functions that work with NDBuffer data structures
+    while utilizing call group functionality for coordinate-based processing.
+
+    Functions provided:
+    - ndbuffer_process_with_groups: 2D buffer processing with call group transformations
+    - ndbuffer_vector_ops_with_groups: Vector (float3) operations with call group offsets
+    - ndbuffer_reduce_with_groups: 3D reduction operations using call group coordinates
+
+    These functions demonstrate how call groups can be used to process structured
+    data with spatial awareness and coordinate-based transformations.
+
+    Args:
+        device: SlangPy device to create the module on
+
+    Returns:
+        Compiled SlangPy module ready for testing
+    """
+    kernel_source = """
+import "slangpy";
+
+float ndbuffer_process_with_groups(
+    float input,
+    out float output,
+    uint2 grid_cell
+) {
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+
+    // Apply a transformation based on call group position
+    float group_factor = 1.0f + 0.1f * float(call_group_id[0] * call_group_id[1]);
+    float thread_factor = 1.0f + 0.05f * float(call_group_thread_id[0] + call_group_thread_id[1]);
+
+    output = input * group_factor * thread_factor;
+
+    return input;
+}
+
+float3 ndbuffer_vector_ops_with_groups(
+    float3 vector_input,
+    uint grid_cell
+) {
+    uint[1] call_group_id = get_call_group_id<1>();
+    uint[1] call_group_thread_id = get_call_group_thread_id<1>();
+
+    // Transform vector based on call group information
+    float3 group_offset = float3(
+        float(call_group_id[0]) * 0.1f,
+        float(call_group_thread_id[0]) * 0.05f,
+        0.0f
+    );
+
+    return vector_input + group_offset;
+}
+
+int ndbuffer_reduce_with_groups(
+    int data_input,
+    uint3 grid_cell
+) {
+    uint[3] call_group_id = get_call_group_id<3>();
+    uint[3] call_group_thread_id = get_call_group_thread_id<3>();
+
+    // Compute a reduction-like operation using call group info
+    int sum = data_input;
+
+    // Add contribution from call group position
+    sum += int(call_group_id[0] + call_group_id[1] + call_group_id[2]);
+
+    return sum;
+}
+"""
+    return helpers.create_module(device, kernel_source)
+
+
+def get_texture_test_module(device: Device):
+    """
+    Create a SlangPy module for texture integration tests.
+
+    This module contains Slang functions that demonstrate call group functionality
+    working with various texture operations including sampling, filtering, and I/O.
+
+    Functions provided:
+    - texture_sample_with_groups: 2D texture sampling with call group-based UV offsets
+      Uses both input (Texture2D) and output (RWTexture2D) textures
+    - texture_reduce_with_groups: Single-channel texture reduction with call group patterns
+      Demonstrates neighborhood sampling based on call group thread positions
+    - texture_3d_with_groups: 3D texture sampling with call group coordinate transformation
+      Shows how call groups work in 3D texture space
+
+    These functions showcase proper texture usage patterns, format handling,
+    and coordinate transformations using call group information.
+
+    Technical Notes:
+    - Handles both multi-channel (RGBA) and single-channel (R) texture formats
+    - Uses proper texture usage flags (shader_resource vs unordered_access)
+    - Demonstrates SamplerState usage with call group offsets
+
+    Args:
+        device: SlangPy device to create the module on
+
+    Returns:
+        Compiled SlangPy module ready for testing
+    """
+    kernel_source = """
+import "slangpy";
+
+float4 texture_sample_with_groups(
+    Texture2D<float4> input_tex,
+    RWTexture2D<float4> output_tex,
+    uint2 grid_cell
+) {
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_id = get_call_id<2>();
+
+    // Sample from input texture with call group-based offset
+    float2 uv = float2(float(call_id[0]), float(call_id[1])) / float2(32.0f, 32.0f);
+    float2 group_offset = float2(float(call_group_id[0]), float(call_group_id[1])) * 0.01f;
+
+    SamplerState samp;
+    float4 sampled = input_tex.SampleLevel(samp, uv + group_offset, 0);
+
+    // Modulate color based on call group thread position
+    float thread_scale = 1.0f + 0.1f * float(call_group_thread_id[0] + call_group_thread_id[1]);
+    float4 result = sampled * thread_scale;
+
+    // Write to output texture
+    uint2 write_coord = uint2(call_id[0], call_id[1]);
+    output_tex[write_coord] = result;
+
+    return result;
+}
+
+float texture_reduce_with_groups(
+    Texture2D<vector<float,1>> input_tex,
+    uint2 grid_cell
+) {
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_id = get_call_id<2>();
+
+    // Sample multiple texels based on call group configuration
+    float sum = 0.0f;
+
+    for (int dx = -int(call_group_thread_id[0]); dx <= int(call_group_thread_id[0]); dx++) {
+        for (int dy = -int(call_group_thread_id[1]); dy <= int(call_group_thread_id[1]); dy++) {
+            int2 coord = int2(call_id[0] + dx, call_id[1] + dy);
+            if (coord.x >= 0 && coord.x < 32 && coord.y >= 0 && coord.y < 32) {
+                sum += input_tex.Load(int3(coord, 0)).r;  // Now we need .r since it's vector<float,1>
+            }
+        }
+    }
+
+    return sum / float((2 * call_group_thread_id[0] + 1) * (2 * call_group_thread_id[1] + 1));
+}
+
+float3 texture_3d_with_groups(
+    Texture3D<float4> tex3d,
+    uint3 grid_cell
+) {
+    uint[3] call_group_id = get_call_group_id<3>();
+    uint[3] call_group_thread_id = get_call_group_thread_id<3>();
+    int[3] call_id = get_call_id<3>();
+
+    // 3D texture sampling with call group-based coordinates
+    float3 uvw = float3(float(call_id[0]), float(call_id[1]), float(call_id[2])) / float3(16.0f, 16.0f, 16.0f);
+
+    // Offset based on call group
+    float3 group_offset = float3(float(call_group_id[0]), float(call_group_id[1]), float(call_group_id[2])) * 0.02f;
+
+    SamplerState samp;
+    float4 sampled = tex3d.SampleLevel(samp, uvw + group_offset, 0);
+
+    return sampled.rgb;
+}
+"""
+    return helpers.create_module(device, kernel_source)
+
+
+def get_transforms_test_module(device: Device):
+    """Create a module for transforms/mapping integration tests."""
+    path = os.path.join(os.path.dirname(__file__), "test_transforms.slang")
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            base_source = f.read()
+    else:
+        base_source = ""
+
+    additional_source = """
+import "slangpy";
+
+float transform_with_call_groups(
+    float input,
+    out float output,
+    uint2 grid_cell
+) {
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+
+    // Apply transformation that depends on call group structure
+    float group_transform = sin(float(call_group_id[0]) * 0.5f) + cos(float(call_group_id[1]) * 0.5f);
+    float thread_transform = float(call_group_thread_id[0] + call_group_thread_id[1]) * 0.1f;
+
+    output = input + group_transform + thread_transform;
+    return input;
+}
+
+float3 vector_transform_with_groups(
+    float3 vector_input,
+    uint2 grid_cell
+) {
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+
+    // Rotate vector based on call group position
+    float angle = float(call_group_id[0] + call_group_id[1]) * 0.1f;
+    float cos_a = cos(angle);
+    float sin_a = sin(angle);
+
+    // Simple 2D rotation in XY plane
+    float3 rotated = float3(
+        vector_input.x * cos_a - vector_input.y * sin_a,
+        vector_input.x * sin_a + vector_input.y * cos_a,
+        vector_input.z + float(call_group_thread_id[0]) * 0.05f
+    );
+
+    return rotated;
+}
+"""
+
+    full_source = base_source + "\n" + additional_source
+    return helpers.create_module(device, full_source)
+
+
+# Autodiff/Tensor Integration Tests
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_tensor_autodiff_with_call_groups(device_type: DeviceType):
+    """
+    Test autodiff tensor operations integrated with call group functionality.
+
+    This test validates that SlangPy's automatic differentiation system works
+    correctly when combined with call group features. It tests both forward
+    and backward passes through differentiable functions that use call group
+    intrinsics.
+
+    Test Flow:
+    1. Creates two random tensors with gradient tracking enabled
+    2. Applies a differentiable function that uses call group scaling
+    3. Performs forward pass and validates results
+    4. Executes backward pass with unit gradients
+    5. Verifies gradients were computed correctly
+
+    Call Group Usage:
+    - Uses (2, 3) call group shape on (4, 6) tensor data
+    - Function scales results based on call group coordinates
+    - Tests that autodiff works through call group intrinsic calls
+
+    Validation:
+    - Result shape matches input tensor shape
+    - All values are finite (no NaN/Inf from call group operations)
+    - Backward pass produces valid gradients for both input tensors
+
+    Args:
+        device_type: Backend device type (D3D12/Vulkan) for parameterized testing
+    """
+    if sys.platform == "darwin":
+        pytest.skip("Skipping on macOS due to slang-gfx resource clear API issue")
+
+    device = helpers.get_device(device_type)
+    module = get_tensor_test_module(device)
+
+    # Create test tensors with gradients
+    np.random.seed(42)
+    a_data = np.random.randn(4, 6).astype(np.float32)
+    b_data = np.random.randn(4, 6).astype(np.float32)
+
+    a = Tensor.from_numpy(device, a_data).with_grads()
+    b = Tensor.from_numpy(device, b_data).with_grads()
+
+    # Test with call group shape
+    call_shape = (4, 6)
+    call_group_shape = (2, 3)
+
+    func = module.tensor_add_with_call_groups.call_group_shape(Shape(call_group_shape))
+    result = func(a, b, spy.grid(call_shape), _result="numpy")
+
+    # Verify result shape and basic correctness
+    assert result.shape == call_shape
+    assert np.all(np.isfinite(result))
+
+    # Test backward pass
+    result_tensor = Tensor.from_numpy(device, result).with_grads()
+    result_tensor.grad_in = Tensor.zeros(device, result.shape, dtype="float")
+    result_tensor.grad_in.storage.copy_from_numpy(np.ones(result.shape, dtype=np.float32))
+
+    func.bwds(a, b, spy.grid(call_shape), result_tensor)
+
+    # Verify gradients were computed
+    assert a.grad_out is not None
+    assert b.grad_out is not None
+    assert np.all(np.isfinite(a.grad_out.to_numpy()))
+    assert np.all(np.isfinite(b.grad_out.to_numpy()))
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_tensor_matrix_ops_with_call_groups(device_type: DeviceType):
+    """Test tensor matrix operations with call groups."""
+    if sys.platform == "darwin":
+        pytest.skip("Skipping on macOS due to slang-gfx resource clear API issue")
+
+    device = helpers.get_device(device_type)
+    module = get_tensor_test_module(device)
+
+    # Create test tensors
+    weights_data = np.random.randn(4, 3).astype(np.float32)
+    x_data = np.random.randn(4, 3).astype(np.float32)
+
+    weights = Tensor.from_numpy(device, weights_data).with_grads()
+    x = Tensor.from_numpy(device, x_data).with_grads()
+
+    # Test with call group shape
+    call_shape = (4, 3)
+    call_group_shape = (2, 3)
+
+    func = module.tensor_matrix_multiply_with_groups.call_group_shape(Shape(call_group_shape))
+    result = func(weights, x, spy.grid(call_shape), _result="numpy")
+
+    # Verify result
+    assert result.shape == call_shape
+    assert np.all(np.isfinite(result))
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_tensor_aggregation_with_call_groups(device_type: DeviceType):
+    """Test tensor aggregation operations with call groups."""
+    device = helpers.get_device(device_type)
+    module = get_tensor_test_module(device)
+
+    # Test with different call group configurations
+    test_cases = [
+        ((8, 4), (2, 2)),
+        ((6, 6), (3, 2)),
+        ((10, 5), (5, 1)),
+    ]
+
+    for call_shape, call_group_shape in test_cases:
+        # Create test tensor matching call_shape
+        input_data = np.random.randn(*call_shape).astype(np.float32)
+        input_tensor = Tensor.from_numpy(device, input_data)
+
+        func = module.tensor_aggregation_with_groups.call_group_shape(Shape(call_group_shape))
+        result = func(input_tensor, spy.grid(call_shape), _result="numpy")
+
+        assert result.shape == call_shape
+        assert np.all(np.isfinite(result))
+
+
+# NDBuffer Integration Tests
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_ndbuffer_2d_with_call_groups(device_type: DeviceType):
+    """Test 2D NDBuffer processing with call groups."""
+    device = helpers.get_device(device_type)
+    module = get_ndbuffer_test_module(device)
+
+    # Create test NDBuffers
+    shape = (8, 6)
+    input_data = np.random.randn(*shape).astype(np.float32)
+
+    input_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+    output_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+
+    helpers.write_ndbuffer_from_numpy(input_buffer, input_data.flatten(), 1)
+
+    # Test with call group shape
+    call_group_shape = (2, 3)
+
+    func = module.ndbuffer_process_with_groups.call_group_shape(Shape(call_group_shape))
+    result = func(input_buffer, output_buffer, spy.grid(shape), _result="numpy")
+
+    # Verify results
+    assert result.shape == shape
+
+    # Read back output buffer and verify
+    output_data = helpers.read_ndbuffer_from_numpy(output_buffer).reshape(shape)
+    assert np.all(np.isfinite(output_data))
+    assert not np.array_equal(input_data, output_data)  # Should be modified
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_ndbuffer_vector_ops_with_call_groups(device_type: DeviceType):
+    """Test NDBuffer vector operations with call groups."""
+    device = helpers.get_device(device_type)
+    module = get_ndbuffer_test_module(device)
+
+    # Create test vector buffer
+    vector_count = 12
+    vector_data = np.random.randn(vector_count, 3).astype(np.float32)
+
+    vector_buffer = NDBuffer(device=device, shape=(vector_count,), dtype=spy.float3)
+    helpers.write_ndbuffer_from_numpy(vector_buffer, vector_data.flatten(), 3)
+
+    # Test with 1D call groups
+    call_shape = (vector_count,)
+    call_group_shape = (4,)
+
+    func = module.ndbuffer_vector_ops_with_groups.call_group_shape(Shape(call_group_shape))
+    result = func(vector_buffer, spy.grid(call_shape), _result="numpy")
+
+    # Verify results
+    assert result.shape == (vector_count, 3)
+    assert np.all(np.isfinite(result))
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_ndbuffer_3d_reduce_with_call_groups(device_type: DeviceType):
+    """Test 3D NDBuffer reduction with call groups."""
+    device = helpers.get_device(device_type)
+    module = get_ndbuffer_test_module(device)
+
+    # Create 3D test data
+    shape = (4, 4, 2)
+    data = np.random.randint(0, 10, shape).astype(np.int32)
+
+    data_buffer = NDBuffer(device=device, shape=shape, dtype=int)
+    helpers.write_ndbuffer_from_numpy(data_buffer, data.flatten(), 1)
+
+    # Test with 3D call groups
+    call_group_shape = (2, 2, 2)
+
+    func = module.ndbuffer_reduce_with_groups.call_group_shape(Shape(call_group_shape))
+    result = func(data_buffer, spy.grid(shape), _result="numpy")
+
+    # Verify results
+    assert result.shape == shape
+    assert np.all(result >= 0)  # Should be positive due to nature of reduction
+
+
+# Texture Integration Tests
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_texture_2d_with_call_groups(device_type: DeviceType):
+    """
+    Test 2D texture operations integrated with call group functionality.
+
+    This test validates that texture sampling, filtering, and writing operations
+    work correctly when combined with call group coordinate transformations.
+    It demonstrates proper texture usage patterns and format handling.
+
+    Test Flow:
+    1. Creates input texture (shader_resource) and output texture (unordered_access)
+    2. Fills input texture with random RGBA data
+    3. Applies texture sampling function with call group-based UV offsets
+    4. Validates results from both function return and output texture
+
+    Technical Details:
+    - Input: Texture2D<float4> with shader_resource usage
+    - Output: RWTexture2D<float4> with unordered_access usage
+    - Uses SamplerState for filtered texture access
+    - Call group coordinates influence UV offset calculations
+    - Thread positions within call groups scale output values
+
+    Call Group Usage:
+    - Uses (8, 8) call group shape on 32x32 texture
+    - UV offsets calculated from call group ID coordinates
+    - Thread scaling based on call group thread positions
+
+    Validation:
+    - Result shape matches texture dimensions plus channel count
+    - All sampled values are finite
+    - Output texture contains valid processed data
+
+    Args:
+        device_type: Backend device type (D3D12/Vulkan) for parameterized testing
+    """
+    if sys.platform == "darwin":
+        pytest.skip("Skipping on macOS due to slang-gfx texture API issues")
+
+    device = helpers.get_device(device_type)
+    module = get_texture_test_module(device)
+
+    # Create test textures
+    tex_size = 32
+    input_desc = TextureDesc()
+    input_desc.width = tex_size
+    input_desc.height = tex_size
+    input_desc.format = Format.rgba32_float
+    input_desc.type = TextureType.texture_2d
+    input_desc.usage = TextureUsage.shader_resource
+
+    output_desc = TextureDesc()
+    output_desc.width = tex_size
+    output_desc.height = tex_size
+    output_desc.format = Format.rgba32_float
+    output_desc.type = TextureType.texture_2d
+    output_desc.usage = TextureUsage.unordered_access
+
+    input_tex = device.create_texture(input_desc)
+    output_tex = device.create_texture(output_desc)
+
+    # Fill input texture with test data
+    test_data = np.random.rand(tex_size, tex_size, 4).astype(np.float32)
+    input_tex.copy_from_numpy(test_data)
+
+    # Test with call groups
+    call_shape = (tex_size, tex_size)
+    call_group_shape = (8, 8)
+
+    func = module.texture_sample_with_groups.call_group_shape(Shape(call_group_shape))
+    result = func(input_tex, output_tex, spy.grid(call_shape), _result="numpy")
+
+    # Verify results
+    assert result.shape == (tex_size, tex_size, 4)
+    assert np.all(np.isfinite(result))
+
+    # Read back output texture and verify
+    output_data = output_tex.to_numpy()
+    assert np.all(np.isfinite(output_data))
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_texture_reduce_with_call_groups(device_type: DeviceType):
+    """Test texture reduction operations with call groups."""
+    if sys.platform == "darwin":
+        pytest.skip("Skipping on macOS due to slang-gfx texture API issues")
+
+    device = helpers.get_device(device_type)
+    module = get_texture_test_module(device)
+
+    # Create test texture
+    tex_size = 32
+    desc = TextureDesc()
+    desc.width = tex_size
+    desc.height = tex_size
+    desc.format = Format.r32_float
+    desc.type = TextureType.texture_2d
+    desc.usage = TextureUsage.shader_resource
+
+    input_tex = device.create_texture(desc)
+
+    # Fill with test data
+    test_data = np.random.rand(tex_size, tex_size).astype(np.float32)  # 2D for single channel
+    input_tex.copy_from_numpy(test_data)
+
+    # Test with different call group sizes
+    test_cases = [
+        (2, 2),
+        (4, 4),
+        (8, 8),
+    ]
+
+    for call_group_shape in test_cases:
+        func = module.texture_reduce_with_groups.call_group_shape(Shape(call_group_shape))
+        result = func(input_tex, spy.grid((tex_size, tex_size)), _result="numpy")
+
+        assert result.shape == (tex_size, tex_size)
+        assert np.all(np.isfinite(result))
+        assert np.all(result >= 0)  # Should be positive due to averaging
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_texture_3d_with_call_groups(device_type: DeviceType):
+    """Test 3D texture operations with call groups."""
+    if sys.platform == "darwin":
+        pytest.skip("Skipping on macOS due to slang-gfx texture API issues")
+
+    device = helpers.get_device(device_type)
+    module = get_texture_test_module(device)
+
+    # Create 3D test texture
+    tex_size = 16  # Smaller size for 3D to avoid memory issues
+    desc = TextureDesc()
+    desc.width = tex_size
+    desc.height = tex_size
+    desc.depth = tex_size
+    desc.format = Format.rgba32_float
+    desc.type = TextureType.texture_3d
+    desc.usage = TextureUsage.shader_resource
+
+    input_tex = device.create_texture(desc)
+
+    # Fill with test data (3D texture needs 4D numpy array: depth, height, width, channels)
+    test_data = np.random.rand(tex_size, tex_size, tex_size, 4).astype(np.float32)
+    input_tex.copy_from_numpy(test_data)
+
+    # Test with 3D call groups
+    call_shape = (tex_size, tex_size, tex_size)
+    call_group_shape = (4, 4, 4)
+
+    func = module.texture_3d_with_groups.call_group_shape(Shape(call_group_shape))
+    result = func(input_tex, spy.grid(call_shape), _result="numpy")
+
+    # Verify results
+    assert result.shape == (tex_size, tex_size, tex_size, 3)  # Returns float3 (rgb)
+    assert np.all(np.isfinite(result))
+
+
+# Transform/Mapping Integration Tests
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_transforms_with_call_groups(device_type: DeviceType):
+    """Test transform operations with call groups."""
+    device = helpers.get_device(device_type)
+    module = get_transforms_test_module(device)
+
+    # Create test data
+    shape = (6, 8)
+    input_data = np.random.randn(*shape).astype(np.float32)
+
+    input_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+    output_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+
+    helpers.write_ndbuffer_from_numpy(input_buffer, input_data.flatten(), 1)
+
+    # Test transform with call groups
+    call_group_shape = (3, 4)
+
+    func = module.transform_with_call_groups.call_group_shape(Shape(call_group_shape))
+    result = func(input_buffer, output_buffer, spy.grid(shape), _result="numpy")
+
+    # Verify results
+    assert result.shape == shape
+    assert np.all(np.isfinite(result))
+
+    # Verify output buffer was modified
+    output_data = helpers.read_ndbuffer_from_numpy(output_buffer).reshape(shape)
+    assert not np.array_equal(input_data, output_data)
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_transforms_with_mapping_and_call_groups(device_type: DeviceType):
+    """
+    Test complex transform operations combining .map() with call groups.
+
+    This test validates the most complex integration scenario: dimension mapping
+    (.map()) combined with call group functionality. It demonstrates proper
+    handling of coordinate transformations when input dimensions are transposed.
+
+    Test Flow:
+    1. Creates vector data in (4, 6, 3) shape (height, width, channels)
+    2. Sets up call group shape (2, 3)
+    3. Applies .map((1, 0)) to transpose input dimensions
+    4. Adjusts grid shape to match transposed coordinates
+    5. Validates results match expected transposed shape
+
+    Technical Challenges Solved:
+    - Shape mismatch resolution between mapped inputs and grid coordinates
+    - Proper grid shape calculation for transposed dimensions
+    - Call group coordinate alignment with mapped data layout
+
+    Key Implementation Detail:
+    When using .map((1, 0)) to transpose from (4, 6) to (6, 4):
+    - Input buffer: (4, 6, 3) -> mapped as (6, 4, 3)
+    - Grid shape: (4, 6) -> adjusted to (6, 4)
+    - Call groups work correctly with transposed coordinates
+
+    Call Group Usage:
+    - Uses (2, 3) call group shape
+    - Works with transposed coordinate system
+    - Vector transformations include call group-based rotations
+
+    Validation:
+    - Result shape matches expected transposed dimensions
+    - All transformation values are finite
+    - Demonstrates mapping/call group interoperability
+
+    Args:
+        device_type: Backend device type (D3D12/Vulkan) for parameterized testing
+    """
+    device = helpers.get_device(device_type)
+    module = get_transforms_test_module(device)
+
+    # Create test vector data
+    shape = (4, 6)
+    vector_data = np.random.randn(*shape, 3).astype(np.float32)
+
+    vector_buffer = NDBuffer(device=device, shape=shape, dtype=spy.float3)
+    helpers.write_ndbuffer_from_numpy(vector_buffer, vector_data.flatten(), 3)
+
+    # Test with both mapping and call groups
+    call_group_shape = (2, 3)
+
+    # Use .map() to transpose dimensions and call groups
+    func = module.vector_transform_with_groups.call_group_shape(Shape(call_group_shape))
+    mapped_func = func.map((1, 0))  # Transpose the input
+
+    # When mapping input dimensions, we need to transpose the grid shape too
+    transposed_shape = (shape[1], shape[0])  # (6, 4) instead of (4, 6)
+    result = mapped_func(vector_buffer, spy.grid(transposed_shape), _result="numpy")
+
+    # Result should have transposed shape
+    expected_shape = (shape[1], shape[0], 3)
+    assert result.shape == expected_shape
+    assert np.all(np.isfinite(result))
+
+
+# Edge Cases and Stress Tests
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_groups_with_large_buffers(device_type: DeviceType):
+    """Test call groups with larger buffer sizes."""
+    device = helpers.get_device(device_type)
+    module = get_ndbuffer_test_module(device)
+
+    # Create larger test case
+    shape = (64, 32)
+    input_data = np.random.randn(*shape).astype(np.float32)
+
+    input_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+    output_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+
+    helpers.write_ndbuffer_from_numpy(input_buffer, input_data.flatten(), 1)
+
+    # Test with various call group sizes
+    test_cases = [
+        (8, 8),
+        (16, 4),
+        (4, 16),
+        (32, 2),
+    ]
+
+    for call_group_shape in test_cases:
+        func = module.ndbuffer_process_with_groups.call_group_shape(Shape(call_group_shape))
+        result = func(input_buffer, output_buffer, spy.grid(shape), _result="numpy")
+
+        assert result.shape == shape
+        assert np.all(np.isfinite(result))
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_groups_misaligned_shapes(device_type: DeviceType):
+    """Test call groups with misaligned shapes (shape not divisible by group size)."""
+    device = helpers.get_device(device_type)
+    module = get_ndbuffer_test_module(device)
+
+    # Create misaligned test case
+    shape = (7, 11)  # Prime numbers to ensure misalignment
+    input_data = np.random.randn(*shape).astype(np.float32)
+
+    input_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+    output_buffer = NDBuffer(device=device, shape=shape, dtype=float)
+
+    helpers.write_ndbuffer_from_numpy(input_buffer, input_data.flatten(), 1)
+
+    # Test with call group size that doesn't divide evenly
+    call_group_shape = (4, 3)
+
+    func = module.ndbuffer_process_with_groups.call_group_shape(Shape(call_group_shape))
+    result = func(input_buffer, output_buffer, spy.grid(shape), _result="numpy")
+
+    assert result.shape == shape
+    assert np.all(np.isfinite(result))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/slangpy_tests/test_call_group_integrations.py
+++ b/slangpy/tests/slangpy_tests/test_call_group_integrations.py
@@ -99,8 +99,8 @@ float tensor_add_with_call_groups(
     uint2 grid_cell
 ) {
     // Use call group functions in differentiable context
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
 
     // Simple operation that can be differentiated
     // Scale the result by call group position for variety
@@ -114,7 +114,7 @@ float tensor_matrix_multiply_with_groups(
     float x_element,
     uint2 grid_cell
 ) {
-    uint[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
 
     // Simple operation with call group scaling
     float scale = 1.0f + 0.05f * float(call_group_id[0] * call_group_id[1]);
@@ -126,8 +126,8 @@ float tensor_aggregation_with_groups(
     float input_element,
     uint2 grid_cell
 ) {
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
 
     // Transform input based on call group information
     float group_factor = 1.0f + 0.1f * float(call_group_id[0]);
@@ -168,8 +168,8 @@ float ndbuffer_process_with_groups(
     out float output,
     uint2 grid_cell
 ) {
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
 
     // Apply a transformation based on call group position
     float group_factor = 1.0f + 0.1f * float(call_group_id[0] * call_group_id[1]);
@@ -184,8 +184,8 @@ float3 ndbuffer_vector_ops_with_groups(
     float3 vector_input,
     uint grid_cell
 ) {
-    uint[1] call_group_id = get_call_group_id<1>();
-    uint[1] call_group_thread_id = get_call_group_thread_id<1>();
+    int[1] call_group_id = get_call_group_id<1>();
+    int[1] call_group_thread_id = get_call_group_thread_id<1>();
 
     // Transform vector based on call group information
     float3 group_offset = float3(
@@ -201,8 +201,8 @@ int ndbuffer_reduce_with_groups(
     int data_input,
     uint3 grid_cell
 ) {
-    uint[3] call_group_id = get_call_group_id<3>();
-    uint[3] call_group_thread_id = get_call_group_thread_id<3>();
+    int[3] call_group_id = get_call_group_id<3>();
+    int[3] call_group_thread_id = get_call_group_thread_id<3>();
 
     // Compute a reduction-like operation using call group info
     int sum = data_input;
@@ -253,8 +253,8 @@ float4 texture_sample_with_groups(
     RWTexture2D<float4> output_tex,
     uint2 grid_cell
 ) {
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
     int[2] call_id = get_call_id<2>();
 
     // Sample from input texture with call group-based offset
@@ -279,8 +279,8 @@ float texture_reduce_with_groups(
     Texture2D<vector<float,1>> input_tex,
     uint2 grid_cell
 ) {
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
     int[2] call_id = get_call_id<2>();
 
     // Sample multiple texels based on call group configuration
@@ -302,8 +302,8 @@ float3 texture_3d_with_groups(
     Texture3D<float4> tex3d,
     uint3 grid_cell
 ) {
-    uint[3] call_group_id = get_call_group_id<3>();
-    uint[3] call_group_thread_id = get_call_group_thread_id<3>();
+    int[3] call_group_id = get_call_group_id<3>();
+    int[3] call_group_thread_id = get_call_group_thread_id<3>();
     int[3] call_id = get_call_id<3>();
 
     // 3D texture sampling with call group-based coordinates
@@ -338,8 +338,8 @@ float transform_with_call_groups(
     out float output,
     uint2 grid_cell
 ) {
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
 
     // Apply transformation that depends on call group structure
     float group_transform = sin(float(call_group_id[0]) * 0.5f) + cos(float(call_group_id[1]) * 0.5f);
@@ -353,8 +353,8 @@ float3 vector_transform_with_groups(
     float3 vector_input,
     uint2 grid_cell
 ) {
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
 
     // Rotate vector based on call group position
     float angle = float(call_group_id[0] + call_group_id[1]) * 0.1f;

--- a/slangpy/tests/slangpy_tests/test_call_groups.py
+++ b/slangpy/tests/slangpy_tests/test_call_groups.py
@@ -58,8 +58,8 @@ import "slangpy";
 float test_functions_exist(uint2 grid_cell) {
     // Test global getter functions with explicit types
     int[2] call_id_result = get_call_id<2>();
-    uint[2] call_group_id_result = get_call_group_id<2>();
-    uint[2] call_group_thread_id_result = get_call_group_thread_id<2>();
+    int[2] call_group_id_result = get_call_group_id<2>();
+    int[2] call_group_thread_id_result = get_call_group_thread_id<2>();
 
     // Return success - we just want to verify compilation works
     return 1.0f;
@@ -85,8 +85,8 @@ def test_1d_call_groups_with_validation(device_type: DeviceType):
 import "slangpy";
 
 uint test_1d_groups(uint grid_cell) {
-    uint[1] call_group_id = get_call_group_id<1>();
-    uint[1] call_group_thread_id = get_call_group_thread_id<1>();
+    int[1] call_group_id = get_call_group_id<1>();
+    int[1] call_group_thread_id = get_call_group_thread_id<1>();
 
     // Return packed result: high 16 bits = group_id, low 16 bits = thread_id
     return (call_group_id[0] << 16) | call_group_thread_id[0];
@@ -148,8 +148,8 @@ import "slangpy";
 
 uint test_call_group_math_2d(uint2 grid_cell) {
     int[2] call_id = get_call_id<2>();
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
 
     // Pack the results:
     // Bits 24-31: call_group_id[0] (Y)
@@ -255,8 +255,8 @@ import "slangpy";
 uint test_5d_basic(uint[5] grid_cell) {
     // Get call group values
     int[5] call_id = get_call_id<5>();
-    uint[5] call_group_id = get_call_group_id<5>();
-    uint[5] call_group_thread_id = get_call_group_thread_id<5>();
+    int[5] call_group_id = get_call_group_id<5>();
+    int[5] call_group_thread_id = get_call_group_thread_id<5>();
 
     // Pack some of the results to validate they're not all zeros
     // Pack dimensions 2, 3, 4 (which have non-trivial group shapes)
@@ -311,8 +311,8 @@ import "slangpy";
 
 uint test_edge_case_basic(uint2 grid_cell) {
     // Get call group functionality and pack results
-    uint[2] call_group_id = get_call_group_id<2>();
-    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+    int[2] call_group_id = get_call_group_id<2>();
+    int[2] call_group_thread_id = get_call_group_thread_id<2>();
 
     // Pack results to validate they're meaningful
     return (call_group_id[0] << 24) | (call_group_id[1] << 16) |
@@ -394,8 +394,8 @@ import "slangpy";
 float test_call_group_math({param_type} grid_pos) {{
     // Just test that the functions can be called without error
     int[{dimension}] call_id = get_call_id<{dimension}>();
-    uint[{dimension}] call_group_id = get_call_group_id<{dimension}>();
-    uint[{dimension}] call_group_thread_id = get_call_group_thread_id<{dimension}>();
+    int[{dimension}] call_group_id = get_call_group_id<{dimension}>();
+    int[{dimension}] call_group_thread_id = get_call_group_thread_id<{dimension}>();
 
     // Return a simple validation that functions executed
     return 1.0f;
@@ -443,8 +443,8 @@ import "slangpy";
 float test_edge_case({param_type} grid_pos) {{
     // Test that edge cases don't crash
     int[{dimension}] call_id = get_call_id<{dimension}>();
-    uint[{dimension}] call_group_id = get_call_group_id<{dimension}>();
-    uint[{dimension}] call_group_thread_id = get_call_group_thread_id<{dimension}>();
+    int[{dimension}] call_group_id = get_call_group_id<{dimension}>();
+    int[{dimension}] call_group_thread_id = get_call_group_thread_id<{dimension}>();
 
     return 1.0f;
 }}

--- a/slangpy/tests/slangpy_tests/test_call_groups.py
+++ b/slangpy/tests/slangpy_tests/test_call_groups.py
@@ -1,0 +1,785 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Tests for call group functionality in SlangPy.
+
+This module tests:
+1. Call group shapes for dimensions 1-5
+2. Shader functions: get_call_id(), get_call_group_id(), get_call_group_thread_id()
+3. Edge cases: misaligned shapes, shapes smaller than groups, etc.
+4. Function existence and specific validation tests
+"""
+
+import numpy as np
+import pytest
+import slangpy as spy
+from slangpy import DeviceType
+from slangpy.slangpy import Shape
+from slangpy.types.buffer import NDBuffer
+from . import helpers
+
+
+# Test data for different dimensions and call group configurations
+CALL_GROUP_TEST_CASES = [
+    # (dimension, call_shape, call_group_shape, description)
+    (1, (8,), (2,), "1D basic aligned"),
+    (1, (9,), (2,), "1D misaligned"),
+    (1, (1,), (4,), "1D smaller than group"),
+    (2, (8, 6), (2, 3), "2D basic aligned"),
+    (2, (9, 7), (2, 3), "2D misaligned"),
+    (2, (1, 1), (4, 4), "2D smaller than group"),
+    (3, (8, 6, 4), (2, 3, 2), "3D basic aligned"),
+    (3, (9, 7, 5), (2, 3, 2), "3D misaligned"),
+    (4, (8, 6, 4, 4), (2, 3, 2, 2), "4D basic aligned"),
+    (4, (9, 7, 5, 3), (2, 3, 2, 2), "4D misaligned"),
+    (5, (8, 6, 4, 4, 2), (2, 3, 2, 2, 2), "5D basic aligned"),
+    (5, (9, 7, 5, 3, 3), (2, 3, 2, 2, 2), "5D misaligned"),
+]
+
+EDGE_CASE_TEST_CASES = [
+    # (dimension, call_shape, call_group_shape, description)
+    (1, (32,), (1,), "1D linear dispatch (group size 1)"),
+    (2, (32, 32), (32, 1), "2D linear first dimension"),
+    (2, (32, 32), (1, 32), "2D linear second dimension"),
+    (3, (100, 4, 2), (32, 2, 2), "3D with varying dimensions"),
+    (2, (3, 5), (10, 10), "2D call smaller than group in all dims"),
+    (3, (8, 4, 12), (4, 8, 6), "3D call smaller in some dims"),
+]
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_functions_exist(device_type: DeviceType):
+    """Test that all call group functions can be called without error."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source = """
+import "slangpy";
+
+float test_functions_exist(uint2 grid_cell) {
+    // Test global getter functions with explicit types
+    int[2] call_id_result = get_call_id<2>();
+    uint[2] call_group_id_result = get_call_group_id<2>();
+    uint[2] call_group_thread_id_result = get_call_group_thread_id<2>();
+
+    // Return success - we just want to verify compilation works
+    return 1.0f;
+}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Test that the function can be called without error
+    result = module.test_functions_exist(spy.grid((4, 6)), _result="numpy")
+
+    # Verify all results are 1.0 (success)
+    assert np.all(result == 1.0)
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_1d_call_groups_with_validation(device_type: DeviceType):
+    """Test 1D call groups with specific mathematical validation."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source = """
+import "slangpy";
+
+uint test_1d_groups(uint grid_cell) {
+    uint[1] call_group_id = get_call_group_id<1>();
+    uint[1] call_group_thread_id = get_call_group_thread_id<1>();
+
+    // Return packed result: high 16 bits = group_id, low 16 bits = thread_id
+    return (call_group_id[0] << 16) | call_group_thread_id[0];
+}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Test with call shape (8,) and call group shape (2,)
+    call_shape = (8,)
+    call_group_shape = (2,)
+
+    result = module.test_1d_groups.call_group_shape(Shape(call_group_shape))(
+        spy.grid(call_shape), _result="numpy"
+    )
+
+    # Extract group IDs and thread IDs
+    group_ids = (result >> 16) & 0xFFFF
+    thread_ids = result & 0xFFFF
+
+    # Validate dimensions
+    assert result.shape == call_shape
+
+    # Basic validation: group IDs should be in range [0, ceil(8/2)-1] = [0, 3]
+    assert np.all(group_ids >= 0) and np.all(group_ids < 4)
+
+    # Thread IDs should be in range [0, 1] (group size is 2)
+    assert np.all(thread_ids >= 0) and np.all(thread_ids < 2)
+
+    # Validate that each call group has exactly one thread with thread_id [0]
+    expected_groups = 4  # ceil(8/2) = 4 groups
+    for group_id in range(expected_groups):
+        zero_count = np.sum((group_ids == group_id) & (thread_ids == 0))
+        assert (
+            zero_count == 1
+        ), f"Call group {group_id} should have exactly 1 thread with thread_id [0], found {zero_count}"
+
+    # Ensure we have a variety of values, not all zeros
+    assert np.max(group_ids) > 0, "Expected some non-zero group IDs"
+    assert np.max(thread_ids) > 0, "Expected some non-zero thread IDs"
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_math_2d_validation(device_type: DeviceType):
+    """
+    Test call group builtin functions and their mathematical relationships for 2D.
+
+    This test validates:
+    1. get_call_group_id() returns valid group indices
+    2. get_call_group_thread_id() returns valid thread indices within groups
+    3. Mathematical consistency between call_id, call_group_id, and call_group_thread_id
+    4. Proper bounds checking for different call group configurations
+    """
+
+    device = helpers.get_device(device_type)
+
+    kernel_source = """
+import "slangpy";
+
+uint test_call_group_math_2d(uint2 grid_cell) {
+    int[2] call_id = get_call_id<2>();
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+
+    // Pack the results:
+    // Bits 24-31: call_group_id[0] (Y)
+    // Bits 16-23: call_group_id[1] (X)
+    // Bits 8-15: call_group_thread_id[0] (Y)
+    // Bits 0-7: call_group_thread_id[1] (X)
+    return (call_group_id[0] << 24) | (call_group_id[1] << 16) |
+           (call_group_thread_id[0] << 8) | call_group_thread_id[1];
+}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Test with multiple configurations
+    test_cases = [
+        ((4, 4), (2, 2)),  # Perfect alignment
+        ((6, 4), (2, 2)),  # Also perfectly aligned
+        ((8, 6), (2, 3)),  # Different group aspect ratio
+        ((5, 7), (2, 2)),  # Unaligned case - will be padded to (6, 8)
+    ]
+
+    for call_shape, group_shape in test_cases:
+        result = module.test_call_group_math_2d.call_group_shape(Shape(group_shape))(
+            spy.grid(call_shape), _result="numpy"
+        )
+
+        # Extract packed values
+        call_group_id_y = (result >> 24) & 0xFF
+        call_group_id_x = (result >> 16) & 0xFF
+        call_group_thread_id_y = (result >> 8) & 0xFF
+        call_group_thread_id_x = result & 0xFF
+
+        # Calculate expected grid dimensions (aligned up to group boundaries)
+        import math
+
+        grid_shape_y = math.ceil(call_shape[0] / group_shape[0])
+        grid_shape_x = math.ceil(call_shape[1] / group_shape[1])
+
+        # Validate bounds for actual call shape (not padded)
+        for y in range(call_shape[0]):
+            for x in range(call_shape[1]):
+                # Validate call_group_id bounds
+                assert (
+                    0 <= call_group_id_y[y, x] < grid_shape_y
+                ), f"call_group_id[0] out of bounds at [{y},{x}]: {call_group_id_y[y, x]} >= {grid_shape_y}"
+                assert (
+                    0 <= call_group_id_x[y, x] < grid_shape_x
+                ), f"call_group_id[1] out of bounds at [{y},{x}]: {call_group_id_x[y, x]} >= {grid_shape_x}"
+
+                # Validate call_group_thread_id bounds
+                assert (
+                    0 <= call_group_thread_id_y[y, x] < group_shape[0]
+                ), f"call_group_thread_id[0] out of bounds at [{y},{x}]: {call_group_thread_id_y[y, x]} >= {group_shape[0]}"
+                assert (
+                    0 <= call_group_thread_id_x[y, x] < group_shape[1]
+                ), f"call_group_thread_id[1] out of bounds at [{y},{x}]: {call_group_thread_id_x[y, x]} >= {group_shape[1]}"
+
+        # Validate that each call group has exactly one thread with thread_id [0,0]
+        for group_y in range(grid_shape_y):
+            for group_x in range(grid_shape_x):
+                # Count threads with [0,0] thread_id in this call group
+                zero_zero_count = 0
+                for y in range(call_shape[0]):
+                    for x in range(call_shape[1]):
+                        if (
+                            call_group_id_y[y, x] == group_y
+                            and call_group_id_x[y, x] == group_x
+                            and call_group_thread_id_y[y, x] == 0
+                            and call_group_thread_id_x[y, x] == 0
+                        ):
+                            zero_zero_count += 1
+
+                # Each call group should have exactly one [0,0] thread (if the group has any threads)
+                group_has_threads = False
+                for y in range(call_shape[0]):
+                    for x in range(call_shape[1]):
+                        if call_group_id_y[y, x] == group_y and call_group_id_x[y, x] == group_x:
+                            group_has_threads = True
+                            break
+                    if group_has_threads:
+                        break
+
+                if group_has_threads:
+                    assert (
+                        zero_zero_count == 1
+                    ), f"Call group [{group_y},{group_x}] should have exactly 1 thread with thread_id [0,0], found {zero_zero_count}"
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_math_5d_validation(device_type: DeviceType):
+    """
+    Test that SlangPy's call group calculations work for 5D (simplified test).
+
+    This test validates that 5D call group functions can be called without errors
+    and return reasonable values, rather than doing deep mathematical validation.
+    """
+
+    device = helpers.get_device(device_type)
+
+    kernel_source = """
+import "slangpy";
+
+uint test_5d_basic(uint[5] grid_cell) {
+    // Get call group values
+    int[5] call_id = get_call_id<5>();
+    uint[5] call_group_id = get_call_group_id<5>();
+    uint[5] call_group_thread_id = get_call_group_thread_id<5>();
+
+    // Pack some of the results to validate they're not all zeros
+    // Pack dimensions 2, 3, 4 (which have non-trivial group shapes)
+    return (call_group_id[2] << 16) | (call_group_thread_id[3] << 8) | call_group_thread_id[4];
+}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Test with simple 5D configuration
+    call_shape = (3, 2, 2, 2, 2)
+    call_group_shape = (1, 1, 2, 2, 2)
+
+    # Create output buffer
+    result_buffer = NDBuffer(device=device, shape=call_shape, dtype=int)
+
+    # Call with call group shape
+    module.test_5d_basic.call_group_shape(Shape(call_group_shape))(
+        spy.grid(call_shape), _result=result_buffer
+    )
+
+    # Validate that we get meaningful values, not all zeros
+    results = result_buffer.to_numpy()
+    assert np.any(results > 0), "Expected some non-zero call group values in 5D test"
+
+    # Extract components for basic validation
+    call_group_id_2 = (results >> 16) & 0xFFFF
+    call_group_thread_id_3 = (results >> 8) & 0xFF
+    call_group_thread_id_4 = results & 0xFF
+
+    # Basic bounds checking
+    import math
+
+    expected_grid_2 = math.ceil(call_shape[2] / call_group_shape[2])  # ceil(2/2) = 1
+    assert np.all(call_group_id_2 < expected_grid_2), "call_group_id[2] out of bounds"
+    assert np.all(
+        call_group_thread_id_3 < call_group_shape[3]
+    ), "call_group_thread_id[3] out of bounds"
+    assert np.all(
+        call_group_thread_id_4 < call_group_shape[4]
+    ), "call_group_thread_id[4] out of bounds"
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_math_edge_cases(device_type: DeviceType):
+    """Test edge cases and boundary conditions."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source = """
+import "slangpy";
+
+uint test_edge_case_basic(uint2 grid_cell) {
+    // Get call group functionality and pack results
+    uint[2] call_group_id = get_call_group_id<2>();
+    uint[2] call_group_thread_id = get_call_group_thread_id<2>();
+
+    // Pack results to validate they're meaningful
+    return (call_group_id[0] << 24) | (call_group_id[1] << 16) |
+           (call_group_thread_id[0] << 8) | call_group_thread_id[1];
+}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Edge case 1: 1x1 groups (should work without error)
+    call_shape = (3, 3)
+
+    # With 1x1 groups
+    result_with_groups = module.test_edge_case_basic.call_group_shape(Shape((1, 1)))(
+        spy.grid(call_shape), _result="numpy"
+    )
+
+    # Validate 1x1 groups: each thread should be its own group
+    group_id_y = (result_with_groups >> 24) & 0xFF
+    group_id_x = (result_with_groups >> 16) & 0xFF
+    thread_id_y = (result_with_groups >> 8) & 0xFF
+    thread_id_x = result_with_groups & 0xFF
+
+    # With 1x1 groups, call_group_id should match position and thread_id should be 0
+    for y in range(call_shape[0]):
+        for x in range(call_shape[1]):
+            assert (
+                group_id_y[y, x] == y
+            ), f"Expected group_id_y={y} at [{y},{x}], got {group_id_y[y, x]}"
+            assert (
+                group_id_x[y, x] == x
+            ), f"Expected group_id_x={x} at [{y},{x}], got {group_id_x[y, x]}"
+            assert (
+                thread_id_y[y, x] == 0
+            ), f"Expected thread_id_y=0 at [{y},{x}], got {thread_id_y[y, x]}"
+            assert (
+                thread_id_x[y, x] == 0
+            ), f"Expected thread_id_x=0 at [{y},{x}], got {thread_id_x[y, x]}"
+
+    # Edge case 2: Group larger than call shape
+    large_group_result = module.test_edge_case_basic.call_group_shape(Shape((4, 4)))(
+        spy.grid((2, 2)), _result="numpy"
+    )
+
+    # With large groups, all threads should be in group [0,0]
+    large_group_id_y = (large_group_result >> 24) & 0xFF
+    large_group_id_x = (large_group_result >> 16) & 0xFF
+    large_thread_id_y = (large_group_result >> 8) & 0xFF
+    large_thread_id_x = large_group_result & 0xFF
+
+    assert np.all(large_group_id_y == 0), "All threads should be in group_id_y=0 for large groups"
+    assert np.all(large_group_id_x == 0), "All threads should be in group_id_x=0 for large groups"
+    assert np.all(large_thread_id_y < 2), "thread_id_y should be < call_shape[0]"
+    assert np.all(large_thread_id_x < 2), "thread_id_x should be < call_shape[1]"
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("dimension,call_shape,call_group_shape,description", CALL_GROUP_TEST_CASES)
+def test_call_group_dimensions(
+    device_type: DeviceType,
+    dimension: int,
+    call_shape: tuple,
+    call_group_shape: tuple,
+    description: str,
+):
+    """Test call groups across different dimensions and configurations."""
+
+    device = helpers.get_device(device_type)
+
+    # Create a simpler test that just validates the math works
+    # For 5D+, use array types like uint[5], uint[6], etc.
+    if dimension <= 4:
+        param_type = {1: "uint", 2: "uint2", 3: "uint3", 4: "uint4"}[dimension]
+    else:
+        param_type = f"uint[{dimension}]"
+    kernel_source = f"""
+import "slangpy";
+
+float test_call_group_math({param_type} grid_pos) {{
+    // Just test that the functions can be called without error
+    int[{dimension}] call_id = get_call_id<{dimension}>();
+    uint[{dimension}] call_group_id = get_call_group_id<{dimension}>();
+    uint[{dimension}] call_group_thread_id = get_call_group_thread_id<{dimension}>();
+
+    // Return a simple validation that functions executed
+    return 1.0f;
+}}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Create output buffer
+    result_buffer = NDBuffer(device=device, shape=call_shape, dtype=float)
+
+    # Call with call group shape
+    module.test_call_group_math.call_group_shape(Shape(call_group_shape))(
+        spy.grid(call_shape), _result=result_buffer
+    )
+
+    # Validate that all calls completed successfully (all should be 1.0)
+    results = result_buffer.to_numpy()
+    assert np.all(
+        results == 1.0
+    ), f"Failed for {description}: {call_shape} with groups {call_group_shape}"
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("dimension,call_shape,call_group_shape,description", EDGE_CASE_TEST_CASES)
+def test_call_group_edge_cases(
+    device_type: DeviceType,
+    dimension: int,
+    call_shape: tuple,
+    call_group_shape: tuple,
+    description: str,
+):
+    """Test edge cases for call group functionality."""
+
+    device = helpers.get_device(device_type)
+
+    # For 5D+, use array types like uint[5], uint[6], etc.
+    if dimension <= 4:
+        param_type = {1: "uint", 2: "uint2", 3: "uint3", 4: "uint4"}[dimension]
+    else:
+        param_type = f"uint[{dimension}]"
+    kernel_source = f"""
+import "slangpy";
+
+float test_edge_case({param_type} grid_pos) {{
+    // Test that edge cases don't crash
+    int[{dimension}] call_id = get_call_id<{dimension}>();
+    uint[{dimension}] call_group_id = get_call_group_id<{dimension}>();
+    uint[{dimension}] call_group_thread_id = get_call_group_thread_id<{dimension}>();
+
+    return 1.0f;
+}}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Create output buffer
+    result_buffer = NDBuffer(device=device, shape=call_shape, dtype=float)
+
+    # Call with edge case call group shape
+    module.test_edge_case.call_group_shape(Shape(call_group_shape))(
+        spy.grid(call_shape), _result=result_buffer
+    )
+
+    # Validate that all calls completed successfully
+    results = result_buffer.to_numpy()
+    assert np.all(
+        results == 1.0
+    ), f"Failed edge case {description}: {call_shape} with groups {call_group_shape}"
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_error_handling(device_type: DeviceType):
+    """Test error handling for invalid call group configurations."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source = """
+import "slangpy";
+
+float test_basic(uint2 grid_pos) {
+    return 1.0f;
+}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+
+    # Test invalid call group shapes
+    with pytest.raises((ValueError, RuntimeError)):
+        # Negative dimensions should fail
+        module.test_basic.call_group_shape(Shape((-1, 2)))(spy.grid((4, 4)), _result="numpy")
+
+    with pytest.raises((ValueError, RuntimeError)):
+        # Zero dimensions should fail
+        module.test_basic.call_group_shape(Shape((0, 2)))(spy.grid((4, 4)), _result="numpy")
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_dimension_validation_simple(device_type: DeviceType):
+    """Test validation of call_group_shape dimensions and values - simplified version."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source_2d = """
+import "slangpy";
+
+float test_2d(uint2 grid_pos) {
+    return 1.0f;
+}
+"""
+
+    module_2d = helpers.create_module(device, kernel_source_2d)
+
+    # Only test zero values first (this works in existing tests)
+    with pytest.raises((ValueError, RuntimeError)) as exc_info:
+        # Zero in call_group_shape should fail
+        module_2d.test_2d.call_group_shape(Shape((2, 0)))(spy.grid((4, 4)), _result="numpy")
+
+    error_message = str(exc_info.value)
+    # The error should be caught at Python level with clear validation message
+    assert "call_group_shape[1] = 0" in error_message and "must be >= 1" in error_message
+
+    # Test that valid configurations still work (regression test)
+    result = module_2d.test_2d.call_group_shape(Shape((2, 2)))(spy.grid((4, 4)), _result="numpy")
+    assert np.all(result == 1.0)
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_dimension_validation_too_many_dims(device_type: DeviceType):
+    """Test validation of call_group_shape having too many dimensions."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source_2d = """
+import "slangpy";
+
+float test_2d(uint2 grid_pos) {
+    return 1.0f;
+}
+"""
+
+    kernel_source_1d = """
+import "slangpy";
+
+float test_1d(uint grid_pos) {
+    return 1.0f;
+}
+"""
+
+    module_2d = helpers.create_module(device, kernel_source_2d)
+    module_1d = helpers.create_module(device, kernel_source_1d)
+
+    # Test call_group_shape with more dimensions than call_shape
+    with pytest.raises((RuntimeError, ValueError)) as exc_info:
+        # 3D call_group_shape for 2D call_shape should fail
+        module_2d.test_2d.call_group_shape(Shape((2, 2, 2)))(spy.grid((4, 4)), _result="numpy")
+
+    error_message = str(exc_info.value)
+    assert "call_group_shape dimension (3)" in error_message
+    assert "call_shape dimension (2)" in error_message
+    assert "cannot have more dimensions than call_shape" in error_message
+
+    # Test with way too many dimensions
+    with pytest.raises((RuntimeError, ValueError)) as exc_info:
+        # 5D call_group_shape for 1D call_shape should fail
+        module_1d.test_1d.call_group_shape(Shape((1, 1, 1, 1, 1)))(spy.grid((8,)), _result="numpy")
+
+    error_message = str(exc_info.value)
+    assert "call_group_shape dimension (5)" in error_message
+    assert "call_shape dimension (1)" in error_message
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_dimension_validation_negative_values(device_type: DeviceType):
+    """Test validation of call_group_shape having negative values."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source_2d = """
+import "slangpy";
+
+float test_2d(uint2 grid_pos) {
+    return 1.0f;
+}
+"""
+
+    module_2d = helpers.create_module(device, kernel_source_2d)
+
+    # Test call_group_shape with negative values
+    with pytest.raises((RuntimeError, ValueError)) as exc_info:
+        # Negative in call_group_shape should fail
+        module_2d.test_2d.call_group_shape(Shape((2, -1)))(spy.grid((4, 4)), _result="numpy")
+
+    error_message = str(exc_info.value)
+    assert "call_group_shape[1] = -1" in error_message and "must be >= 1" in error_message
+
+    # Test mixed invalid values
+    with pytest.raises((RuntimeError, ValueError)) as exc_info:
+        # First invalid value should be caught
+        module_2d.test_2d.call_group_shape(Shape((0, -1)))(spy.grid((4, 4)), _result="numpy")
+
+    error_message = str(exc_info.value)
+    assert "call_group_shape[0] = 0" in error_message and "must be >= 1" in error_message
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_dimension_validation_zero_dimensions(device_type: DeviceType):
+    """Test that zero-dimensional call_group_shape is valid and gets padded with 1's."""
+
+    device = helpers.get_device(device_type)
+
+    kernel_source_2d = """
+import "slangpy";
+
+float test_2d(uint2 grid_pos) {
+    return 1.0f;
+}
+"""
+
+    module_2d = helpers.create_module(device, kernel_source_2d)
+
+    # Test call_group_shape with zero dimensions Shape(())
+    # This should be VALID - it means "use default linear behavior"
+    # and should get padded to [1, 1] for a 2D call shape
+    result = module_2d.test_2d.call_group_shape(Shape(()))(spy.grid((4, 4)), _result="numpy")
+
+    # Should work and produce correct result shape
+    assert result.shape == (4, 4)
+    assert np.all(result == 1.0)
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_call_group_math_verified_thread_id_patterns(device_type: DeviceType):
+    """
+    Test call group math by validating the exact thread_id patterns for known configurations.
+
+    This test validates specific thread_id values that result from call group dispatch arrangements.
+    The output format is [call_id_x, call_id_y, thread_id.x] for each position [y, x].
+    Note: get_call_id<2>() returns [y, x] but we rearrange to [x, y] for clarity.
+
+    Two key scenarios tested:
+
+    1. DEFAULT CASE (no call groups):
+       - Uses default linear dispatch (effectively 1×1 call groups)
+       - thread_id.x follows pattern: thread_id = y * width + x
+       - Examples: [0,0]→thread_id=0, [0,1]→thread_id=1, [1,0]→thread_id=64, [1,1]→thread_id=65
+
+    2. CALL GROUP CASE (4, 8) groups:
+       - Threads arranged in spatial 4×8 groups
+       - thread_id assignment depends on group layout and changes from linear pattern
+       - Examples: [0,0]→thread_id=0, [0,1]→thread_id=1, [1,0]→thread_id=8, [1,1]→thread_id=9
+
+    The key insight: call groups change how thread_id.x is assigned while call_id remains position-based.
+    """
+
+    device = helpers.get_device(device_type)
+
+    kernel_source = """
+import "slangpy";
+
+// Returns call_id and thread_id for pattern validation
+// Note: get_call_id<2>() returns [y, x] order
+uint3 test_thread_id_patterns(uint2 grid_cell, uint3 thread_id) {
+    int[2] call_id = get_call_id<2>();
+    return uint3(call_id[1], call_id[0], thread_id.x);  // Return as [x, y, thread_id.x]
+}
+"""
+
+    module = helpers.create_module(device, kernel_source)
+    call_shape = (32, 64)  # 32 rows × 64 columns
+
+    # Test 1: DEFAULT CASE (no call groups)
+    # Expected: Linear thread assignment where thread_id.x = y * width + x
+    result_default = module.test_thread_id_patterns(
+        spy.grid(call_shape), spy.thread_id(), _result="numpy"
+    )
+
+    # Row 0: thread_id should equal x coordinate
+    # Position [y=0,x=0]: call_id_x=0, call_id_y=0, thread_id=0*64+0=0
+    # Position [y=0,x=1]: call_id_x=1, call_id_y=0, thread_id=0*64+1=1
+    # Position [y=0,x=63]: call_id_x=63, call_id_y=0, thread_id=0*64+63=63
+    for x in range(min(10, call_shape[1])):  # Test first 10 positions
+        expected_call_id_x = x
+        expected_call_id_y = 0
+        expected_thread_id = 0 * call_shape[1] + x  # y * width + x
+        expected = [expected_call_id_x, expected_call_id_y, expected_thread_id]
+        actual = result_default[0, x]
+        assert np.array_equal(
+            actual, expected
+        ), f"Default [0,{x}]: expected {expected}, got {actual}"
+
+    # Row 1: thread_id should be 64 + x
+    # Position [y=1,x=0]: call_id_x=0, call_id_y=1, thread_id=1*64+0=64
+    # Position [y=1,x=1]: call_id_x=1, call_id_y=1, thread_id=1*64+1=65
+    for x in range(min(10, call_shape[1])):  # Test first 10 positions
+        expected_call_id_x = x
+        expected_call_id_y = 1
+        expected_thread_id = 1 * call_shape[1] + x  # y * width + x = 64 + x
+        expected = [expected_call_id_x, expected_call_id_y, expected_thread_id]
+        actual = result_default[1, x]
+        assert np.array_equal(
+            actual, expected
+        ), f"Default [1,{x}]: expected {expected}, got {actual}"
+
+    # Last position [y=31,x=63]: call_id_x=63, call_id_y=31, thread_id should be 31*64+63=2047 (total threads - 1)
+    expected_31_63 = [63, 31, 31 * call_shape[1] + 63]  # [63, 31, 2047]
+    actual_31_63 = result_default[31, 63]
+    assert np.array_equal(
+        actual_31_63, expected_31_63
+    ), f"Default [31,63]: expected {expected_31_63}, got {actual_31_63}"
+
+    # Test 2: CALL GROUP CASE (4, 8) groups
+    # Expected: Non-linear thread assignment due to spatial group arrangement
+    call_group_shape = (4, 8)
+    result_grouped = module.test_thread_id_patterns.call_group_shape(Shape(call_group_shape))(
+        spy.grid(call_shape), spy.thread_id(), _result="numpy"
+    )
+
+    # With (4, 8) call groups, thread assignment follows group-based pattern:
+    # - Grid divided into 8×8 call groups (32÷4 = 8 rows, 64÷8 = 8 columns of groups)
+    # - Each group contains 4×8 = 32 threads
+    # - thread_id assignment prioritizes spatial locality within groups
+
+    # Row 0 positions: early positions should have thread_id = x (same as default)
+    # This happens because first group spans [0,0] to [3,7] and early threads get low IDs
+    for x in range(min(8, call_shape[1])):  # Test first group's width
+        expected_call_id_x = x
+        expected_call_id_y = 0
+        expected_thread_id = x  # Should match default for early positions
+        expected = [expected_call_id_x, expected_call_id_y, expected_thread_id]
+        actual = result_grouped[0, x]
+        assert np.array_equal(
+            actual, expected
+        ), f"Grouped [0,{x}]: expected {expected}, got {actual}"
+
+    # Row 1 key positions: thread_id pattern changes due to spatial grouping
+    # Position [1,0]: In same group as [0,0], should have thread_id offset by group row
+    # Based on (4,8) groups: thread within group gets ID based on position in group
+    expected_1_0 = [0, 1, 8]  # 2nd row of first group: base_id + row_offset*group_width
+    actual_1_0 = result_grouped[1, 0]
+    assert np.array_equal(
+        actual_1_0, expected_1_0
+    ), f"Grouped [1,0]: expected {expected_1_0}, got {actual_1_0}"
+
+    expected_1_1 = [1, 1, 9]  # Next column in same row of group
+    actual_1_1 = result_grouped[1, 1]
+    assert np.array_equal(
+        actual_1_1, expected_1_1
+    ), f"Grouped [1,1]: expected {expected_1_1}, got {actual_1_1}"
+
+    # Test cross-group boundaries
+    # Position [0,8]: Start of second call group in same row
+    # This position starts a new group, so thread_id pattern differs from linear
+    expected_0_8_thread_id = 32  # Start of 2nd group (group_id=1 * group_size=32)
+    expected_0_8 = [8, 0, expected_0_8_thread_id]
+    actual_0_8 = result_grouped[0, 8]
+    assert np.array_equal(
+        actual_0_8, expected_0_8
+    ), f"Grouped [0,8]: expected {expected_0_8}, got {actual_0_8}"
+
+    # Position [4,0]: Start of second row of call groups
+    # This moves to next "group row", affecting thread_id assignment
+    expected_4_0_thread_id = 256  # Start of 2nd group row (8 groups * 32 threads each)
+    expected_4_0 = [0, 4, expected_4_0_thread_id]
+    actual_4_0 = result_grouped[4, 0]
+    assert np.array_equal(
+        actual_4_0, expected_4_0
+    ), f"Grouped [4,0]: expected {expected_4_0}, got {actual_4_0}"
+
+    # Verify call_id invariant: call_id should always match [x, y] position
+    for y in range(0, call_shape[0], 8):  # Sample every 8th row
+        for x in range(0, call_shape[1], 8):  # Sample every 8th column
+            call_id_x = result_grouped[y, x, 0]
+            call_id_y = result_grouped[y, x, 1]
+            assert call_id_x == x, f"call_id[0] should equal x at [{y},{x}]: got {call_id_x}"
+            assert call_id_y == y, f"call_id[1] should equal y at [{y},{x}]: got {call_id_y}"
+
+    # Validate last position still gets highest thread_id (total threads - 1)
+    expected_31_63 = [63, 31, 2047]  # Last thread should still be 2047
+    actual_31_63 = result_grouped[31, 63]
+    assert np.array_equal(
+        actual_31_63, expected_31_63
+    ), f"Grouped [31,63]: expected {expected_31_63}, got {actual_31_63}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -414,7 +414,7 @@ nb::object NativeCallData::exec(
         // call_group_shape.size() > 0.
         if (call_group_shape.size() > cs.size()) {
             throw std::runtime_error(fmt::format(
-                "call_group_shape dimension ({}) must be <= call_shape dimension ({}). "
+                "call_group_shape dimensionality ({}) must be <= call_shape dimensionality ({}). "
                 "call_group_shape cannot have more dimensions than call_shape.",
                 call_group_shape.size(),
                 cs.size()
@@ -426,7 +426,7 @@ nb::object NativeCallData::exec(
             // log a debug message, giving users a chance to correct their calls.
             if (is_log_enabled(LogLevel::debug)) {
                 log_debug(
-                    "call_group_shape dimension ({}) < call_shape dimension ({}). "
+                    "call_group_shape dimensionality ({}) < call_shape dimensionality ({}). "
                     "Padding call_group_shape with {} leading 1's. "
                     "Consider specifying full dimensions for better performance.",
                     call_group_shape.size(),

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <sstream>
+#include <cmath>
 
 #include "nanobind.h"
 
@@ -391,15 +392,126 @@ nb::object NativeCallData::exec(
         }
     }
 
-    // Calculate total threads and strides.
-    int total_threads = 1;
-    std::vector<int> strides;
     const std::vector<int>& cs = call_shape.as_vector();
+    std::vector<int> strides;
+    int current_stride = 1;
     for (auto it = cs.rbegin(); it != cs.rend(); ++it) {
-        strides.push_back(total_threads);
-        total_threads *= *it;
+        strides.push_back(current_stride);
+        current_stride *= *it;
     }
     std::reverse(strides.begin(), strides.end());
+
+    // Get call group shape from build info
+    std::vector<int> call_group_shape;
+
+    if (m_call_group_shape.valid() && m_call_group_shape.size() > 0) {
+        // Similar to cs, this will be recieved with the first dimension
+        // as the right most element, ex: [..., z, y, x].
+        call_group_shape = m_call_group_shape.as_vector();
+
+        // Verify that call_group_shape has valid dimensions and values.
+        // Our check above should have already validated that
+        // call_group_shape.size() > 0.
+        if (call_group_shape.size() > cs.size()) {
+            throw std::runtime_error(fmt::format(
+                "call_group_shape dimension ({}) must be <= call_shape dimension ({}). "
+                "call_group_shape cannot have more dimensions than call_shape.",
+                call_group_shape.size(),
+                cs.size()
+            ));
+        } else if (call_group_shape.size() < cs.size()) {
+            // Call group shape size is less than the call shape size so we need to
+            // pad the call group shape with 1's to account for the missing dimensions.
+            // However, inserting at the front of the vector will be inefficient, so
+            // log a debug message, giving users a chance to correct their calls.
+            if (is_log_enabled(LogLevel::debug)) {
+                log_debug(
+                    "call_group_shape dimension ({}) < call_shape dimension ({}). "
+                    "Padding call_group_shape with {} leading 1's. "
+                    "Consider specifying full dimensions for better performance.",
+                    call_group_shape.size(),
+                    cs.size(),
+                    cs.size() - call_group_shape.size()
+                );
+            }
+
+            for (size_t i = 0; i < (cs.size() - call_group_shape.size()); ++i) {
+                // Insert 1's for the dimensions we were not given
+                call_group_shape.insert(call_group_shape.begin(), 1);
+            }
+        }
+
+        // Verify that all elements of call_group_shape are >= 1
+        for (size_t i = 0; i < call_group_shape.size(); ++i) {
+            if (call_group_shape[i] < 1) {
+                throw std::runtime_error(fmt::format(
+                    "call_group_shape[{}] = {} is invalid. All call_group_shape elements must be >= 1.",
+                    i,
+                    call_group_shape[i]
+                ));
+            }
+        }
+    } else {
+
+        // We already know the size/dimensionality of all the shape and
+        // stride vectors at this point. Use reserve() to preallocate
+        // to the exact size required for efficiency.
+        call_group_shape.reserve(cs.size());
+
+        // Default to making the call group shape all 1's. This will force the
+        // grid shape to be identical to the call shape giving us linear
+        // dispatches by default when a call group shape is not specified.
+        // In this case, conceptually all thread's have their own "group" even
+        // though they will still be executed in groups of 32.
+        for (int i = 0; i < cs.size(); i++) {
+            call_group_shape.push_back(1);
+        }
+    }
+
+    // Calculate the group strides
+    std::vector<int> call_group_strides;
+    call_group_strides.reserve(cs.size());
+    current_stride = 1;
+    for (auto it = call_group_shape.rbegin(); it != call_group_shape.rend(); ++it) {
+        call_group_strides.push_back(current_stride);
+        current_stride *= *it;
+    }
+    std::reverse(call_group_strides.begin(), call_group_strides.end());
+
+    // Calculate the grid shape and total threads.
+    //
+    // Note: The call shape may not be call group shape aligned, in which case we
+    //       will align up the call shape. This will result in
+    //       aligned_call_shape.size - call_shape.size wasted threads. It might be
+    //       possible to create some logic to avoid waste, but a call group would
+    //       likely end up torn and representing different regions of the call shape,
+    //       which would likely defeat the purpose of using call groups for better
+    //       memory coherency and uses of shared memory.
+    int total_threads = 1;
+    std::vector<int> call_grid_shape;
+    std::vector<int> aligned_call_shape;
+    call_grid_shape.reserve(cs.size());
+    aligned_call_shape.reserve(cs.size());
+    bool is_call_shape_unaligned = false;
+    for (int i = 0; i < cs.size(); i++) {
+        // When the call shape is not call group shape aligned, we will add some
+        // padding to align up.
+        call_grid_shape.push_back((int)std::ceil((float)cs[i] / (float)call_group_shape[i]));
+        aligned_call_shape.push_back(call_grid_shape.back() * call_group_shape[i]);
+        if (aligned_call_shape[i] != cs[i])
+            is_call_shape_unaligned = true;
+        total_threads *= aligned_call_shape.back();
+    }
+
+    // Calculate the grid strides
+    std::vector<int> call_grid_strides;
+    call_grid_strides.reserve(cs.size());
+    current_stride = 1;
+    for (auto it = call_grid_shape.rbegin(); it != call_grid_shape.rend(); ++it) {
+        call_grid_strides.push_back(current_stride);
+        current_stride *= *it;
+    }
+    std::reverse(call_grid_strides.begin(), call_grid_strides.end());
 
     nb::list read_back;
 
@@ -415,10 +527,18 @@ nb::object NativeCallData::exec(
         if (call_data_cursor.is_reference())
             call_data_cursor = call_data_cursor.dereference();
 
-        if (!strides.empty()) {
-            call_data_cursor["_call_stride"]._set_array_unsafe(&strides[0], strides.size() * 4, strides.size());
+        if (!call_grid_strides.empty()) {
             call_data_cursor["_call_dim"]._set_array_unsafe(&cs[0], cs.size() * 4, cs.size());
+            call_data_cursor["_grid_stride"]
+                ._set_array_unsafe(&call_grid_strides[0], call_grid_strides.size() * 4, call_grid_strides.size());
+            call_data_cursor["_grid_dim"]
+                ._set_array_unsafe(&call_grid_shape[0], call_grid_shape.size() * 4, call_grid_shape.size());
+            call_data_cursor["_group_stride"]
+                ._set_array_unsafe(&call_group_strides[0], call_group_strides.size() * 4, call_group_strides.size());
+            call_data_cursor["_group_dim"]
+                ._set_array_unsafe(&call_group_shape[0], call_group_shape.size() * 4, call_group_shape.size());
         }
+
         call_data_cursor["_thread_count"] = uint3(total_threads, 1, 1);
 
         m_runtime->write_shader_cursor_pre_dispatch(
@@ -448,6 +568,16 @@ nb::object NativeCallData::exec(
         log_debug("  Call shape: {}", call_shape.to_string());
         log_debug("  Call mode: {}", m_call_mode);
         log_debug("  Strides: [{}]", fmt::join(strides, ", "));
+        log_debug("  Call grid shape: [{}]", fmt::join(call_grid_shape, ", "));
+        log_debug("  Call grid strides: [{}]", fmt::join(call_grid_strides, ", "));
+        log_debug("  Call group shape: [{}]", fmt::join(call_group_shape, ", "));
+        log_debug("  Call group strides: [{}]", fmt::join(call_group_strides, ", "));
+        if (is_call_shape_unaligned) {
+            log_debug("  Call shape was not aligned to the given call group shape");
+            log_debug("  and has been padded up as a reult. Note that this will");
+            log_debug("  result in wasted threads.");
+            log_debug("  Aligned call shape: [{}]", fmt::join(aligned_call_shape, ", "));
+        }
         log_debug("  Threads: {}", total_threads);
     }
 
@@ -1074,6 +1204,12 @@ SGL_PY_EXPORT(utils_slangpy)
             nb::arg("args"),
             nb::arg("kwargs"),
             D_NA(NativeCallData, append_to)
+        )
+        .def_prop_rw(
+            "call_group_shape",
+            &NativeCallData::get_call_group_shape,
+            &NativeCallData::set_call_group_shape,
+            D_NA(NativeCallData, call_group_shape)
         )
         .def("log", &NativeCallData::log, "level"_a, "msg"_a, "frequency"_a = LogFrequency::always, D(Logger, log))
         .DEF_LOG_METHOD(log_debug)

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -653,7 +653,14 @@ public:
     void set_logger(ref<Logger> logger) { m_logger = logger; }
 
     /// Set the shape of call groups when a dispatch is made.
-    void set_call_group_shape(Shape call_group_shape) { m_call_group_shape = call_group_shape; }
+    void set_call_group_shape(std::optional<Shape> call_group_shape)
+    {
+        if (call_group_shape.has_value()) {
+            m_call_group_shape = call_group_shape.value();
+        } else {
+            m_call_group_shape = Shape(std::nullopt);
+        }
+    }
 
     /// Get the shape of call groups when a dispatch is made.
     const Shape& get_call_group_shape() const { return m_call_group_shape; }

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -652,6 +652,12 @@ public:
     /// Set the logger
     void set_logger(ref<Logger> logger) { m_logger = logger; }
 
+    /// Set the shape of call groups when a dispatch is made.
+    void set_call_group_shape(Shape call_group_shape) { m_call_group_shape = call_group_shape; }
+
+    /// Get the shape of call groups when a dispatch is made.
+    const Shape& get_call_group_shape() const { return m_call_group_shape; }
+
     /// Call the compute kernel with the provided arguments and keyword arguments.
     nb::object call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs);
 
@@ -696,6 +702,7 @@ private:
     Shape m_last_call_shape;
     std::string m_debug_name;
     ref<Logger> m_logger;
+    Shape m_call_group_shape;
 
     nb::object
     exec(ref<NativeCallRuntimeOptions> opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);


### PR DESCRIPTION
Enhanced Kernel Dispatch Flexibility in SlangPy (#72)

This commit introduces enhanced kernel dispatch flexibility via
a new "call_group_shape()" function that enables more fine-grained
control over GPU thread organization and dispatch patterns. A simple
usage example might look something like:

`call_data = module.test2D.call_group_shape(Shape((4,8)))(spy.grid((32,64)), spy.thread_id(), _result='numpy')`

Where a shader named "test2D" is being given a call group shape of
4x8 (note that the ordering is [y,x] here), a call shape of 32x64
as a result of the spy.grid((32,64)) being passed in, as well as given
the thread_id. The mapping of call-id's to thread-id's from such a call
would look like:

[call-id[0] (y), call-id[1] (x), thread-id]

[   0    0    0]
[   1    0    1]
[   2    0    2]
...
[  61    0  229]
[  62    0  230]
[  63    0  231]
[   0    1    8]
[   1    1    9]
[   2    1   10]
...
[  61    1  237]
[  62    1  238]
[  63    1  239]

Running without the call_group_shape function:

`call_data = module.test2D.(spy.grid((32,64)), spy.thread_id(), _result='numpy')`

or alternatively:

`call_data = module.test2D.call_group_shape(Shape(()))(spy.grid((32,64)), spy.thread_id(), _result='numpy')`

results in SlangPy using it's standard linear dispatch scheme using call groups
containing 32 threads and the mapping from call-id's to thread-id's from such
calls would look like:

[   0    0    0]
[   1    0    1]
[   2    0    2]
...
[  61    0   61]
[  62    0   62]
[  63    0   63]
[   0    1   64]
[   1    1   65]
[   2    1   66]
...
[  61    1  125]
[  62    1  126]
[  63    1  127]

Conceptually, the default when not specifying a call group shape can be thought
of as running dispatches where each thread has its own call group, but in
actuallity, threads are still run in groups of 32. Thus a call like:

`call_data = module.test2D_thread.call_group_shape(Shape((1,1)))(spy.grid((32,64)), spy.thread_id(), _result='numpy')`

Will ultimately function differently than the two examples above and would likely
have worse performance. Similarly:

`call_data = module.test2D_thread.call_group_shape(Shape((1,32)))(spy.grid((32,64)), spy.thread_id(), _result='numpy')`

Can also function differently from the default case where call group shape is
not specified, as we can now run into alignment issues when the call shape is
not aligned to 32 threads in the "x" dimension (ex a 1x33 call group shape on a
32x64 call shape).

The new functionality also works with arbitrary dimensionalities:

`...test5D_thread.call_group_shape(Shape((2,2,2,2,2)))(spy.grid((2,2,2,32,64)), spy.thread_id(), _result='numpy')`

Using the new call_group_shape functionality, developers can now specify how
threads are arranged spatially, allowing for better uses of shared memory and
better control over memory access patterns.

In order to support the new functionality, the change extends the existing
dispatch system to support call_group_shape parameters with proper validation,
padding, and alignment handling, while also handling edge cases for misaligned
shapes and dimensions smaller than group sizes, while also providing error reporting
for invalid configurations.

The change includes unit tests that validate call group functionality across
1D through 5D dispatches to ensure mathematical consistency of the group ID
calculations and thread ID assignments. The tests cover both typical use
cases and edge cases and have been added under:

-slangpy/tests/slangpy_tests/test_call_groups.py

The change also includes integration tests to ensure call group functionality
works with SlangPy's existing major features such as tensor operations with
autodiff support, NDBuffer processing, texture sampling and filtering, and
transformation mapping operations. These integration tests have been added
under:

-slangpy/tests/slangpy_tests/test_call_group_integrations.py