### PR TITLE
Fix build problem when multiple VS toolsets are installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ cd slangpy
 pip install .
 ```
 
+## Build Options
+
+When building from source, you can customize the build using the following CMake options (passed with `-D<OPTION>=<VALUE>`):
+
+| Option                          | Description                                                                 | Default |
+| ------------------------------- | --------------------------------------------------------------------------- | ------- |
+| `SGL_BUILD_PYTHON`              | Build the Python extension module.                                          | `ON`    |
+| `SGL_BUILD_EXAMPLES`            | Build the example applications.                                             | `ON`    |
+| `SGL_BUILD_TESTS`               | Build the test suite.                                                       | `ON`    |
+| `SGL_BUILD_DOC`                 | Build the documentation.                                                    | `OFF`   |
+| `SGL_USE_DYNAMIC_CUDA`          | Load the CUDA driver API dynamically at runtime.                            | `ON`    |
+| `SGL_MSVC_TOOLSET_VERSION`      | Specify an exact MSVC toolset version to use (e.g., `14.38.33130`).         | Unset   |
+
 ## License
 
 SlangPy source code is licensed under the Apache-2.0 License - see the [LICENSE.txt](LICENSE.txt) file for details.

--- a/external/vcpkg-triplets/x64-windows-static-md-fix.cmake
+++ b/external/vcpkg-triplets/x64-windows-static-md-fix.cmake
@@ -1,3 +1,25 @@
+# Allow user to explicitly specify a toolset version via -DSGL_MSVC_TOOLSET_VERSION=...
+# If not specified, it falls back to the VCToolsVersion from the developer environment.
+if(DEFINED SGL_MSVC_TOOLSET_VERSION)
+    set(toolset_to_use ${SGL_MSVC_TOOLSET_VERSION})
+    message(STATUS "Triplet: Using user-specified toolset version '${toolset_to_use}'.")
+elseif(DEFINED ENV{VCToolsVersion})
+    set(toolset_to_use "$ENV{VCToolsVersion}")
+    message(STATUS "Triplet: Using toolset version from environment: '${toolset_to_use}'.")
+endif()
+
+if(DEFINED toolset_to_use)
+    # Set the detailed toolset version. This forces vcpkg to use the specific toolset.
+    set(VCPKG_PLATFORM_TOOLSET_VERSION "${toolset_to_use}")
+
+    # Also set the major toolset version, as vcpkg may require it to be present.
+    string(REGEX MATCH "^([0-9]+)\\.([0-9])" _match "${toolset_to_use}")
+    if(_match)
+        set(derived_toolset "v${CMAKE_MATCH_1}${CMAKE_MATCH_2}")
+        set(VCPKG_PLATFORM_TOOLSET "${derived_toolset}")
+    endif()
+endif()
+
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)


### PR DESCRIPTION
When there are more than one visual studio toolset is installed, CMake may use an older version of the toolset while vcpkg always uses the latest one.

This PR adds a new CMake option to set which toolset version you want to use explicitly.
If it not explicitly set, it checks the environment variable, "VCToolsVersion", that gets set by the Visual Studio build environment command such as "x64 Native Tools Command Prompt for VS 2022".