### PR TITLE
CI with latest slang

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -1,0 +1,145 @@
+name: ci-latest-slang
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # run at 1 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows, linux]
+        config: [Debug, Release]
+        python: ["3.10"]
+        include:
+          # Builds running on self-hosted runners
+          - { os: windows, platform: x86_64, compiler: msvc, config: Debug, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Windows, X64] } }
+          - { os: windows, platform: x86_64, compiler: msvc, config: Release, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Windows, X64] } }
+          - { os: linux, platform: x86_64, compiler: gcc, config: Debug, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Linux, X64] } }
+          - { os: linux, platform: x86_64, compiler: gcc, config: Release, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Linux, X64] } }
+
+    env:
+      # Environment variables used by ci.py
+      CI_OS: ${{ matrix.os }}
+      CI_PLATFORM: ${{ matrix.platform }}
+      CI_COMPILER: ${{ matrix.compiler }}
+      CI_CONFIG: ${{ matrix.config }}
+      CI_PYTHON: ${{ matrix.python }}
+      CI_FLAGS: ${{ matrix.flags }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Cleanup submodules # Fix for https://github.com/actions/checkout/issues/358
+        run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
+
+      # Setup Linux.
+      - name: Setup Linux
+        if: startsWith(matrix.os, 'linux') && contains(matrix.runs-on, 'ubuntu-')
+        run: |
+          sudo apt update && sudo apt install -y libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config
+
+      # Setup Python.
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+
+      # Setup Python environment.
+      - name: Setup Python environment
+        run: |
+          python -m pip install -r requirements-dev.txt
+          python -m pip install pytest-github-actions-annotate-failures
+
+      # Setup MSVC.
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      # Setup CMake/Ninja.
+      - name: Setup CMake/Ninja
+        uses: lukka/get-cmake@latest
+
+      # Build latest Slang.
+      - name: Build latest Slang
+        run: |
+          git clone --recursive https://github.com/shader-slang/slang.git
+          cd slang
+          mkdir build
+          cmake -B build --preset default
+          cmake --build build --config ${{ matrix.config }} --parallel
+
+      # Setup.
+      - name: Setup
+        run: python tools/ci.py setup
+
+      # Setup vcpkg caching.
+      # Only run on hosted runners.
+      # For self-hosted runners, we use a local cache directory.
+      - name: Set vcpkg cache directory
+        if: startsWith(matrix.runs-on, 'ubuntu-') || startsWith(matrix.runs-on, 'macos-') || startsWith(matrix.runs-on, 'windows-')
+        run: |
+          echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg-cache" >> $GITHUB_ENV
+          mkdir -p ${{ github.workspace }}/vcpkg-cache
+      - name: Setup vcpkg caching
+        if: startsWith(matrix.runs-on, 'ubuntu-') || startsWith(matrix.runs-on, 'macos-') || startsWith(matrix.runs-on, 'windows-')
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json', 'external/vcpkg-triplets/**') }}
+
+      # Configure.
+      - name: Configure
+        run: python tools/ci.py --cmake-args="-DSGL_LOCAL_SLANG=ON -DSGL_LOCAL_SLANG_DIR=slang -DSGL_LOCAL_SLANG_BUILD_DIR=build/${{ matrix.config }}" configure
+
+      # Build.
+      - name: Build
+        run: python tools/ci.py build
+
+      # Typing Checks (Python)
+      - name: Typing Checks (Python)
+        run: python tools/ci.py typing-check-python
+
+      # Unit Tests (C++)
+      - name: Unit Tests (C++)
+        if: contains(matrix.flags, 'unit-test')
+        run: python tools/ci.py unit-test-cpp
+
+      # Unit Tests (Python)
+      - name: Unit Tests (Python)
+        if: contains(matrix.flags, 'unit-test')
+        run: python tools/ci.py unit-test-python
+
+      # Unit Test Report
+      - name: Unit Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: contains(matrix.flags, 'unit-test')
+        with:
+          report_paths: 'reports/*-junit.xml'
+          check_name: "Unit Test Report"
+
+      # Generate Coverage Report
+      - name: Generate Coverage Report
+        if: contains(matrix.flags, 'coverage')
+        run: python tools/ci.py coverage-report
+
+      # Coverage Report
+      - name: Coverage Report
+        uses: actions/upload-artifact@v4
+        if: contains(matrix.flags, 'coverage')
+        with:
+          name: coverage-report
+          path: reports/coverage.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - "**.md"
       - .github/workflows/wheels.yml
       - .github/workflows/ci-gcp.yml
+      - .github/workflows/ci-latest-slang.yml
   pull_request:
     branches: [main]
     paths-ignore:
@@ -19,6 +20,7 @@ on:
       - "**.md"
       - .github/workflows/wheels.yml
       - .github/workflows/ci-gcp.yml
+      - .github/workflows/ci-latest-slang.yml
   workflow_dispatch:
 
 permissions:

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -138,6 +138,8 @@ def configure(args: Any):
         cmd += " -DSGL_ENABLE_HEADER_VALIDATION=ON"
     if "coverage" in args.flags:
         cmd += " -DSGL_ENABLE_COVERAGE=ON"
+    if args.cmake_args != "":
+        cmd += " " + args.cmake_args
     run_command(cmd)
 
 
@@ -181,6 +183,7 @@ def main():
     parser.add_argument("--config", type=str, action="store", help="Config (Release, Debug)")
     parser.add_argument("--python", type=str, action="store", help="Python version")
     parser.add_argument("--flags", type=str, action="store", help="Additional flags")
+    parser.add_argument("--cmake-args", type=str, action="store", help="Additional CMake arguments")
 
     commands = parser.add_subparsers(dest="command", required=True, help="sub-command help")
 
@@ -210,6 +213,7 @@ def main():
         ("config", "CI_CONFIG", "Debug"),
         ("python", "CI_PYTHON", "3.9"),
         ("flags", "CI_FLAGS", ""),
+        ("cmake_args", "CI_CMAKE_ARGS", ""),
     ]
 
     for var, env_var, default_value in VARS:


### PR DESCRIPTION
Add a new `ci-slang-latest` CI workflow (see https://github.com/shader-slang/slangpy/actions/workflows/ci-latest-slang.yml) that tests slangpy against latest slang from `master` branch. Currently we test slangpy/slang on Windows and Linux in both Release and Debug configs. The workflow is scheduled to be triggered at 1 AM UTC every night.