### PR TITLE
Removed unnecessary explicit default ctor to enable aggregate init

### DIFF
--- a/src/sgl/utils/texture_loader.cpp
+++ b/src/sgl/utils/texture_loader.cpp
@@ -365,8 +365,6 @@ inline ref<Texture> create_texture_array(
     return texture;
 }
 
-TextureLoader::Options::Options() { }
-
 TextureLoader::TextureLoader(ref<Device> device)
     : m_device(std::move(device))
 {

--- a/src/sgl/utils/texture_loader.h
+++ b/src/sgl/utils/texture_loader.h
@@ -35,8 +35,6 @@ public:
         /// Resource usage flags for the texture.
         /// \c TextureUsage::render_target will be added automatically if \c generate_mips is true.
         TextureUsage usage{TextureUsage::shader_resource};
-
-        Options();
     };
 
     /**


### PR DESCRIPTION
This allows calling the `load_texture` like this:

```
auto texture = m_texture_loader->load_texture(absolute_path, 
    sgl::TextureLoader::Options{
        .load_as_srgb = srgb, 
        .generate_mips = generate_mips, 
        .usage = usage});
```

With the ctor present, this aggregate init isn't possible.
(This still requires the explicit spelling out of `sgl::TextureLoader::Options` because of the `optional`, but removing that in favor of a default by-value param could have perf implications)