### PR TITLE
Updated decompose eps to allow importing certain USD scenes.

### DIFF
--- a/src/sgl/math/matrix_math.h
+++ b/src/sgl/math/matrix_math.h
@@ -326,7 +326,9 @@ inline bool decompose(
     // an easy way to test for singularity of the upper 3x3 component.
     matrix<T, 4, 4> perspective_matrix(local_matrix);
     perspective_matrix[3] = vector<T, 4>(0, 0, 0, 1);
-    if (abs(determinant(perspective_matrix)) < eps)
+    // Determinant contains scale in each axis. Comparing with eps like GLM would reject scale
+    // less than 0.0049 (which is convert from cm to m, and then scale down 2x)
+    if (abs(determinant(perspective_matrix)) < eps * eps * eps)
         return false;
 
     // First, isolate perspective. This is the messiest.


### PR DESCRIPTION
Some USD scenes are modelled in cm, and when loaded in meters (with 0.01 scale), objects that have been scaled down more than 2x would not fit into the GLM epsilon in matrix decompose.

The problem is that the determinant contains product of scales on all axes, so rejecting it as too small should be done on product of 3 epsilons (eps^3).