### PR TITLE
Enable passing Python ints to Slang float fields

### DIFF
--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -485,8 +485,9 @@ namespace impl
     // If type B implements IConvertibleFrom<A>, then we can safely convert from A to B
     interface IConvertibleFrom<From> {}
 
-    // A python int can be passed to any slang integer scalar type
+    // A python int can be passed to any slang int/float scalar type
     extension<T : __BuiltinIntegerType> T : IConvertibleFrom<int> {}
+    extension<T : __BuiltinFloatingPointType> T : IConvertibleFrom<int> {}
 
     // A python int (e.g. a buffer address) can be passed to any slang pointer type
     extension<T> Ptr<T> : IConvertibleFrom<int> {}

--- a/slangpy/tests/slangpy_tests/test_custom_types.py
+++ b/slangpy/tests/slangpy_tests/test_custom_types.py
@@ -426,6 +426,26 @@ Particle rand_float_soa(Particle input) {
     assert np.all(pos >= -100.0) and np.all(pos <= 100.0)
     assert np.all(dir >= 0) and np.all(dir <= np.pi * 2)
 
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_parameter_to_field_conversion(device_type: DeviceType):
+
+    # Create function that just dumps input to output
+    device = helpers.get_device(device_type)
+    kernel_output_values = helpers.create_function_from_module(
+        device,
+        "parameter_to_field_test",
+        f"""
+struct Uniform {{
+    float x;
+}}
+
+int parameter_to_field_test(Uniform u) {{
+    return int(u.x);
+}}
+""",
+    )
+
+    assert kernel_output_values({'x': 512}) == 512
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_range(device_type: DeviceType):


### PR DESCRIPTION
Fixes #119

The previous PR (#306) tried to additionally allow passing floats to int fields, but this behavior is discouraged and inconsistent with Python ([see this upstream PR, now closed](https://github.com/wjakob/nanobind/pull/1097#issuecomment-3033013135)). The changes in this PR are the reduced version of the older PR and require no upstream changes.