### PR TITLE
Enable slangpy tests on Metal

### DIFF
--- a/slangpy/tests/slangpy_tests/test_array.py
+++ b/slangpy/tests/slangpy_tests/test_array.py
@@ -161,6 +161,9 @@ int inc(Val val) {
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_vectorize_struct_with_resource_array(device_type: DeviceType):
+    if device_type == DeviceType.metal:
+        # https://github.com/shader-slang/slang/issues/7606
+        pytest.skip("Crash in the slang compiler")
 
     device = helpers.get_device(device_type)
     function = helpers.create_function_from_module(
@@ -196,6 +199,9 @@ int inc(Val val) {
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_vectorize_struct_with_ndbuffer_array(device_type: DeviceType):
+    if device_type == DeviceType.metal:
+        # https://github.com/shader-slang/slang/issues/7606
+        pytest.skip("Crash in the slang compiler")
 
     device = helpers.get_device(device_type)
     function = helpers.create_function_from_module(
@@ -232,6 +238,9 @@ int inc(Val val) {
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_vectorize_struct_with_tensor_array(device_type: DeviceType):
+    if device_type == DeviceType.metal:
+        # https://github.com/shader-slang/slang/issues/7606
+        pytest.skip("Crash in the slang compiler")
 
     device = helpers.get_device(device_type)
     function = helpers.create_function_from_module(
@@ -263,6 +272,9 @@ float inc(Val val) {
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_2d_mapped_vectorize_struct_with_tensor_array(device_type: DeviceType):
+    if device_type == DeviceType.metal:
+        # https://github.com/shader-slang/slang/issues/7606
+        pytest.skip("Crash in the slang compiler")
 
     device = helpers.get_device(device_type)
     function = helpers.create_function_from_module(

--- a/slangpy/tests/slangpy_tests/test_packed_arg.py
+++ b/slangpy/tests/slangpy_tests/test_packed_arg.py
@@ -95,6 +95,9 @@ int inc(Val val) {
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_vectorize_struct_with_tensor_array(device_type: DeviceType):
+    if device_type == DeviceType.metal:
+        # https://github.com/shader-slang/slang/issues/7606
+        pytest.skip("Crash in the slang compiler")
 
     device = helpers.get_device(device_type)
     function = helpers.create_function_from_module(

--- a/slangpy/tests/slangpy_tests/test_pointers.py
+++ b/slangpy/tests/slangpy_tests/test_pointers.py
@@ -8,15 +8,14 @@ from slangpy import grid
 from slangpy import DeviceType, BufferUsage
 from slangpy.types import NDBuffer
 
-
 sys.path.append(str(Path(__file__).parent))
 import helpers
 
 # Filter default device types to only include those that support pointers
+# TODO: Metal does support pointers but the is a slang bug leading to incorrect Metal shader code
+# https://github.com/shader-slang/slang/issues/7605
 POINTER_DEVICE_TYPES = [
-    x
-    for x in helpers.DEFAULT_DEVICE_TYPES
-    if x in [DeviceType.vulkan, DeviceType.cuda, DeviceType.metal]
+    x for x in helpers.DEFAULT_DEVICE_TYPES if x in [DeviceType.vulkan, DeviceType.cuda]
 ]
 
 

--- a/slangpy/tests/slangpy_tests/test_textures.py
+++ b/slangpy/tests/slangpy_tests/test_textures.py
@@ -13,12 +13,6 @@ from slangpy.builtin.texture import SCALARTYPE_TO_TEXTURE_FORMAT
 from slangpy.types.buffer import _slang_to_numpy
 import sys
 
-if sys.platform == "darwin":
-    pytest.skip(
-        "Skipping on macOS: Waiting for slang-gfx fix for resource clear API https://github.com/shader-slang/slang/issues/6640",
-        allow_module_level=True,
-    )
-
 
 def load_test_module(device_type: DeviceType):
     device = helpers.get_device(device_type)
@@ -172,6 +166,8 @@ def make_grid_data(type: TextureType, array_length: int = 1):
 def test_read_write_texture(device_type: DeviceType, slices: int, mips: int, type: TextureType):
     if device_type == DeviceType.cuda:
         pytest.skip("Limited texture support in CUDA backend")
+    if device_type == DeviceType.metal:
+        pytest.skip("Limited texture support in Metal backend")
 
     m = load_test_module(device_type)
     assert m is not None
@@ -223,6 +219,8 @@ def test_read_write_texture_with_resource_views(
 ):
     if device_type == DeviceType.cuda:
         pytest.skip("Limited texture support in CUDA backend")
+    if device_type == DeviceType.metal:
+        pytest.skip("Limited texture support in Metal backend")
 
     m = load_test_module(device_type)
     assert m is not None
@@ -276,6 +274,9 @@ def test_read_write_texture_with_resource_views(
 @pytest.mark.parametrize("mips", [ALL_MIPS, 1])
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_copy_value(device_type: DeviceType, slices: int, mips: int, type: TextureType):
+    if device_type == DeviceType.metal and type == TextureType.texture_1d and mips > 1:
+        pytest.skip("1D textures with mip maps are not supported on Metal")
+
     m = load_test_module(device_type)
     assert m is not None
 
@@ -311,6 +312,9 @@ def test_copy_value(device_type: DeviceType, slices: int, mips: int, type: Textu
 def test_copy_mip_values_with_resource_views(
     device_type: DeviceType, slices: int, mips: int, type: TextureType
 ):
+    if device_type == DeviceType.metal and type == TextureType.texture_1d and mips > 1:
+        pytest.skip("1D textures with mip maps are not supported on Metal")
+
     m = load_test_module(device_type)
     assert m is not None
 
@@ -348,6 +352,9 @@ def test_copy_mip_values_with_resource_views(
 def test_copy_mip_values_with_all_uav_resource_views(
     device_type: DeviceType, slices: int, mips: int, type: TextureType
 ):
+    if device_type == DeviceType.metal and type == TextureType.texture_1d and mips > 1:
+        pytest.skip("1D textures with mip maps are not supported on Metal")
+
     m = load_test_module(device_type)
     assert m is not None
 
@@ -483,6 +490,8 @@ def texture_return_value_impl(
 @pytest.mark.parametrize("channels", [1, 2, 4])
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_texture_return_value(device_type: DeviceType, texel_name: str, dims: int, channels: int):
+    if device_type == DeviceType.metal:
+        pytest.skip("Limited texture support in Metal backend")
     texture_return_value_impl(device_type, texel_name, dims, channels, Texture)
 
 


### PR DESCRIPTION
- enable running slangpy tests on metal
- skip tests if metal device does not support parameter blocks (which is the case for hosted github runners)
- skip various tests that have issues