### PR TITLE
Add buffercursor ndarray write

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -26,7 +26,7 @@ pre-commit install
 pre-commit run --all-files
 
 #Run unit tests
-pytest
+pytest slangpy/tests
 ```
 
 ## Tests
@@ -34,13 +34,13 @@ pytest
 If opened in VS Code, the default setup will detect and register tests in the VS Code testing tools. To run manually:
 
 ```
-pytest
+pytest slangpy/tests
 ```
 
 To debug a test, simply run the corresponding test file
 
 ## Adding new tests
 
-`tests/slangpy/slangpy_tests/test_sgl.py` is a very basic test example. Note it:
+`slangpy/tests/slangpy_tests/test_sgl.py` is a very basic test example. Note it:
 - Use parameterization to create a test that runs once per device type
 - Includes an `__main__` handler at the bottom to allow the file to be debugged

--- a/slangpy/tests/device/test_buffer_cursor.py
+++ b/slangpy/tests/device/test_buffer_cursor.py
@@ -423,5 +423,89 @@ def test_apply_changes(device_type: spy.DeviceType, seed: int):
             check_match(test, element[name].read())
 
 
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+@pytest.mark.parametrize("seed", RAND_SEEDS)
+def test_apply_changes_ndarray(device_type: spy.DeviceType, seed: int):
+
+    # Randomize the order of the tests
+    tests = [
+        ("f_float", "float", "1.0", 1.0),
+        ("f_float1", "float1", "2.0", [2.0]),
+        ("f_float2", "float2", "float2(2.0, 3.0)", [2.0, 3.0]),
+        ("f_float3", "float3", "float3(2.0, 3.0, 4.0)", [2.0, 3.0, 4.0]),
+        ("f_float4", "float4", "float4(2.0, 3.0, 4.0, 5.0)", [2.0, 3.0, 4.0, 5.0]),
+    ]
+    random.seed(seed)
+    random.shuffle(tests)
+
+    # Create the module and buffer layout
+    (kernel, buffer_layout) = make_copy_module(device_type, tests)
+
+    # Make a buffer with 128 elements and a cursor to wrap it
+    count = 128
+    src = kernel.device.create_buffer(
+        element_count=count,
+        struct_type=buffer_layout,
+        usage=spy.BufferUsage.shader_resource | spy.BufferUsage.unordered_access,
+        data=np.zeros(buffer_layout.element_type_layout.stride * count, dtype=np.uint8),
+    )
+    dest = kernel.device.create_buffer(
+        element_count=count,
+        struct_type=buffer_layout,
+        usage=spy.BufferUsage.shader_resource | spy.BufferUsage.unordered_access,
+        data=np.zeros(buffer_layout.element_type_layout.stride * count, dtype=np.uint8),
+    )
+    src_cursor = spy.BufferCursor(buffer_layout.element_type_layout, src)
+    dest_cursor = spy.BufferCursor(buffer_layout.element_type_layout, dest)
+
+    # Populate source cursor
+    source_data = {}
+    for test in tests:
+        (name, gpu_type, gpu_val, value) = test[0:4]
+        my_list = []
+        if isinstance(value, list):
+            my_list = [[x + i for x in value] for i in range(count)]
+        elif isinstance(value, float):
+            my_list = [value + i for i in range(count)]
+        source_data[name] = np.array(my_list, dtype=np.float32)
+
+    src_cursor.write_multiple(source_data)
+
+    # Apply changes to source
+    src_cursor.apply()
+
+    # Load the dest cursor - this should end up with it containing 0s as its not been written
+    dest_cursor.load()
+
+    # Verify 0s
+    for i in range(count):
+        element = dest_cursor[i]
+        assert element["f_float"].read() == 0
+
+    # Dispatch the kernel
+    kernel.dispatch([count, 1, 1], src=src, dest=dest)
+
+    # Verify still 0s as we've not refreshed the cursor yet!
+    for i in range(count):
+        element = dest_cursor[i]
+        assert element["f_float"].read() == 0
+
+    # Refresh the buffer
+    dest_cursor.load()
+
+    # Verify data in dest buffer matches
+    for i in range(count):
+        element = dest_cursor[i]
+        for test in tests:
+            name = test[0]
+            expected_value = test[3]
+            if isinstance(expected_value, float):
+                expected_value += i
+            elif isinstance(expected_value, list):
+                expected_value = [x + i for x in expected_value]
+            result = element[name].read()
+            assert expected_value == result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/device/test_buffer_cursor.py
+++ b/slangpy/tests/device/test_buffer_cursor.py
@@ -469,7 +469,7 @@ def test_apply_changes_ndarray(device_type: spy.DeviceType, seed: int):
             my_list = [value + i for i in range(count)]
         source_data[name] = np.array(my_list, dtype=np.float32)
 
-    src_cursor.write_multiple(source_data)
+    src_cursor.write_from_numpy(source_data)
 
     # Apply changes to source
     src_cursor.apply()

--- a/src/sgl/device/buffer_cursor.h
+++ b/src/sgl/device/buffer_cursor.h
@@ -75,6 +75,8 @@ public:
     void _get_vector(void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension) const;
     void _get_matrix(void* data, size_t size, TypeReflection::ScalarType scalar_type, int rows, int cols) const;
 
+    void _set_offset(size_t new_offset) { m_offset = new_offset; }
+
 private:
     void write_data(size_t offset, const void* data, size_t size);
     void read_data(size_t offset, void* data, size_t size) const;

--- a/src/slangpy_ext/device/buffer_cursor.cpp
+++ b/src/slangpy_ext/device/buffer_cursor.cpp
@@ -107,8 +107,8 @@ SGL_PY_EXPORT(device_buffer_cursor)
         .def("__getitem__", [](BufferCursor& self, int index) { return self[index]; })
         .def("__len__", [](BufferCursor& self) { return self.element_count(); })
         .def(
-            "write_multiple",
-            [](BufferCursor& self, nb::object nbval) { detail::_writeconv.write_multiple(self, nbval); },
+            "write_from_numpy",
+            [](BufferCursor& self, nb::object nbval) { detail::_writeconv.write_from_numpy(self, nbval); },
             "data"_a
         )
         .def(

--- a/src/slangpy_ext/device/buffer_cursor.cpp
+++ b/src/slangpy_ext/device/buffer_cursor.cpp
@@ -107,6 +107,11 @@ SGL_PY_EXPORT(device_buffer_cursor)
         .def("__getitem__", [](BufferCursor& self, int index) { return self[index]; })
         .def("__len__", [](BufferCursor& self) { return self.element_count(); })
         .def(
+            "write_multiple",
+            [](BufferCursor& self, nb::object nbval) { detail::_writeconv.write_multiple(self, nbval); },
+            "data"_a
+        )
+        .def(
             "to_numpy",
             [](BufferCursor& self)
             {

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -441,6 +441,13 @@ private:
         for (size_t dim = 1; dim < nbarray.ndim(); ++dim) {
             element_byte_size *= nbarray.shape(dim);
         }
+        SGL_CHECK(
+            element_byte_size == self.type_layout()->size(),
+            "The BufferElement size ({}) does not match the ndarray size ({}) of the last {} dimensions.",
+            self.type_layout()->size(),
+            element_byte_size,
+            nbarray.ndim() - 1
+        );
 
         for (size_t index = 0; index < dst.element_count(); ++index) {
             self.set_data(data + index * nbarray.stride(0) * itemsize, element_byte_size);

--- a/src/slangpy_ext/nanobind.h
+++ b/src/slangpy_ext/nanobind.h
@@ -270,21 +270,29 @@ nb::type_slots gc_helper_type_slots()
 
 namespace sgl {
 
+/// Check if ndarray is contiguous from the `first_dimension` (inclusive) onwards
 template<typename... Args>
-size_t is_ndarray_contiguous(const nb::ndarray<Args...>& array)
+size_t is_ndarray_partially_contiguous(const nb::ndarray<Args...>& array, size_t first_dimension = 0)
 {
-    if (array.ndim() == 0)
+    if (array.ndim() <= first_dimension)
         return false;
     size_t prod = 1;
     for (size_t i = array.ndim() - 1;;) {
         if (array.stride(i) != narrow_cast<int64_t>(prod))
             return false;
         prod *= array.shape(i);
-        if (i == 0)
+        if (i == first_dimension)
             break;
         --i;
     }
     return true;
+}
+
+
+template<typename... Args>
+size_t is_ndarray_contiguous(const nb::ndarray<Args...>& array)
+{
+    return is_ndarray_partially_contiguous(array, 0);
 }
 
 inline cuda::TensorView ndarray_to_cuda_tensor_view(nb::ndarray<nb::device::cuda> array)


### PR DESCRIPTION
Basic interface for writing multiple values into a buffer at once.

Takes a dictionary of ndarrays, where the first dimension of the ndarray must be the size of the buffer. The values are then rather blindly written into the buffer, with only a bytesize check.