### PR TITLE
Changed operator= return values to be more standard compliant

### DIFF
--- a/src/sgl/device/buffer_cursor.h
+++ b/src/sgl/device/buffer_cursor.h
@@ -46,9 +46,10 @@ public:
     void set_data(const void* data, size_t size);
 
     template<typename T>
-    void operator=(const T& value)
+    BufferElementCursor& operator=(const T& value)
     {
         set(value);
+        return *this;
     }
 
     template<typename T>

--- a/src/sgl/device/shader_cursor.h
+++ b/src/sgl/device/shader_cursor.h
@@ -73,9 +73,10 @@ public:
     void set_cuda_tensor_view(const cuda::TensorView& tensor_view) const;
 
     template<typename T>
-    void operator=(const T& value) const
+    const ShaderCursor& operator=(const T& value) const
     {
         set(value);
+        return *this;
     }
 
     template<typename T>


### PR DESCRIPTION
The standard pattern of operator= is:
```
Foo& operator=(const ConvertibleToFoo&)
```
ShaderCursor has `operator=` on const, so I made it return `const ShaderCursor&`