### PR TITLE
Enable more flexible conversions from Python scalars to SlangPy arguments

### DIFF
--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -458,6 +458,7 @@ namespace impl
     // slang type. This works around mismatches between the type systems: Python e.g.
     // only knows float or int, but slang has a much wider array of scalar types;
     // integers alone have 8 different types.
+    //
     // This gets even worse when lists are thrown into the mix, and trying to pass
     // e.g. [1, 2, 3] to uint16_t[3] would fail if the ValueType picks the default
     // of int[3] to pass to slang. We could attempt to check this in python, but
@@ -465,21 +466,30 @@ namespace impl
     //
     // To solve this, we check if the python type (e.g. float[3]) type can be converted
     // safely to the slang type using slang generic constraints.
+    //
     // If type B implements IConvertibleFrom<A>, then we can safely convert from A to B
-    interface IConvertibleFrom<From> {}
+    interface IConvertibleFrom<From> {};
 
     // A python int can be passed to any slang float/int scalar type
-    extension<T : __BuiltinArithmeticType> T : IConvertibleFrom<int> {}
+    extension<To : __BuiltinArithmeticType> To : IConvertibleFrom<int> {}
 
-    // A python float can be passed to any slang float scalar type
-    extension<T : __BuiltinArithmeticType> T : IConvertibleFrom<float> {}
+    // A python float can be passed to any slang float/int scalar type
+    extension<To : __BuiltinArithmeticType> To : IConvertibleFrom<float> {}
 
     // A python array can be passed to any slang array of the same length, as
     // long as their element types can be safely passed
-    extension<S, T : IConvertibleFrom<S>, let N : int, ArrT : ISizedArray<T, N>> ArrT : IConvertibleFrom<Array<S, N>> {}
+    extension<From: __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int, ArrTo : ISizedArray<To, N>>
+    ArrTo : IConvertibleFrom<Array<From, N>> {};
+    
+    extension<From: __BuiltinFloatingPointType, To : IConvertibleFrom<From>, let N : int, ArrTo : ISizedArray<To, N>>
+    ArrTo : IConvertibleFrom<Array<From, N>> {};
 
     // A vector is convertible to another vector of the same length who's element types are convertible
-    extension<S, T : IConvertibleFrom<S>, let N : int> vector<T,N> : IConvertibleFrom<vector<S, N>> {}
+    extension<From: __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+    
+    extension<From: __BuiltinFloatingPointType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
 
     // This function allows us to check if type A is convertible to type B.
     // We attempt to specialize allowedConversionWitness with types [A, B]

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -468,8 +468,9 @@ namespace impl
     // If type B implements IConvertibleFrom<A>, then we can safely convert from A to B
     interface IConvertibleFrom<From> {}
 
-    // A python int can be passed to any slang integer scalar type
-    extension<T : __BuiltinIntegerType> T : IConvertibleFrom<int> {}
+    // A python int can be passed to any slang float/int scalar type
+    extension<T : __BuiltinArithmeticType> T : IConvertibleFrom<int> {}
+    // extension<T : __BuiltinIntegerType> T : IConvertibleFrom<int> {}
 
     // A python float can be passed to any slang float scalar type
     extension<T : __BuiltinFloatingPointType> T : IConvertibleFrom<float> {}

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -470,10 +470,9 @@ namespace impl
 
     // A python int can be passed to any slang float/int scalar type
     extension<T : __BuiltinArithmeticType> T : IConvertibleFrom<int> {}
-    // extension<T : __BuiltinIntegerType> T : IConvertibleFrom<int> {}
 
     // A python float can be passed to any slang float scalar type
-    extension<T : __BuiltinFloatingPointType> T : IConvertibleFrom<float> {}
+    extension<T : __BuiltinArithmeticType> T : IConvertibleFrom<float> {}
 
     // A python array can be passed to any slang array of the same length, as
     // long as their element types can be safely passed

--- a/slangpy/tests/slangpy_tests/test_custom_types.py
+++ b/slangpy/tests/slangpy_tests/test_custom_types.py
@@ -453,7 +453,7 @@ int range_test(int input) {
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-@pytest.mark.parametrize("configuration", [(int, 'float'), (float, 'int')])
+@pytest.mark.parametrize("configuration", [(int, "float"), (float, "int")])
 def test_parameter_to_field_conversion(device_type: DeviceType, configuration: Tuple[type, str]):
 
     # Create function that just dumps input to output
@@ -473,7 +473,7 @@ int parameter_to_field_test(Uniform u) {{
 """,
     )
 
-    assert kernel_output_values({'x': ptype(512)}) == 512
+    assert kernel_output_values({"x": ptype(512)}) == 512
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/slangpy/tests/slangpy_tests/test_vectorizing.py
+++ b/slangpy/tests/slangpy_tests/test_vectorizing.py
@@ -66,7 +66,7 @@ def test_implicit_cast_no_vectorization(device_type: DeviceType):
     binding = call_data.debug_only_bindings.args[0]
     assert binding.vector_mapping.as_tuple() == ()
     assert binding.vector_type is not None
-    assert binding.vector_type.name == "float"
+    assert binding.vector_type.name == "int"
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -608,8 +608,18 @@ private:
             self.set(val);
             return;
         }
-        auto val = nb::cast<ValType>(nbval);
-        self.set(val);
+
+        try {
+            auto val = nb::cast<ValType>(nbval);
+            self.set(val);
+        } catch (const std::exception& err) {
+            SGL_THROW(
+                "Failed to cast value to C++ scalar type '{}' from Python type '{}' (msg: {})",
+                typeid(ValType).name(),
+                nbval.ptr()->ob_type->tp_name,
+                err.what()
+            );
+        }
     }
 
     /// Default implementation of write vector from numpy array.


### PR DESCRIPTION
Addresses #119

**TLDR:** Allow passing Python `int`s as `float`s to slangpy (scalar parameters and fields of struct parameters) and vice versa.

From the SlangPy side this really only involves modifying the `IConvertibleFrom` specializations in `core.slang`. In addition to errors with passing a Python `int` to a SlangPy `float` field, there were likewise errors in passing a Python `float` to a SlangPy `int` field.

```slang
struct IntStruct {
        int x;
}

struct FloatStruct {
        float x;
}

float4 ok(float x)
{
        return x;
}

float4 error1(IntStruct s)
{
        return s.x;
}

float4 error2(FloatStruct s)
{
        return s.x;
}
```

```py
module = spy.Module.load_from_file(device, 'example.slang')

# Invocations
x = module.ok(x=512)
x = module.error1({ 'x': 512.0 })
x = module.error2({ 'x': 512 })
```

> [!IMPORTANT]  
> For Python `float` to SlangPy `int` field passing to work, there needs to be a slight correction in nanobind. Casting from int to float works already, but casting the other way (float to int) will result in a crash. I have a fix implemented in a fork on the current SlangPy nanobind fork, the diff can be viewed [here](https://github.com/skallweitNV/nanobind/compare/inheritance-fix...venkataram-nv:nanobind:casting?diff=split&w).