### PR TITLE
Add shader and pipeline labels + flag for enabling compilation reports

### DIFF
--- a/slangpy/core/utils.py
+++ b/slangpy/core/utils.py
@@ -24,6 +24,7 @@ def create_device(
     enable_cuda_interop: bool = False,
     enable_print: bool = False,
     enable_hot_reload: bool = True,
+    enable_compilation_reports: bool = False,
 ):
     """
     Create a device with basic settings for SlangPy. For full control over device init,
@@ -46,6 +47,7 @@ def create_device(
         enable_cuda_interop=enable_cuda_interop,
         enable_print=enable_print,
         enable_hot_reload=enable_hot_reload,
+        enable_compilation_reports=enable_compilation_reports,
     )
 
     if is_running_in_jupyter():

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -111,6 +111,7 @@ Device::Device(const DeviceDesc& desc)
         // TODO(slang-rhi) make configurable but default to true
         .enableValidation = true,
         .debugCallback = &DebugLogger::get(),
+        .enableCompilationReports = m_desc.enable_compilation_reports,
     };
     log_debug(
         "Creating graphics device (type: {}, luid: {}, shader_cache_path: {}).",
@@ -848,6 +849,10 @@ std::string Device::to_string() const
         "  adapter_name = \"{}\",\n"
         "  adapter_luid = {},\n"
         "  enable_debug_layers = {},\n"
+        "  enable_cuda_interop = {},\n"
+        "  enable_print = {},\n"
+        "  enable_hot_reload = {},\n"
+        "  enable_compilation_reports = {},\n"
         "  supported_shader_model = {},\n"
         "  shader_cache_enabled = {},\n"
         "  shader_cache_path = \"{}\"\n"
@@ -856,6 +861,10 @@ std::string Device::to_string() const
         m_info.adapter_name,
         string::hexlify(m_info.adapter_luid),
         m_desc.enable_debug_layers,
+        m_desc.enable_cuda_interop,
+        m_desc.enable_print,
+        m_desc.enable_hot_reload,
+        m_desc.enable_compilation_reports,
         m_supported_shader_model,
         m_shader_cache_enabled,
         m_shader_cache_path

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -104,6 +104,9 @@ struct DeviceDesc {
     /// Note: Currently windows and linux only.
     bool enable_hot_reload{true};
 
+    /// Enable compilation reports.
+    bool enable_compilation_reports{true};
+
     /// Adapter LUID to select adapter on which the device will be created.
     std::optional<AdapterLUID> adapter_luid;
 

--- a/src/sgl/device/pipeline.cpp
+++ b/src/sgl/device/pipeline.cpp
@@ -50,7 +50,10 @@ ComputePipeline::ComputePipeline(ref<Device> device, ComputePipelineDesc desc)
 
 void ComputePipeline::recreate()
 {
-    rhi::ComputePipelineDesc rhi_desc{.program = m_desc.program->rhi_shader_program()};
+    rhi::ComputePipelineDesc rhi_desc{
+        .program = m_desc.program->rhi_shader_program(),
+        .label = m_desc.label.empty() ? nullptr : m_desc.label.c_str(),
+    };
     SLANG_RHI_CALL(
         m_device->rhi_device()->createComputePipeline(rhi_desc, (rhi::IComputePipeline**)m_rhi_pipeline.writeRef())
     );
@@ -70,10 +73,12 @@ std::string ComputePipeline::to_string() const
         "ComputePipeline(\n"
         "  device = {},\n"
         "  program = {},\n"
+        "  label = {},\n"
         "  thread_group_size = {}\n"
         ")",
         m_device,
         m_desc.program,
+        m_desc.label,
         m_thread_group_size
     );
 }
@@ -162,6 +167,7 @@ void RenderPipeline::recreate()
             .alphaToCoverageEnable = desc.multisample.alpha_to_coverage_enable,
             .alphaToOneEnable = desc.multisample.alpha_to_one_enable,
         },
+        .label = m_desc.label.empty() ? nullptr : m_desc.label.c_str(),
     };
 
     SLANG_RHI_CALL(
@@ -180,11 +186,13 @@ std::string RenderPipeline::to_string() const
 {
     return fmt::format(
         "RenderPipeline(\n"
-        "  device = {}\n"
-        "  program = {}\n"
+        "  device = {},\n"
+        "  program = {},\n"
+        "  label = {}\n"
         ")",
         m_device,
-        m_desc.program
+        m_desc.program,
+        m_desc.label
     );
 }
 
@@ -224,6 +232,7 @@ void RayTracingPipeline::recreate()
         .maxRayPayloadSize = desc.max_ray_payload_size,
         .maxAttributeSizeInBytes = desc.max_attribute_size,
         .flags = static_cast<rhi::RayTracingPipelineFlags>(desc.flags),
+        .label = m_desc.label.empty() ? nullptr : m_desc.label.c_str(),
     };
     SLANG_RHI_CALL(m_device->rhi_device()
                        ->createRayTracingPipeline(rhi_desc, (rhi::IRayTracingPipeline**)m_rhi_pipeline.writeRef()));
@@ -240,11 +249,13 @@ std::string RayTracingPipeline::to_string() const
 {
     return fmt::format(
         "RayTracingPipeline(\n"
-        "  device = {}\n"
-        "  program = {}\n"
+        "  device = {},\n"
+        "  program = {},\n"
+        "  label = {}\n"
         ")",
         m_device,
-        m_desc.program
+        m_desc.program,
+        m_desc.label
     );
 }
 

--- a/src/sgl/device/pipeline.h
+++ b/src/sgl/device/pipeline.h
@@ -43,6 +43,7 @@ private:
 
 struct ComputePipelineDesc {
     ref<ShaderProgram> program;
+    std::string label;
 };
 
 /// Compute pipeline.
@@ -80,6 +81,7 @@ struct RenderPipelineDesc {
     DepthStencilDesc depth_stencil;
     RasterizerDesc rasterizer;
     MultisampleDesc multisample;
+    std::string label;
 };
 
 /// Render pipeline.
@@ -123,6 +125,7 @@ struct RayTracingPipelineDesc {
     uint32_t max_ray_payload_size{0};
     uint32_t max_attribute_size{8};
     RayTracingPipelineFlags flags{RayTracingPipelineFlags::none};
+    std::string label;
 };
 
 /// Ray tracing pipeline.

--- a/src/sgl/device/shader.h
+++ b/src/sgl/device/shader.h
@@ -474,6 +474,7 @@ struct ShaderProgramDesc {
     std::vector<ref<SlangModule>> modules;
     std::vector<ref<SlangEntryPoint>> entry_points;
     std::optional<SlangLinkOptions> link_options;
+    std::string label;
 };
 struct ShaderProgramData : Object {
     Slang::ComPtr<slang::IComponentType> linked_program;

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -25,6 +25,7 @@ SGL_DICT_TO_DESC_FIELD(enable_debug_layers, bool)
 SGL_DICT_TO_DESC_FIELD(enable_cuda_interop, bool)
 SGL_DICT_TO_DESC_FIELD(enable_print, bool)
 SGL_DICT_TO_DESC_FIELD(enable_hot_reload, bool)
+SGL_DICT_TO_DESC_FIELD(enable_compilation_reports, bool)
 SGL_DICT_TO_DESC_FIELD(adapter_luid, AdapterLUID)
 SGL_DICT_TO_DESC_FIELD(compiler_options, SlangCompilerOptions)
 SGL_DICT_TO_DESC_FIELD(shader_cache_path, std::filesystem::path)
@@ -135,6 +136,11 @@ SGL_PY_EXPORT(device_device)
         .def_rw("enable_cuda_interop", &DeviceDesc::enable_cuda_interop, D(DeviceDesc, enable_cuda_interop))
         .def_rw("enable_print", &DeviceDesc::enable_print, D(DeviceDesc, enable_print))
         .def_rw("enable_hot_reload", &DeviceDesc::enable_hot_reload, D(DeviceDesc, adapter_luid))
+        .def_rw(
+            "enable_compilation_reports",
+            &DeviceDesc::enable_compilation_reports,
+            D_NA(DeviceDesc, enable_compilation_reports)
+        )
         .def_rw("adapter_luid", &DeviceDesc::adapter_luid, D(DeviceDesc, adapter_luid))
         .def_rw("compiler_options", &DeviceDesc::compiler_options, D(DeviceDesc, compiler_options))
         .def_rw("shader_cache_path", &DeviceDesc::shader_cache_path, D(DeviceDesc, shader_cache_path));
@@ -233,6 +239,7 @@ SGL_PY_EXPORT(device_device)
            bool enable_cuda_interop,
            bool enable_print,
            bool enable_hot_reload,
+           bool enable_compilation_reports,
            std::optional<AdapterLUID> adapter_luid,
            std::optional<SlangCompilerOptions> compiler_options,
            std::optional<std::filesystem::path> shader_cache_path)
@@ -243,6 +250,7 @@ SGL_PY_EXPORT(device_device)
                 .enable_cuda_interop = enable_cuda_interop,
                 .enable_print = enable_print,
                 .enable_hot_reload = enable_hot_reload,
+                .enable_compilation_reports = enable_compilation_reports,
                 .adapter_luid = adapter_luid,
                 .compiler_options = compiler_options.value_or(SlangCompilerOptions{}),
                 .shader_cache_path = shader_cache_path,
@@ -252,7 +260,8 @@ SGL_PY_EXPORT(device_device)
         "enable_debug_layers"_a = DeviceDesc().enable_debug_layers,
         "enable_cuda_interop"_a = DeviceDesc().enable_cuda_interop,
         "enable_print"_a = DeviceDesc().enable_print,
-        "enable_hot_reload"_a = true,
+        "enable_hot_reload"_a = DeviceDesc().enable_hot_reload,
+        "enable_compilation_reports"_a = DeviceDesc().enable_compilation_reports,
         "adapter_luid"_a.none() = nb::none(),
         "compiler_options"_a.none() = nb::none(),
         "shader_cache_path"_a.none() = nb::none(),

--- a/src/slangpy_ext/device/pipeline.cpp
+++ b/src/slangpy_ext/device/pipeline.cpp
@@ -9,6 +9,7 @@
 namespace sgl {
 SGL_DICT_TO_DESC_BEGIN(ComputePipelineDesc)
 SGL_DICT_TO_DESC_FIELD(program, ref<ShaderProgram>)
+SGL_DICT_TO_DESC_FIELD(label, std::string)
 SGL_DICT_TO_DESC_END()
 
 SGL_DICT_TO_DESC_BEGIN(RenderPipelineDesc)
@@ -19,6 +20,7 @@ SGL_DICT_TO_DESC_FIELD(targets, std::vector<ColorTargetDesc>)
 SGL_DICT_TO_DESC_FIELD(depth_stencil, DepthStencilDesc)
 SGL_DICT_TO_DESC_FIELD(rasterizer, RasterizerDesc)
 SGL_DICT_TO_DESC_FIELD(multisample, MultisampleDesc)
+SGL_DICT_TO_DESC_FIELD(label, std::string)
 SGL_DICT_TO_DESC_END()
 
 SGL_DICT_TO_DESC_BEGIN(HitGroupDesc)
@@ -35,6 +37,7 @@ SGL_DICT_TO_DESC_FIELD(max_recursion, uint32_t)
 SGL_DICT_TO_DESC_FIELD(max_ray_payload_size, uint32_t)
 SGL_DICT_TO_DESC_FIELD(max_attribute_size, uint32_t)
 SGL_DICT_TO_DESC_FIELD(flags, RayTracingPipelineFlags)
+SGL_DICT_TO_DESC_FIELD(label, std::string)
 SGL_DICT_TO_DESC_END()
 } // namespace sgl
 
@@ -51,7 +54,8 @@ SGL_PY_EXPORT(device_pipeline)
             [](ComputePipelineDesc* self, nb::dict dict)
             { new (self) ComputePipelineDesc(dict_to_ComputePipelineDesc(dict)); }
         )
-        .def_rw("program", &ComputePipelineDesc::program, D(ComputePipelineDesc, program));
+        .def_rw("program", &ComputePipelineDesc::program, D(ComputePipelineDesc, program))
+        .def_rw("label", &ComputePipelineDesc::label, D_NA(ComputePipelineDesc, label));
     nb::implicitly_convertible<nb::dict, ComputePipelineDesc>();
 
     nb::class_<ComputePipeline, Pipeline>(m, "ComputePipeline", D(ComputePipeline))
@@ -75,7 +79,8 @@ SGL_PY_EXPORT(device_pipeline)
         .def_rw("targets", &RenderPipelineDesc::targets, D(RenderPipelineDesc, targets))
         .def_rw("depth_stencil", &RenderPipelineDesc::depth_stencil, D(RenderPipelineDesc, depth_stencil))
         .def_rw("rasterizer", &RenderPipelineDesc::rasterizer, D(RenderPipelineDesc, rasterizer))
-        .def_rw("multisample", &RenderPipelineDesc::multisample, D(RenderPipelineDesc, multisample));
+        .def_rw("multisample", &RenderPipelineDesc::multisample, D(RenderPipelineDesc, multisample))
+        .def_rw("label", &RenderPipelineDesc::label, D_NA(RenderPipelineDesc, label));
 
     nb::class_<RenderPipeline, Pipeline>(m, "RenderPipeline", D(RenderPipeline)) //
         .def_prop_ro("native_handle", &RenderPipeline::native_handle, D(RenderPipeline, native_handle));
@@ -129,7 +134,8 @@ SGL_PY_EXPORT(device_pipeline)
             &RayTracingPipelineDesc::max_attribute_size,
             D(RayTracingPipelineDesc, max_attribute_size)
         )
-        .def_rw("flags", &RayTracingPipelineDesc::flags, D(RayTracingPipelineDesc, flags));
+        .def_rw("flags", &RayTracingPipelineDesc::flags, D(RayTracingPipelineDesc, flags))
+        .def_rw("label", &RayTracingPipelineDesc::label, D_NA(RayTracingPipelineDesc, label));
     nb::implicitly_convertible<nb::dict, RayTracingPipelineDesc>();
 
     nb::class_<RayTracingPipeline, Pipeline>(m, "RayTracingPipeline", D(RayTracingPipeline)) //


### PR DESCRIPTION
- Add `label` to `RenderPipelineDesc`, `ComputePipelineDesc`, `RayTracingPipelineDesc` and `ShaderProgramDesc`
- Auto-generate labels for shader programs
- Enable compilation time reports by default (add `DeviceDesc::enable_compilation_reports` flag to override)

For now, this allows to get debug prints for shader/pipeline compilation times in RHI if global log level is increased to `debug`. A future PR will add additional API to query compilation reports on specific programs.