### PR TITLE
Add API for generating mips

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Version 0.32.0 (TBA)
 ----------------------------
 
 - Allow creating ``Bitmap`` from non-contiguous arrays.
+- Add ``sgl::CommandEncoder::generate_mips()`` (``slangpy.CommandEncoder.generate_mips()``) to generate mipmaps for textures.
 
 Version 0.31.0 (June 5, 2025)
 ----------------------------

--- a/src/sgl/device/blit.cpp
+++ b/src/sgl/device/blit.cpp
@@ -101,16 +101,16 @@ void Blitter::blit(CommandEncoder* command_encoder, Texture* dst, Texture* src, 
     blit(command_encoder, dst->create_view({}), src->create_view({}), filter);
 }
 
-void Blitter::generate_mips(CommandEncoder* command_encoder, Texture* texture, uint32_t array_layer)
+void Blitter::generate_mips(CommandEncoder* command_encoder, Texture* texture, uint32_t layer)
 {
     SGL_CHECK_NOT_NULL(command_encoder);
     SGL_CHECK_NOT_NULL(texture);
-    SGL_CHECK_LT(array_layer, texture->array_length());
+    SGL_CHECK_LT(layer, texture->layer_count());
 
     for (uint32_t i = 0; i < texture->mip_count() - 1; ++i) {
         ref<TextureView> src = texture->create_view({
             .subresource_range{
-                .layer = array_layer,
+                .layer = layer,
                 .layer_count = 1,
                 .mip = i,
                 .mip_count = 1,
@@ -118,7 +118,7 @@ void Blitter::generate_mips(CommandEncoder* command_encoder, Texture* texture, u
         });
         ref<TextureView> dst = texture->create_view({
             .subresource_range{
-                .layer = array_layer,
+                .layer = layer,
                 .layer_count = 1,
                 .mip = i + 1,
                 .mip_count = 1,

--- a/src/sgl/device/blit.h
+++ b/src/sgl/device/blit.h
@@ -58,9 +58,9 @@ public:
      *
      * \param command_encoder Command encoder.
      * \param texture Texture to generate mipmaps for.
-     * \param array_layer Array layer to generate mipmaps for.
+     * \param layer Array layer to generate mipmaps for.
      */
-    void generate_mips(CommandEncoder* command_encoder, Texture* texture, uint32_t array_layer = 0);
+    void generate_mips(CommandEncoder* command_encoder, Texture* texture, uint32_t layer = 0);
 
 private:
     enum class TextureDataType {

--- a/src/sgl/device/command.cpp
+++ b/src/sgl/device/command.cpp
@@ -644,6 +644,14 @@ void CommandEncoder::blit(Texture* dst, Texture* src, TextureFilteringMode filte
     m_device->_blitter()->blit(this, dst, src, filter);
 }
 
+void CommandEncoder::generate_mips(Texture* texture, uint32_t layer)
+{
+    SGL_CHECK(m_open, "Command encoder is finished");
+    SGL_CHECK_NOT_NULL(texture);
+    SGL_CHECK(layer < texture->layer_count(), "Layer index out of bounds");
+    m_device->_blitter()->generate_mips(this, texture, layer);
+}
+
 void CommandEncoder::resolve_query(
     QueryPool* query_pool,
     uint32_t index,

--- a/src/sgl/device/command.h
+++ b/src/sgl/device/command.h
@@ -316,6 +316,8 @@ public:
      */
     void blit(Texture* dst, Texture* src, TextureFilteringMode filter = TextureFilteringMode::linear);
 
+    void generate_mips(Texture* texture, uint32_t layer = 0);
+
     void resolve_query(QueryPool* query_pool, uint32_t index, uint32_t count, Buffer* buffer, DeviceOffset offset);
 
     void build_acceleration_structure(

--- a/src/slangpy_ext/device/command.cpp
+++ b/src/slangpy_ext/device/command.cpp
@@ -450,6 +450,13 @@ SGL_PY_EXPORT(device_command)
             D(CommandEncoder, blit, 2)
         )
         .def(
+            "generate_mips",
+            &CommandEncoder::generate_mips,
+            "texture"_a,
+            "layer"_a = 0,
+            D_NA(CommandEncoder, generate_mips)
+        )
+        .def(
             "resolve_query",
             &CommandEncoder::resolve_query,
             "query_pool"_a,


### PR DESCRIPTION
- Add `CommandEncoder::generate_mips`.
- Rename `array_layer` argument to `layer`.