### PR TITLE
Allow retargeting strided buffer view to another buffer

### DIFF
--- a/slangpy/tests/slangpy_tests/test_buffer_views.py
+++ b/slangpy/tests/slangpy_tests/test_buffer_views.py
@@ -244,6 +244,35 @@ def test_view_errors(device_type: DeviceType, buffer_type: Union[Type[Tensor], T
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_point_to(device_type: DeviceType):
+
+    device = helpers.get_device(device_type)
+
+    # Create two identical buffers with different random data
+    data_a = np.random.rand(16, 16, 16)
+    data_b = np.random.rand(16, 16, 16)
+
+    tensor_a = Tensor.from_numpy(device, data_a)
+    tensor_b = Tensor.from_numpy(device, data_b)
+
+    # Take a slice from the first buffer
+    slice_a = tensor_a[5]
+    assert slice_a.shape == (16, 16)
+    assert slice_a.offset == 5 * 16 * 16
+
+    # Sanity check: Verify slice matches expected data
+    assert np.all(slice_a.to_numpy() == data_a[5])
+
+    # Retarget slice_a to point to a slice of data_b
+    slice_b = tensor_b[2]
+    slice_a.point_to(slice_b)
+
+    # Very shape is unchanged, but data reflects new view
+    assert slice_a.shape == (16, 16)
+    assert np.all(slice_a.to_numpy() == data_b[2])
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 @pytest.mark.parametrize("buffer_type", [Tensor, NDBuffer])
 def test_broadcast_to(device_type: DeviceType, buffer_type: Union[Type[Tensor], Type[NDBuffer]]):
 

--- a/src/sgl/utils/slangpy.h
+++ b/src/sgl/utils/slangpy.h
@@ -163,6 +163,16 @@ public:
         }
     }
 
+    bool operator==(const Shape& o) const
+    {
+        if (valid() != o.valid())
+            return false;
+        if (!valid() && !o.valid())
+            return true;
+
+        return *m_shape == *o.m_shape;
+    }
+
 private:
     std::optional<std::vector<int>> m_shape;
 };

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -402,6 +402,18 @@ void StridedBufferView::copy_from_numpy(nb::ndarray<nb::numpy> data)
     m_storage->set_data(data.data(), data_size, byte_offset);
 }
 
+void StridedBufferView::point_to(ref<StridedBufferView> target)
+{
+    SGL_CHECK(shape() == target->shape(), "Shape of existing and new view must match");
+    SGL_CHECK(usage() == target->usage(), "Usage flags of existing and new buffer must match");
+    SGL_CHECK(memory_type() == target->memory_type(), "Memory type of existing and new buffer must match");
+    SGL_CHECK(element_stride() == target->element_stride(), "Element size of new and existing data type must match");
+
+    desc().offset = target->offset();
+    desc().strides = target->strides();
+    m_storage = target->m_storage;
+}
+
 } // namespace sgl::slangpy
 
 SGL_PY_EXPORT(utils_slangpy_strided_buffer_view)
@@ -438,5 +450,6 @@ SGL_PY_EXPORT(utils_slangpy_strided_buffer_view)
         .def("to_numpy", &StridedBufferView::to_numpy, D_NA(StridedBufferView, to_numpy))
         .def("to_torch", &StridedBufferView::to_torch, D_NA(StridedBufferView, to_torch))
         .def("copy_from_numpy", &StridedBufferView::copy_from_numpy, "data"_a, D_NA(StridedBufferView, copy_from_numpy))
-        .def("is_contiguous", &StridedBufferView::is_contiguous, D_NA(&StridedBufferView, is_contiguous));
+        .def("is_contiguous", &StridedBufferView::is_contiguous, D_NA(&StridedBufferView, is_contiguous))
+        .def("point_to", &StridedBufferView::point_to, "target"_a, D_NA(&StridedBufferView, point_to));
 }

--- a/src/slangpy_ext/utils/slangpystridedbufferview.h
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.h
@@ -65,6 +65,8 @@ public:
     /// Copy from CPU memory (as a numpy array) into GPU buffer
     void copy_from_numpy(nb::ndarray<nb::numpy> data);
 
+    void point_to(ref<StridedBufferView> target);
+
 protected:
     // In-place versions of view changing methods.
     // Derived classes are supposed the non-inplace versions by creating a copy


### PR DESCRIPTION
Roughly equivalent to `torch.Tensor.set_`. Preserves type and shape, but retargets the view to point to another.