### PR TITLE
Change the _trampoline signature

### DIFF
--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -519,7 +519,9 @@ def generate_code(
     for x in root_params:
         if x.access[0] == AccessType.read or x.access[0] == AccessType.readwrite:
             data_name = (
-                f"_param_{x.variable_name}" if x.create_param_block else f"call_data.{x.variable_name}"
+                f"_param_{x.variable_name}"
+                if x.create_param_block
+                else f"call_data.{x.variable_name}"
             )
             cg.trampoline.append_statement(
                 f"{data_name}.load(context.map(_m_{x.variable_name}), {x.variable_name})"
@@ -559,7 +561,9 @@ def generate_code(
             if not x.python.is_writable:
                 raise BoundVariableException(f"Cannot read back value for non-writable type", x)
             data_name = (
-                f"_param_{x.variable_name}" if x.create_param_block else f"call_data.{x.variable_name}"
+                f"_param_{x.variable_name}"
+                if x.create_param_block
+                else f"call_data.{x.variable_name}"
             )
             cg.trampoline.append_statement(
                 f"{data_name}.store(context.map(_m_{x.variable_name}), {x.variable_name})"

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -509,7 +509,7 @@ def generate_code(
     trampoline_fn = "_trampoline"
     if context.call_mode != CallMode.prim:
         cg.trampoline.append_line("[Differentiable]")
-    cg.trampoline.append_line(f"void {trampoline_fn}(Context context)")
+    cg.trampoline.append_line(f"void {trampoline_fn}(Context __slangpy_context__)")
     cg.trampoline.begin_block()
 
     # Declare parameters and load inputs
@@ -524,7 +524,7 @@ def generate_code(
                 else f"call_data.{x.variable_name}"
             )
             cg.trampoline.append_statement(
-                f"{data_name}.load(context.map(_m_{x.variable_name}), {x.variable_name})"
+                f"{data_name}.load(__slangpy_context__.map(_m_{x.variable_name}), {x.variable_name})"
             )
 
     cg.trampoline.append_indent()
@@ -566,7 +566,7 @@ def generate_code(
                 else f"call_data.{x.variable_name}"
             )
             cg.trampoline.append_statement(
-                f"{data_name}.store(context.map(_m_{x.variable_name}), {x.variable_name})"
+                f"{data_name}.store(__slangpy_context__.map(_m_{x.variable_name}), {x.variable_name})"
             )
 
     cg.trampoline.end_block()
@@ -603,12 +603,12 @@ def generate_code(
 
         context_args += ", CallShapeInfo::get_call_id().shape"
 
-    cg.kernel.append_statement(f"Context context = {{{context_args}}}")
+    cg.kernel.append_statement(f"Context __slangpy_context__ = {{{context_args}}}")
 
     # Call the trampoline function
     fn = trampoline_fn
     if context.call_mode == CallMode.bwds:
         fn = f"bwd_diff({fn})"
-    cg.kernel.append_statement(f"{fn}(context)")
+    cg.kernel.append_statement(f"{fn}(__slangpy_context__)")
 
     cg.kernel.end_block()

--- a/slangpy/tests/slangpy_tests/test_array.py
+++ b/slangpy/tests/slangpy_tests/test_array.py
@@ -24,10 +24,10 @@ def test_simple_array(device_type: DeviceType):
         device,
         "sum",
         r"""
-int sum(int[4] vals) {
+int sum(int[4] data) {
     int sum = 0;
     for (int i = 0; i < 4; i++) {
-        sum += vals[i];
+        sum += data[i];
     }
     return sum;
 }


### PR DESCRIPTION
Close #111

Change the _trampoline signature to exclude the CallData parameter, because there is already a ParameterBlock created for CallData.

In addition, since we choose a very common name for the parameter name of CallData - "data", this prevents user from writing function with the same parameter name.