### PR TITLE
Refactored common cursors setters and getters

### DIFF
--- a/slangpy/tests/device/test_buffer_cursor.py
+++ b/slangpy/tests/device/test_buffer_cursor.py
@@ -346,7 +346,7 @@ def test_cursor_read_write(device_type: spy.DeviceType, seed: int):
     (kernel, resource_type_layout) = make_fill_in_module(device_type, tests)
 
     # Create a buffer cursor with its own data
-    cursor = spy.BufferCursor(resource_type_layout.element_type_layout, 1)
+    cursor = spy.BufferCursor(device_type, resource_type_layout.element_type_layout, 1)
 
     # Populate the first element
     element = cursor[0]
@@ -355,7 +355,7 @@ def test_cursor_read_write(device_type: spy.DeviceType, seed: int):
         element[name] = value
 
     # Create new cursor by copying the first, and read element
-    cursor2 = spy.BufferCursor(resource_type_layout.element_type_layout, 1)
+    cursor2 = spy.BufferCursor(device_type, resource_type_layout.element_type_layout, 1)
     cursor2.copy_from_numpy(cursor.to_numpy())
     element2 = cursor2[0]
 
@@ -389,7 +389,7 @@ def test_fill_from_kernel(device_type: spy.DeviceType, seed: int):
     kernel.dispatch([count, 1, 1], buffer=buffer)
 
     # Create a cursor and read the buffer by copying its data
-    cursor = spy.BufferCursor(resource_type_layout.element_type_layout, count)
+    cursor = spy.BufferCursor(device_type, resource_type_layout.element_type_layout, count)
     cursor.copy_from_numpy(buffer.to_numpy())
 
     # Verify data matches
@@ -453,7 +453,7 @@ def test_cursor_lifetime(device_type: spy.DeviceType):
     (kernel, resource_type_layout) = make_fill_in_module(device_type, get_tests(device_type))
 
     # Create a buffer cursor with its own data
-    cursor = spy.BufferCursor(resource_type_layout.element_type_layout, 1)
+    cursor = spy.BufferCursor(device_type, resource_type_layout.element_type_layout, 1)
 
     # Get element
     element = cursor[0]

--- a/src/sgl/device/buffer_cursor.cpp
+++ b/src/sgl/device/buffer_cursor.cpp
@@ -115,6 +115,11 @@ void BufferElementCursor::set_data(const void* data, size_t size)
     write_data(m_offset, data, size);
 }
 
+DeviceType BufferElementCursor::_get_device_type() const
+{
+    return m_buffer->get_device_type();
+}
+
 // Explicit instantiation of the methods
 template void
 CursorWriteWrappers<BufferElementCursor, size_t>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
@@ -305,16 +310,18 @@ void BufferElementCursor::read_data(size_t offset, void* data, size_t size) cons
     m_buffer->read_data(offset, data, size);
 }
 
-BufferCursor::BufferCursor(ref<TypeLayoutReflection> element_layout, void* data, size_t size)
+BufferCursor::BufferCursor(DeviceType device_type, ref<TypeLayoutReflection> element_layout, void* data, size_t size)
     : m_element_type_layout(std::move(element_layout))
+    , m_device_type(device_type)
     , m_buffer((uint8_t*)data)
     , m_size(size)
     , m_owner(false)
 {
 }
 
-BufferCursor::BufferCursor(ref<TypeLayoutReflection> element_layout, size_t element_count)
+BufferCursor::BufferCursor(DeviceType device_type, ref<TypeLayoutReflection> element_layout, size_t element_count)
     : m_element_type_layout(std::move(element_layout))
+    , m_device_type(device_type)
 {
     m_size = element_count * m_element_type_layout->stride();
     m_buffer = new uint8_t[m_size];
@@ -323,6 +330,7 @@ BufferCursor::BufferCursor(ref<TypeLayoutReflection> element_layout, size_t elem
 
 BufferCursor::BufferCursor(ref<TypeLayoutReflection> element_layout, ref<Buffer> resource, bool load_before_write)
     : m_element_type_layout(std::move(element_layout))
+    , m_device_type(resource->device()->type())
 {
     m_resource = std::move(resource);
     m_size = m_resource->size();

--- a/src/sgl/device/buffer_cursor.cpp
+++ b/src/sgl/device/buffer_cursor.cpp
@@ -115,125 +115,10 @@ void BufferElementCursor::set_data(const void* data, size_t size)
     write_data(m_offset, data, size);
 }
 
-void BufferElementCursor::_set_array(
-    const void* data,
-    size_t size,
-    TypeReflection::ScalarType scalar_type,
-    size_t element_count
-)
-{
-    ref<const TypeReflection> element_type = m_type_layout->unwrap_array()->type();
-    size_t element_size = cursor_utils::get_scalar_type_size(element_type->scalar_type());
-
-    cursor_utils::check_array(m_type_layout->slang_target(), size, scalar_type, element_count);
-
-    size_t stride = m_type_layout->element_stride();
-    if (element_size == stride) {
-        write_data(m_offset, data, size);
-    } else {
-        size_t offset = m_offset;
-        for (size_t i = 0; i < element_count; ++i) {
-            write_data(offset, reinterpret_cast<const uint8_t*>(data) + i * element_size, element_size);
-            offset += stride;
-        }
-    }
-}
-
-void BufferElementCursor::_get_array(
-    void* data,
-    size_t size,
-    TypeReflection::ScalarType scalar_type,
-    size_t element_count
-) const
-{
-    ref<const TypeReflection> element_type = m_type_layout->unwrap_array()->type();
-    size_t element_size = cursor_utils::get_scalar_type_size(element_type->scalar_type());
-
-    cursor_utils::check_array(m_type_layout->slang_target(), size, scalar_type, element_count);
-
-    size_t stride = m_type_layout->element_stride();
-    if (element_size == stride) {
-        read_data(m_offset, data, size);
-    } else {
-        size_t offset = m_offset;
-        for (size_t i = 0; i < element_count; ++i) {
-            read_data(offset, reinterpret_cast<uint8_t*>(data) + i * element_size, element_size);
-            offset += stride;
-        }
-    }
-}
-void BufferElementCursor::_set_scalar(const void* data, size_t size, TypeReflection::ScalarType scalar_type)
-{
-    cursor_utils::check_scalar(m_type_layout->slang_target(), size, scalar_type);
-    write_data(m_offset, data, size);
-}
-
-void BufferElementCursor::_get_scalar(void* data, size_t size, TypeReflection::ScalarType scalar_type) const
-{
-    cursor_utils::check_scalar(m_type_layout->slang_target(), size, scalar_type);
-    read_data(m_offset, data, size);
-}
-
-void BufferElementCursor::_set_vector(
-    const void* data,
-    size_t size,
-    TypeReflection::ScalarType scalar_type,
-    int dimension
-)
-{
-    cursor_utils::check_vector(m_type_layout->slang_target(), size, scalar_type, dimension);
-    write_data(m_offset, data, size);
-}
-
-void BufferElementCursor::_get_vector(void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension)
-    const
-{
-    cursor_utils::check_vector(m_type_layout->slang_target(), size, scalar_type, dimension);
-    read_data(m_offset, data, size);
-}
-
-void BufferElementCursor::_set_matrix(
-    const void* data,
-    size_t size,
-    TypeReflection::ScalarType scalar_type,
-    int rows,
-    int cols
-)
-{
-    cursor_utils::check_matrix(m_type_layout->slang_target(), size, scalar_type, rows, cols);
-    size_t stride = slang_type_layout()->getStride();
-    if (stride != size) {
-        size_t row_stride = stride / rows;
-        size_t row_size = size / rows;
-        for (int i = 0; i < rows; ++i) {
-            write_data(m_offset + i * row_stride, reinterpret_cast<const uint8_t*>(data) + i * row_size, row_size);
-        }
-    } else {
-        write_data(m_offset, data, size);
-    }
-}
-
-void BufferElementCursor::_get_matrix(
-    void* data,
-    size_t size,
-    TypeReflection::ScalarType scalar_type,
-    int rows,
-    int cols
-) const
-{
-    cursor_utils::check_matrix(m_type_layout->slang_target(), size, scalar_type, rows, cols);
-    size_t stride = slang_type_layout()->getStride();
-    if (stride != size) {
-        size_t row_stride = stride / rows;
-        size_t row_size = size / rows;
-        for (int i = 0; i < rows; ++i) {
-            read_data(m_offset + i * row_stride, reinterpret_cast<uint8_t*>(data) + i * row_size, row_size);
-        }
-    } else {
-        read_data(m_offset, data, size);
-    }
-}
-
+// Explicit instantiation of the method
+template void
+CursorWriteWrappers<BufferElementCursor, size_t>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
+    const;
 
 //
 // Setter specializations
@@ -339,106 +224,59 @@ GETSET_SCALAR(double, float64);
 template<>
 SGL_API void BufferElementCursor::set(const bool& value)
 {
-    uint v = value ? 1 : 0;
-    _set_scalar(&v, sizeof(v), TypeReflection::ScalarType::bool_);
+    _set_bool(value);
 }
 template<>
 SGL_API void BufferElementCursor::get(bool& value) const
 {
-    uint v;
-    _get_scalar(&v, sizeof(v), TypeReflection::ScalarType::bool_);
-    value = v != 0;
+    _get_bool(value);
 }
 
 template<>
 SGL_API void BufferElementCursor::set(const bool1& value)
 {
-#if SGL_MACOS
-    bool1 v = value;
-#else
-    uint1 v(value.x ? 1 : 0);
-#endif
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 1);
+    _set_boolN(value);
 }
 template<>
 SGL_API void BufferElementCursor::get(bool1& value) const
 {
-#if SGL_MACOS
-    bool1 v;
-#else
-    uint1 v;
-#endif
-    _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 1);
-    value = bool1(v.x != 0);
+    _get_boolN(value);
 }
 
 template<>
 SGL_API void BufferElementCursor::set(const bool2& value)
 {
-#if SGL_MACOS
-    bool2 v = value;
-#else
-    uint2 v = {value.x ? 1 : 0, value.y ? 1 : 0};
-#endif
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 2);
+    _set_boolN(value);
 }
 
 template<>
 SGL_API void BufferElementCursor::get(bool2& value) const
 {
-#if SGL_MACOS
-    bool2 v;
-#else
-    uint2 v;
-#endif
-    _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 2);
-    value = {v.x != 0, v.y != 0};
+    _get_boolN(value);
 }
 
 template<>
 SGL_API void BufferElementCursor::set(const bool3& value)
 {
-#if SGL_MACOS
-    bool3 v = value;
-#else
-    uint3 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0};
-#endif
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 3);
+    _set_boolN(value);
 }
 
 template<>
 SGL_API void BufferElementCursor::get(bool3& value) const
 {
-#if SGL_MACOS
-    bool3 v;
-#else
-    uint3 v;
-#endif
-    _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 3);
-    value = {v.x != 0, v.y != 0, v.z != 0};
+    _get_boolN(value);
 }
 
 template<>
 SGL_API void BufferElementCursor::set(const bool4& value)
 {
-#if SGL_MACOS
-    bool4 v = value;
-#else
-    uint4 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0, value.w ? 1 : 0};
-#endif
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 4);
+    _set_boolN(value);
 }
 
 template<>
 SGL_API void BufferElementCursor::get(bool4& value) const
 {
-#if SGL_MACOS
-    bool4 v;
-#else
-    uint4 v;
-#endif
-    _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 4);
-    value = {v.x != 0, v.y != 0, v.z != 0, v.w != 0};
+    _get_boolN(value);
 }
 
 template<>
@@ -453,7 +291,7 @@ SGL_API void BufferElementCursor::get(DescriptorHandle& value) const
     read_data(m_offset, &value.value, sizeof(value.value));
 }
 
-void BufferElementCursor::write_data(size_t offset, const void* data, size_t size)
+void BufferElementCursor::write_data(size_t offset, const void* data, size_t size) const
 {
     m_buffer->write_data(offset, data, size);
 }

--- a/src/sgl/device/buffer_cursor.cpp
+++ b/src/sgl/device/buffer_cursor.cpp
@@ -120,6 +120,10 @@ template void
 CursorWriteWrappers<BufferElementCursor, size_t>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
     const;
 
+template void
+CursorWriteWrappers<BufferElementCursor, size_t>::_set_vector(const void*, size_t, TypeReflection::ScalarType, int)
+    const;
+
 //
 // Setter specializations
 //

--- a/src/sgl/device/buffer_cursor.cpp
+++ b/src/sgl/device/buffer_cursor.cpp
@@ -115,7 +115,7 @@ void BufferElementCursor::set_data(const void* data, size_t size)
     write_data(m_offset, data, size);
 }
 
-// Explicit instantiation of the method
+// Explicit instantiation of the methods
 template void
 CursorWriteWrappers<BufferElementCursor, size_t>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
     const;

--- a/src/sgl/device/buffer_cursor.h
+++ b/src/sgl/device/buffer_cursor.h
@@ -6,6 +6,7 @@
 #include "sgl/device/shader_offset.h"
 #include "sgl/device/reflection.h"
 #include "sgl/device/cursor_utils.h"
+#include "sgl/device/device.h"
 
 #include "sgl/core/config.h"
 #include "sgl/core/macros.h"
@@ -78,6 +79,7 @@ public:
     void _get_data(size_t offset, void* data, size_t size) const { return read_data(offset, data, size); }
     size_t _get_offset() const { return m_offset; }
     static size_t _increment_offset(size_t offset, size_t diff) { return offset + diff; }
+    DeviceType _get_device_type() const;
 
 private:
     void write_data(size_t offset, const void* data, size_t size) const;
@@ -100,10 +102,10 @@ public:
 
     /// Create with none-owning view of specific block of memory. Number of
     /// elements is inferred from the size of the block and the type layout.
-    BufferCursor(ref<TypeLayoutReflection> element_layout, void* data, size_t size);
+    BufferCursor(DeviceType device_type, ref<TypeLayoutReflection> element_layout, void* data, size_t size);
 
     /// Create buffer + allocate space internally for a given number of elements.
-    BufferCursor(ref<TypeLayoutReflection> element_layout, size_t element_count);
+    BufferCursor(DeviceType device_type, ref<TypeLayoutReflection> element_layout, size_t element_count);
 
     /// Create as a view onto a buffer resource. Disable load_before_write to
     /// prevent automatic loading of current buffer state before writing data to it.
@@ -163,9 +165,13 @@ public:
     /// Get the resource this cursor represents (if any).
     ref<Buffer> resource() const { return m_resource; }
 
+    /// Get device type that determines the data layout rules.
+    DeviceType get_device_type() const { return m_device_type; }
+
 private:
     ref<const TypeLayoutReflection> m_element_type_layout;
     ref<Buffer> m_resource;
+    DeviceType m_device_type;
     uint8_t* m_buffer{nullptr};
     size_t m_size{0};
     bool m_owner{false};

--- a/src/sgl/device/buffer_cursor.h
+++ b/src/sgl/device/buffer_cursor.h
@@ -10,13 +10,16 @@
 #include "sgl/core/config.h"
 #include "sgl/core/macros.h"
 
+#include "sgl/device/cursor_access_wrappers.h"
+
 #include <string_view>
 
 namespace sgl {
 
 /// Represents a single element of a given type in a block of memory, and
 /// provides read/write tools to access its members via reflection.
-class SGL_API BufferElementCursor {
+class SGL_API BufferElementCursor : public CursorWriteWrappers<BufferElementCursor, size_t>,
+                                    public CursorReadWrappers<BufferElementCursor, size_t> {
 public:
     BufferElementCursor() = default;
 
@@ -68,20 +71,16 @@ public:
     template<typename T>
     void set(const T& value);
 
-    void _set_array(const void* data, size_t size, TypeReflection::ScalarType scalar_type, size_t element_count);
-    void _set_scalar(const void* data, size_t size, TypeReflection::ScalarType scalar_type);
-    void _set_vector(const void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension);
-    void _set_matrix(const void* data, size_t size, TypeReflection::ScalarType scalar_type, int rows, int cols);
-
-    void _get_array(void* data, size_t size, TypeReflection::ScalarType scalar_type, size_t element_count) const;
-    void _get_scalar(void* data, size_t size, TypeReflection::ScalarType scalar_type) const;
-    void _get_vector(void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension) const;
-    void _get_matrix(void* data, size_t size, TypeReflection::ScalarType scalar_type, int rows, int cols) const;
-
     void _set_offset(size_t new_offset) { m_offset = new_offset; }
 
+    /// CursorWriteWrappers, CursorReadWrappers
+    void _set_data(size_t offset, const void* data, size_t size) const { write_data(offset, data, size); }
+    void _get_data(size_t offset, void* data, size_t size) const { return read_data(offset, data, size); }
+    size_t _get_offset() const { return m_offset; }
+    static size_t _increment_offset(size_t offset, size_t diff) { return offset + diff; }
+
 private:
-    void write_data(size_t offset, const void* data, size_t size);
+    void write_data(size_t offset, const void* data, size_t size) const;
     void read_data(size_t offset, void* data, size_t size) const;
 
     ref<const TypeLayoutReflection> m_type_layout;

--- a/src/sgl/device/cursor_access_wrappers.h
+++ b/src/sgl/device/cursor_access_wrappers.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "sgl/device/fwd.h"
+#include "sgl/device/device.h"
 #include "sgl/device/reflection.h"
 #include "sgl/device/cursor_utils.h"
 
@@ -91,7 +92,7 @@ public:
     void _set_bool(const bool& value) const
     {
 #if SGL_MACOS
-        if (m_shader_object->device()->type() == DeviceType::metal) {
+        if (_get_device_type_internal == DeviceType::metal) {
             _set_scalar(&value, sizeof(value), TypeReflection::ScalarType::bool_);
             return;
         }
@@ -104,7 +105,7 @@ public:
     void _set_boolN(const sgl::math::vector<bool, N>& value) const
     {
 #if SGL_MACOS
-        if (m_shader_object->device()->type() == DeviceType::metal) {
+        if (_get_device_type_internal == DeviceType::metal) {
             _set_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, 1);
             return;
         }
@@ -135,6 +136,8 @@ private:
     {
         return static_cast<const BaseCursor*>(this)->slang_type_layout();
     }
+
+    DeviceType _get_device_type_internal() const { return static_cast<const BaseCursor*>(this)->_get_device_type(); }
 };
 
 template<typename BaseCursor, typename TOffset>
@@ -193,7 +196,7 @@ public:
     void _get_bool(bool& value) const
     {
 #if SGL_MACOS
-        if (m_shader_object->device()->type() == DeviceType::metal) {
+        if (_get_device_type_internal == DeviceType::metal) {
             _get_scalar(&value, sizeof(value), TypeReflection::ScalarType::bool_);
             return;
         }
@@ -207,8 +210,8 @@ public:
     void _get_boolN(sgl::math::vector<bool, N>& value) const
     {
 #if SGL_MACOS
-        if (m_shader_object->device()->type() == DeviceType::metal) {
-            _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, N);
+        if (_get_device_type_internal == DeviceType::metal) {
+            _get_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, N);
             return;
         }
 #endif
@@ -237,6 +240,8 @@ private:
     {
         return static_cast<const BaseCursor*>(this)->slang_type_layout();
     }
+
+    DeviceType _get_device_type_internal() const { return static_cast<const BaseCursor*>(this)->_get_device_type(); }
 };
 
 

--- a/src/sgl/device/cursor_access_wrappers.h
+++ b/src/sgl/device/cursor_access_wrappers.h
@@ -92,7 +92,7 @@ public:
     void _set_bool(const bool& value) const
     {
 #if SGL_MACOS
-        if (_get_device_type_internal == DeviceType::metal) {
+        if (_get_device_type_internal() == DeviceType::metal) {
             _set_scalar(&value, sizeof(value), TypeReflection::ScalarType::bool_);
             return;
         }
@@ -105,7 +105,7 @@ public:
     void _set_boolN(const sgl::math::vector<bool, N>& value) const
     {
 #if SGL_MACOS
-        if (_get_device_type_internal == DeviceType::metal) {
+        if (_get_device_type_internal() == DeviceType::metal) {
             _set_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, 1);
             return;
         }
@@ -196,7 +196,7 @@ public:
     void _get_bool(bool& value) const
     {
 #if SGL_MACOS
-        if (_get_device_type_internal == DeviceType::metal) {
+        if (_get_device_type_internal() == DeviceType::metal) {
             _get_scalar(&value, sizeof(value), TypeReflection::ScalarType::bool_);
             return;
         }
@@ -210,7 +210,7 @@ public:
     void _get_boolN(sgl::math::vector<bool, N>& value) const
     {
 #if SGL_MACOS
-        if (_get_device_type_internal == DeviceType::metal) {
+        if (_get_device_type_internal() == DeviceType::metal) {
             _get_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, N);
             return;
         }

--- a/src/sgl/device/cursor_access_wrappers.h
+++ b/src/sgl/device/cursor_access_wrappers.h
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "sgl/device/fwd.h"
+#include "sgl/device/reflection.h"
+#include "sgl/device/cursor_utils.h"
+
+// TODO: Decide if we want to disable / optimize type checks
+// currently can represent 50% of the cost of writes in
+// certain situations.
+#define SGL_ENABLE_CURSOR_TYPE_CHECKS
+
+namespace sgl {
+
+template<typename TOffset, typename BaseCursor>
+class SGL_API CursorWriteWrappers {
+    using BaseCursorOffset = TOffset;
+
+public:
+    void _set_array(const void* data, size_t size, TypeReflection::ScalarType scalar_type, size_t element_count) const
+    {
+        slang::TypeReflection* element_type = cursor_utils::unwrap_array(_get_slang_type_layout())->getType();
+        size_t element_size
+            = cursor_utils::get_scalar_type_size((TypeReflection::ScalarType)element_type->getScalarType());
+
+#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
+        cursor_utils::check_array(_get_slang_type_layout(), size, scalar_type, element_count);
+#else
+        SGL_UNUSED(scalar_type);
+        SGL_UNUSED(element_count);
+#endif
+
+        size_t stride = _get_slang_type_layout()->getElementStride(SLANG_PARAMETER_CATEGORY_UNIFORM);
+        if (element_size == stride) {
+            _set_data_internal(_get_offset_internal(), data, size);
+        } else {
+            auto offset = _get_offset_internal();
+            for (size_t i = 0; i < element_count; ++i) {
+                _set_data_internal(offset, reinterpret_cast<const uint8_t*>(data) + i * element_size, element_size);
+                offset = _increment_offset_internal(offset, stride);
+            }
+        }
+    }
+
+    void _set_scalar(const void* data, size_t size, TypeReflection::ScalarType scalar_type) const
+    {
+#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
+        cursor_utils::check_scalar(_get_slang_type_layout(), size, scalar_type);
+#else
+        SGL_UNUSED(scalar_type);
+#endif
+        _set_data_internal(_get_offset_internal(), data, size);
+    }
+
+    void _set_vector(const void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension) const
+    {
+#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
+        cursor_utils::check_vector(_get_slang_type_layout(), size, scalar_type, dimension);
+#else
+        SGL_UNUSED(scalar_type);
+        SGL_UNUSED(dimension);
+#endif
+        _set_data_internal(_get_offset_internal(), data, size);
+    }
+
+    void _set_matrix(const void* data, size_t size, TypeReflection::ScalarType scalar_type, int rows, int cols) const
+    {
+#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
+        cursor_utils::check_matrix(_get_slang_type_layout(), size, scalar_type, rows, cols);
+#else
+        SGL_UNUSED(scalar_type);
+        SGL_UNUSED(cols);
+#endif
+
+        if (rows > 1) {
+            size_t mat_stride = _get_slang_type_layout()->getStride();
+            size_t row_stride = mat_stride / rows;
+
+            size_t row_size = size / rows;
+            auto offset = _get_offset_internal();
+            for (int row = 0; row < rows; ++row) {
+                _set_data_internal(
+                    _get_offset_internal(),
+                    reinterpret_cast<const uint8_t*>(data) + row * row_size,
+                    row_size
+                );
+                offset = _increment_offset_internal(offset, row_stride);
+            }
+        } else {
+            _set_data_internal(_get_offset_internal(), data, size);
+        }
+    }
+
+private:
+    void _set_data_internal(BaseCursorOffset offset, const void* data, size_t size) const
+    {
+        static_cast<const BaseCursor*>(this)->_set_data(offset, data, size);
+    }
+
+    BaseCursorOffset _get_offset_internal() const { return static_cast<const BaseCursor*>(this)->_get_offset(); }
+    BaseCursorOffset _increment_offset_internal(BaseCursorOffset offset, size_t diff) const
+    {
+        return BaseCursor::_increment_offset(offset, diff);
+    }
+
+    slang::TypeLayoutReflection* _get_slang_type_layout() const
+    {
+        return static_cast<const BaseCursor*>(this)->slang_type_layout();
+    }
+};
+
+template<typename TOffset, typename BaseCursor>
+class SGL_API CursorReadWrappers {
+    using BaseCursorOffset = TOffset;
+
+public:
+    void _get_array(void* data, size_t size, TypeReflection::ScalarType scalar_type, size_t element_count) const
+    {
+        ref<const TypeReflection> element_type = _get_slang_type_layout()->unwrap_array()->type();
+        size_t element_size = cursor_utils::get_scalar_type_size(element_type->scalar_type());
+
+        cursor_utils::check_array(_get_slang_type_layout()->slang_target(), size, scalar_type, element_count);
+
+        size_t stride = _get_slang_type_layout()->element_stride();
+        if (element_size == stride) {
+            _get_data_internal(_get_offset_internal(), data, size);
+        } else {
+            auto offset = _get_offset_internal();
+            for (size_t i = 0; i < element_count; ++i) {
+                read_data(offset, reinterpret_cast<uint8_t*>(data) + i * element_size, element_size);
+                offset = _increment_offset_internal(offset, stride);
+            }
+        }
+    }
+
+    void _get_scalar(void* data, size_t size, TypeReflection::ScalarType scalar_type) const
+    {
+        cursor_utils::check_scalar(_get_slang_type_layout(), size, scalar_type);
+        _get_data_internal(_get_offset_internal(), data, size);
+    }
+
+    void _get_vector(void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension) const
+    {
+        cursor_utils::check_vector(_get_slang_type_layout(), size, scalar_type, dimension);
+        _get_data_internal(_get_offset_internal(), data, size);
+    }
+
+    void _get_matrix(void* data, size_t size, TypeReflection::ScalarType scalar_type, int rows, int cols) const
+    {
+        cursor_utils::check_matrix(_get_slang_type_layout(), size, scalar_type, rows, cols);
+        size_t stride = _get_slang_type_layout()->getStride();
+        if (stride != size) {
+            size_t row_stride = stride / rows;
+            size_t row_size = size / rows;
+            auto offset = _get_offset_internal();
+            for (int i = 0; i < rows; ++i) {
+                _get_data_internal(offset, reinterpret_cast<uint8_t*>(data) + i * row_size, row_size);
+                offset = _increment_offset_internal(offset, row_stride);
+            }
+        } else {
+            _get_data_internal(_get_offset_internal(), data, size);
+        }
+    }
+
+private:
+    void _get_data_internal(BaseCursorOffset offset, void* data, size_t size) const
+    {
+        static_cast<const BaseCursor*>(this)->_get_data(offset, data, size);
+    }
+
+    BaseCursorOffset _get_offset_internal() const { return static_cast<const BaseCursor*>(this)->_get_offset(); }
+    BaseCursorOffset _increment_offset_internal(BaseCursorOffset offset, size_t diff) const
+    {
+        return BaseCursor::_increment_offset(offset, diff);
+    }
+
+    slang::TypeLayoutReflection* _get_slang_type_layout() const
+    {
+        return static_cast<const BaseCursor*>(this)->slang_type_layout();
+    }
+};
+
+
+} // namespace sgl

--- a/src/sgl/device/cursor_access_wrappers.h
+++ b/src/sgl/device/cursor_access_wrappers.h
@@ -116,6 +116,9 @@ public:
         _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, N);
     }
 
+protected:
+    CursorWriteWrappers() = default;
+
 private:
     void _set_data_internal(BaseCursorOffset offset, const void* data, size_t size) const
     {
@@ -214,6 +217,9 @@ public:
         for (int i = 0; i < N; ++i)
             value[i] = (v[i] != 0);
     }
+
+protected:
+    CursorReadWrappers() = default;
 
 private:
     void _get_data_internal(BaseCursorOffset offset, void* data, size_t size) const

--- a/src/sgl/device/cursor_utils.h
+++ b/src/sgl/device/cursor_utils.h
@@ -10,28 +10,28 @@
 namespace sgl {
 
 namespace cursor_utils {
-    size_t SGL_API get_scalar_type_size(TypeReflection::ScalarType type);
+    SGL_API size_t get_scalar_type_size(TypeReflection::ScalarType type);
 
-    slang::TypeLayoutReflection* SGL_API unwrap_array(slang::TypeLayoutReflection* layout);
+    SGL_API slang::TypeLayoutReflection* unwrap_array(slang::TypeLayoutReflection* layout);
 
-    void SGL_API check_array(
+    SGL_API void check_array(
         slang::TypeLayoutReflection* type_layout,
         size_t size,
         TypeReflection::ScalarType scalar_type,
         size_t element_count
     );
 
-    void SGL_API
+    SGL_API void
     check_scalar(slang::TypeLayoutReflection* type_layout, size_t size, TypeReflection::ScalarType scalar_type);
 
-    void SGL_API check_vector(
+    SGL_API void check_vector(
         slang::TypeLayoutReflection* type_layout,
         size_t size,
         TypeReflection::ScalarType scalar_type,
         int dimension
     );
 
-    void SGL_API check_matrix(
+    SGL_API void check_matrix(
         slang::TypeLayoutReflection* type_layout,
         size_t size,
         TypeReflection::ScalarType scalar_type,

--- a/src/sgl/device/cursor_utils.h
+++ b/src/sgl/device/cursor_utils.h
@@ -5,30 +5,33 @@
 #include "sgl/device/fwd.h"
 #include "sgl/device/reflection.h"
 
+#include "sgl/core/macros.h"
+
 namespace sgl {
 
 namespace cursor_utils {
-    size_t get_scalar_type_size(TypeReflection::ScalarType type);
+    size_t SGL_API get_scalar_type_size(TypeReflection::ScalarType type);
 
-    slang::TypeLayoutReflection* unwrap_array(slang::TypeLayoutReflection* layout);
+    slang::TypeLayoutReflection* SGL_API unwrap_array(slang::TypeLayoutReflection* layout);
 
-    void check_array(
+    void SGL_API check_array(
         slang::TypeLayoutReflection* type_layout,
         size_t size,
         TypeReflection::ScalarType scalar_type,
         size_t element_count
     );
 
-    void check_scalar(slang::TypeLayoutReflection* type_layout, size_t size, TypeReflection::ScalarType scalar_type);
+    void SGL_API
+    check_scalar(slang::TypeLayoutReflection* type_layout, size_t size, TypeReflection::ScalarType scalar_type);
 
-    void check_vector(
+    void SGL_API check_vector(
         slang::TypeLayoutReflection* type_layout,
         size_t size,
         TypeReflection::ScalarType scalar_type,
         int dimension
     );
 
-    void check_matrix(
+    void SGL_API check_matrix(
         slang::TypeLayoutReflection* type_layout,
         size_t size,
         TypeReflection::ScalarType scalar_type,

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -492,35 +492,6 @@ void ShaderCursor::set_pointer(uint64_t pointer_value) const
     set_data(&pointer_value, 8);
 }
 
-void ShaderCursor::_set_array(
-    const void* data,
-    size_t size,
-    TypeReflection::ScalarType scalar_type,
-    size_t element_count
-) const
-{
-    slang::TypeReflection* element_type = cursor_utils::unwrap_array(m_type_layout)->getType();
-    size_t element_size = cursor_utils::get_scalar_type_size((TypeReflection::ScalarType)element_type->getScalarType());
-
-#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
-    cursor_utils::check_array(m_type_layout, size, scalar_type, element_count);
-#else
-    SGL_UNUSED(scalar_type);
-    SGL_UNUSED(element_count);
-#endif
-
-    size_t stride = m_type_layout->getElementStride(SLANG_PARAMETER_CATEGORY_UNIFORM);
-    if (element_size == stride) {
-        m_shader_object->set_data(m_offset, data, size);
-    } else {
-        ShaderOffset offset = m_offset;
-        for (size_t i = 0; i < element_count; ++i) {
-            m_shader_object->set_data(offset, reinterpret_cast<const uint8_t*>(data) + i * element_size, element_size);
-            offset.uniform_offset += narrow_cast<uint32_t>(stride);
-        }
-    }
-}
-
 void ShaderCursor::_set_array_unsafe(const void* data, size_t size, size_t element_count) const
 {
     slang::TypeReflection* element_type = cursor_utils::unwrap_array(m_type_layout)->getType();
@@ -538,57 +509,14 @@ void ShaderCursor::_set_array_unsafe(const void* data, size_t size, size_t eleme
     }
 }
 
-void ShaderCursor::_set_scalar(const void* data, size_t size, TypeReflection::ScalarType scalar_type) const
+void ShaderCursor::_set_data(ShaderOffset offset, const void* data, size_t size) const
 {
-#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
-    cursor_utils::check_scalar(m_type_layout, size, scalar_type);
-#else
-    SGL_UNUSED(scalar_type);
-#endif
-    m_shader_object->set_data(m_offset, data, size);
+    m_shader_object->set_data(offset, data, size);
 }
 
-void ShaderCursor::_set_vector(const void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension)
-    const
-{
-#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
-    cursor_utils::check_vector(m_type_layout, size, scalar_type, dimension);
-#else
-    SGL_UNUSED(scalar_type);
-    SGL_UNUSED(dimension);
-#endif
-    m_shader_object->set_data(m_offset, data, size);
-}
-
-void ShaderCursor::_set_matrix(
-    const void* data,
-    size_t size,
-    TypeReflection::ScalarType scalar_type,
-    int rows,
-    int cols
-) const
-{
-#ifdef SGL_ENABLE_CURSOR_TYPE_CHECKS
-    cursor_utils::check_matrix(m_type_layout, size, scalar_type, rows, cols);
-#else
-    SGL_UNUSED(scalar_type);
-    SGL_UNUSED(cols);
-#endif
-
-    if (rows > 1) {
-        size_t mat_stride = m_type_layout->getStride();
-        size_t row_stride = mat_stride / rows;
-
-        size_t row_size = size / rows;
-        ShaderOffset offset = m_offset;
-        for (int row = 0; row < rows; ++row) {
-            m_shader_object->set_data(offset, reinterpret_cast<const uint8_t*>(data) + row * row_size, row_size);
-            offset.uniform_offset += narrow_cast<uint32_t>(row_stride);
-        }
-    } else {
-        m_shader_object->set_data(m_offset, data, size);
-    }
-}
+template void
+CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
+    const;
 
 //
 // Setter specializations
@@ -727,66 +655,31 @@ SET_SCALAR(double, float64);
 template<>
 SGL_API void ShaderCursor::set(const bool& value) const
 {
-#if SGL_MACOS
-    if (m_shader_object->device()->type() == DeviceType::metal) {
-        _set_scalar(&value, sizeof(value), TypeReflection::ScalarType::bool_);
-        return;
-    }
-#endif
-    uint v = value ? 1 : 0;
-    _set_scalar(&v, sizeof(v), TypeReflection::ScalarType::bool_);
+    _set_bool(value);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool1& value) const
 {
-#if SGL_MACOS
-    if (m_shader_object->device()->type() == DeviceType::metal) {
-        _set_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, 1);
-        return;
-    }
-#endif
-    uint1 v(value.x ? 1 : 0);
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 1);
+    _set_boolN(value);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool2& value) const
 {
-#if SGL_MACOS
-    if (m_shader_object->device()->type() == DeviceType::metal) {
-        _set_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, 2);
-        return;
-    }
-#endif
-    uint2 v = {value.x ? 1 : 0, value.y ? 1 : 0};
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 2);
+    _set_boolN(value);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool3& value) const
 {
-#if SGL_MACOS
-    if (m_shader_object->device()->type() == DeviceType::metal) {
-        _set_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, 3);
-        return;
-    }
-#endif
-    uint3 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0};
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 3);
+    _set_boolN(value);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool4& value) const
 {
-#if SGL_MACOS
-    if (m_shader_object->device()->type() == DeviceType::metal) {
-        _set_vector(&value, sizeof(value), TypeReflection::ScalarType::bool_, 4);
-        return;
-    }
-#endif
-    uint4 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0, value.w ? 1 : 0};
-    _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 4);
+    _set_boolN(value);
 }
 
 } // namespace sgl

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -514,6 +514,11 @@ void ShaderCursor::_set_data(ShaderOffset offset, const void* data, size_t size)
     m_shader_object->set_data(offset, data, size);
 }
 
+DeviceType ShaderCursor::_get_device_type() const
+{
+    return m_shader_object->device()->type();
+}
+
 // Explicit instantiation of the methods
 template void
 CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -514,8 +514,13 @@ void ShaderCursor::_set_data(ShaderOffset offset, const void* data, size_t size)
     m_shader_object->set_data(offset, data, size);
 }
 
+// Explicit instantiation of the methods
 template void
 CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
+    const;
+
+template void
+CursorWriteWrappers<BufferElementCursor, size_t>::_set_vector(const void*, size_t, TypeReflection::ScalarType, int)
     const;
 
 //

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -520,7 +520,7 @@ CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_array(const void*, size_t,
     const;
 
 template void
-CursorWriteWrappers<BufferElementCursor, size_t>::_set_vector(const void*, size_t, TypeReflection::ScalarType, int)
+CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_vector(const void*, size_t, TypeReflection::ScalarType, int)
     const;
 
 //

--- a/src/sgl/device/shader_cursor.h
+++ b/src/sgl/device/shader_cursor.h
@@ -96,6 +96,7 @@ public:
         offset.uniform_offset += narrow_cast<uint32_t>(diff);
         return offset;
     }
+    DeviceType _get_device_type() const;
 
 private:
     slang::TypeLayoutReflection* m_type_layout;

--- a/src/sgl/device/shader_cursor.h
+++ b/src/sgl/device/shader_cursor.h
@@ -10,6 +10,8 @@
 #include "sgl/core/config.h"
 #include "sgl/core/macros.h"
 
+#include "sgl/device/cursor_access_wrappers.h"
+
 #include <string_view>
 
 namespace sgl {
@@ -19,7 +21,7 @@ namespace sgl {
 /// allocating/freeing them repeatedly. This is far faster, however does introduce
 /// a risk of mem access problems if the shader cursor is kept alive longer than
 /// the shader object it was created from.
-class SGL_API ShaderCursor {
+class SGL_API ShaderCursor : public CursorWriteWrappers<ShaderCursor, ShaderOffset> {
 public:
     ShaderCursor() = default;
 
@@ -84,12 +86,16 @@ public:
     template<typename T>
     void set(const T& value) const;
 
-    void _set_array(const void* data, size_t size, TypeReflection::ScalarType scalar_type, size_t element_count) const;
     void _set_array_unsafe(const void* data, size_t size, size_t element_count) const;
 
-    void _set_scalar(const void* data, size_t size, TypeReflection::ScalarType scalar_type) const;
-    void _set_vector(const void* data, size_t size, TypeReflection::ScalarType scalar_type, int dimension) const;
-    void _set_matrix(const void* data, size_t size, TypeReflection::ScalarType scalar_type, int rows, int cols) const;
+    /// CursorWriteWrappers, CursorReadWrappers
+    void _set_data(ShaderOffset offset, const void* data, size_t size) const;
+    ShaderOffset _get_offset() const { return m_offset; }
+    static ShaderOffset _increment_offset(ShaderOffset offset, size_t diff)
+    {
+        offset.uniform_offset += narrow_cast<uint32_t>(diff);
+        return offset;
+    }
 
 private:
     slang::TypeLayoutReflection* m_type_layout;

--- a/src/slangpy_ext/device/buffer_cursor.cpp
+++ b/src/slangpy_ext/device/buffer_cursor.cpp
@@ -76,7 +76,13 @@ SGL_PY_EXPORT(device_buffer_cursor)
 
     // Interface to simpler root cursor object that maps to the larger buffer.
     nb::class_<BufferCursor, Object>(m, "BufferCursor", D(BufferCursor)) //
-        .def(nb::init<ref<TypeLayoutReflection>, size_t>(), "element_layout"_a, "size"_a, D(BufferCursor, BufferCursor))
+        .def(
+            nb::init<DeviceType, ref<TypeLayoutReflection>, size_t>(),
+            "device_type"_a,
+            "element_layout"_a,
+            "size"_a,
+            D(BufferCursor, BufferCursor)
+        )
         .def(
             nb::init<ref<TypeLayoutReflection>, ref<Buffer>, bool>(),
             "element_layout"_a,


### PR DESCRIPTION
- BufferElementCursor and ShaderCursor now use CRTP to share the implementation of `_set_scalar`, `_set_array`, `_set_vector`, and `_set_matrix`.
- Also introduced `_set_bool`, `_set_boolN`, `_get_bool` and `_get_boolN` to handle converting between 1B (cpu, cuda, metal) and 4B (d3d12, vulkan, wgpu) bools.