### PR TITLE
Revert "Fix build problem when multiple VS toolsets are installed (#3…

### DIFF
--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -216,9 +216,6 @@ The following table lists the available configuration options:
     * - ``SGL_ENABLE_HEADER_VALIDATION``
       - ``OFF``
       - Enable header validation
-    * - ``SGL_MSVC_TOOLSET_VERSION``
-      - ``Unset``
-      - Specify an exact MSVC toolset version to use (e.g., `14.38.33130`)
 
 
 VS Code

--- a/external/vcpkg-triplets/x64-windows-static-md-fix.cmake
+++ b/external/vcpkg-triplets/x64-windows-static-md-fix.cmake
@@ -1,25 +1,3 @@
-# Allow user to explicitly specify a toolset version via -DSGL_MSVC_TOOLSET_VERSION=...
-# If not specified, it falls back to the VCToolsVersion from the developer environment.
-if(DEFINED SGL_MSVC_TOOLSET_VERSION)
-    set(toolset_to_use ${SGL_MSVC_TOOLSET_VERSION})
-    message(STATUS "Triplet: Using user-specified toolset version '${toolset_to_use}'.")
-elseif(DEFINED ENV{VCToolsVersion})
-    set(toolset_to_use "$ENV{VCToolsVersion}")
-    message(STATUS "Triplet: Using toolset version from environment: '${toolset_to_use}'.")
-endif()
-
-if(DEFINED toolset_to_use)
-    # Set the detailed toolset version. This forces vcpkg to use the specific toolset.
-    set(VCPKG_PLATFORM_TOOLSET_VERSION "${toolset_to_use}")
-
-    # Also set the major toolset version, as vcpkg may require it to be present.
-    string(REGEX MATCH "^([0-9]+)\\.([0-9])" _match "${toolset_to_use}")
-    if(_match)
-        set(derived_toolset "v${CMAKE_MATCH_1}${CMAKE_MATCH_2}")
-        set(VCPKG_PLATFORM_TOOLSET "${derived_toolset}")
-    endif()
-endif()
-
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)


### PR DESCRIPTION
…15)"

This reverts commit 1a0aee7822ce77ccb359f6d946e505d102cd1820.


after this change I cannot build slangpy on my machine anymore:

```
[cmake] -- Running vcpkg install
[cmake] Detecting compiler hash for triplet x64-windows...
[cmake] Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe
[cmake] error: in triplet x64-windows-static-md-fix: Unable to find a valid Visual Studio instance
[cmake]   with toolset version v144
[cmake]   with toolset version prefix 14.43.34808
[cmake] The following Visual Studio instances were considered:
[cmake]   C:\Program Files\Microsoft Visual Studio\2022\Professional
[cmake]   C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional
[cmake]   C:\Program Files\Microsoft Visual Studio\2022\Professional
[cmake] The following paths were examined for Visual Studio instances:
[cmake]   C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary/Build\vcvarsall.bat
[cmake]   C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary/Build\vcvarsall.bat
[cmake]   C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary/Build\vcvarsall.bat
[cmake] 
[cmake] -- Running vcpkg install - failed
```