### PR TITLE
Provide better error message and add doc for 'strict_broadcasting'

### DIFF
--- a/docs/src/basics/broadcasting.rst
+++ b/docs/src/basics/broadcasting.rst
@@ -96,7 +96,7 @@ Conceptually, broadcasting the same value to all dimensions is similar to adding
     Out     (10,3,4)
 
 Where SlangPy differs from NumPy and certain other ML packages is that it will by design **not**
-automatically extend the dimensions of a value **unless** it is a single value. This is to prevent
+by default automatically extend the dimensions of a value **unless** it is a single value. This is to prevent
 accidental broadcasting of values that should be treated as errors. For example, consider the following
 
 .. code-block:: python
@@ -105,6 +105,23 @@ accidental broadcasting of values that should be treated as errors. For example,
     A      (3,4)
     B      (10,3,4)
     Out    Error
+
+However, SlangPy provides a way to disable this behavior by setting the `strict_broadcasting` option to `False` when
+loading the module, e.g.
+
+.. code-block:: python
+
+    module = spy.Module.load_from_source(..., options={{"strict_broadcasting": False}})
+
+In this case, SlangPy will automatically broadcast the dimensionality of the arguments that have the lower dimensionality
+match other arguments who have to match the higher dimensionality. For example, take the above example again:
+
+.. code-block:: python
+
+    SlangPy would automatically extend A to (1,3,4)
+    A      (3,4)
+    B      (10,3,4)
+    Out    (10,3,4)
 
 Broadcasting with other types
 -----------------------------

--- a/docs/src/basics/broadcasting.rst
+++ b/docs/src/basics/broadcasting.rst
@@ -95,26 +95,7 @@ Conceptually, broadcasting the same value to all dimensions is similar to adding
     B       (10,3,4)
     Out     (10,3,4)
 
-Where SlangPy differs from NumPy and certain other ML packages is that it will by design **not**
-by default automatically extend the dimensions of a value **unless** it is a single value. This is to prevent
-accidental broadcasting of values that should be treated as errors. For example, consider the following
-
-.. code-block:: python
-
-    NumPy would automatically extend A to (1,3,4), SlangPy does not
-    A      (3,4)
-    B      (10,3,4)
-    Out    Error
-
-However, SlangPy provides a way to disable this behavior by setting the `strict_broadcasting` option to `False` when
-loading the module, e.g.
-
-.. code-block:: python
-
-    module = spy.Module.load_from_source(..., options={{"strict_broadcasting": False}})
-
-In this case, SlangPy will automatically broadcast the dimensionality of the arguments that have the lower dimensionality
-match other arguments who have to match the higher dimensionality. For example, take the above example again:
+Similar to NumPy and certain other ML packages, SlangPy will by default automatically extend the dimensions of a value.
 
 .. code-block:: python
 
@@ -122,6 +103,22 @@ match other arguments who have to match the higher dimensionality. For example, 
     A      (3,4)
     B      (10,3,4)
     Out    (10,3,4)
+
+In order to prevent accidental broadcasting of values that should be treated as errors, SlangPy also provides a way to disable
+this behavior by setting the `strict_broadcasting` option to `False` when loading the module, e.g.
+
+.. code-block:: python
+
+    module = spy.Module.load_from_source(..., options={{"strict_broadcasting": False}})
+
+In this case, SlangPy will not automatically extend the dimensionality of a value **unless** it is a single value.
+
+.. code-block:: python
+
+    SlangPy would not automatically extend A to (1,3,4)
+    A      (3,4)
+    B      (10,3,4)
+    Out    Error
 
 Broadcasting with other types
 -----------------------------

--- a/slangpy/bindings/boundvariable.py
+++ b/slangpy/bindings/boundvariable.py
@@ -434,14 +434,10 @@ class BoundVariable:
                     f"""
 Strict broadcasting is enabled and the argument `{self.name}` at parameter index `{self.param_index}` has dimensionality of ({self.call_dimensionality})
 while the kernel's dimensionality is ({context.call_dimensionality}).
-Note: This error usually happens when the arguments in a call have different dimensionalities,
-by default SlangPy will not automatically broadcast the dimentionality of arguments
+Note: This error usually happens when the arguments in a call have different dimensionalities. By default SlangPy will automatically broadcast
+the dimentionality of arguments, however if 'strict_broadcasting' option is enabled when loading the module, SlangPy will not perform the broadcasting.
 (See: https://slangpy.shader-slang.org/en/latest/src/basics/broadcasting.html for details).
-You can disable strict broadcasting by setting the `strict_broadcasting` option to `False` when
-loading the module so that SlangPy will automatically broadcast the argument's dimensionality.
-
-E.g. `module = spy.Module.load_from_source(..., options={{"strict_broadcasting": False}})`
-
+You can disable strict broadcasting by not setting the `strict_broadcasting` option when loading the module.
 More Advancedly, SlangPy provides a `mapping` functionality to finer control the argument's dimensionality,
 you can find more information in the Mapping section of the documentation (https://slangpy.shader-slang.org/en/latest/src/basics/mapping.html).
 """,

--- a/slangpy/bindings/boundvariable.py
+++ b/slangpy/bindings/boundvariable.py
@@ -431,7 +431,20 @@ class BoundVariable:
                 and self.call_dimensionality != context.call_dimensionality
             ):
                 raise BoundVariableException(
-                    f"Strict broadcasting is enabled and {self.path} dimensionality ({self.call_dimensionality}) is neither 0 or the kernel dimensionality ({context.call_dimensionality})",
+f"""
+Strict broadcasting is enabled and the argument `{self.name}` at parameter index `{self.param_index}` has dimensionality of ({self.call_dimensionality})
+while the kernel's dimensionality is ({context.call_dimensionality}).
+Note: This error usually happens when the arguments in a call have different dimensionalities,
+by default SlangPy will not automatically broadcast the dimentionality of arguments
+(See: https://slangpy.shader-slang.org/en/latest/src/basics/broadcasting.html for details).
+You can disable strict broadcasting by setting the `strict_broadcasting` option to `False` when
+loading the module so that SlangPy will automatically broadcast the argument's dimensionality.
+
+E.g. `module = spy.Module.load_from_source(..., options={{"strict_broadcasting": False}})`
+
+More Advancedly, SlangPy provides a `mapping` functionality to finer control the argument's dimensionality,
+you can find more information in the Mapping section of the documentation (https://slangpy.shader-slang.org/en/latest/src/basics/mapping.html).
+""",
                     self,
                 )
 

--- a/slangpy/bindings/boundvariable.py
+++ b/slangpy/bindings/boundvariable.py
@@ -431,7 +431,7 @@ class BoundVariable:
                 and self.call_dimensionality != context.call_dimensionality
             ):
                 raise BoundVariableException(
-f"""
+                    f"""
 Strict broadcasting is enabled and the argument `{self.name}` at parameter index `{self.param_index}` has dimensionality of ({self.call_dimensionality})
 while the kernel's dimensionality is ({context.call_dimensionality}).
 Note: This error usually happens when the arguments in a call have different dimensionalities,

--- a/slangpy/core/function.py
+++ b/slangpy/core/function.py
@@ -533,7 +533,7 @@ class Function(FunctionNode):
         if not "implicit_tensor_casts" in self._options:
             self._options["implicit_tensor_casts"] = True
         if not "strict_broadcasting" in self._options:
-            self._options["strict_broadcasting"] = True
+            self._options["strict_broadcasting"] = False
 
         # Generate signature for hashing
         lines = []

--- a/slangpy/tests/slangpy_tests/test_errors.py
+++ b/slangpy/tests/slangpy_tests/test_errors.py
@@ -123,7 +123,9 @@ def test_bad_implicit_buffer_cast(device_type: DeviceType):
 def test_invalid_broadcast(device_type: DeviceType):
 
     device = helpers.get_device(device_type)
-    function = helpers.create_function_from_module(device, "foo2", MODULE)
+    function = helpers.create_function_from_module(
+        device, "foo2", MODULE, options={"strict_broadcasting": True}
+    )
 
     buffer = NDBuffer(device, dtype=float, shape=(10,))
     buffer2 = NDBuffer(device, dtype=float, shape=(10, 10))

--- a/slangpy/tests/slangpy_tests/test_vectorizing.py
+++ b/slangpy/tests/slangpy_tests/test_vectorizing.py
@@ -333,8 +333,7 @@ def test_fail_implicit_dimension_adding_vectorization(device_type: DeviceType):
 def test_none_strict_implicit_dimension_adding_vectorization(device_type: DeviceType):
 
     device = helpers.get_device(device_type)
-    function = helpers.create_function_from_module(
-        device, "add", SIMPLE_FUNC)
+    function = helpers.create_function_from_module(device, "add", SIMPLE_FUNC)
 
     a = NDBuffer(device=device, dtype=float, shape=(10, 10))
     b = NDBuffer(device=device, dtype=float, shape=(10,))

--- a/slangpy/tests/slangpy_tests/test_vectorizing.py
+++ b/slangpy/tests/slangpy_tests/test_vectorizing.py
@@ -334,8 +334,7 @@ def test_none_strict_implicit_dimension_adding_vectorization(device_type: Device
 
     device = helpers.get_device(device_type)
     function = helpers.create_function_from_module(
-        device, "add", SIMPLE_FUNC, options={"strict_broadcasting": False}
-    )
+        device, "add", SIMPLE_FUNC)
 
     a = NDBuffer(device=device, dtype=float, shape=(10, 10))
     b = NDBuffer(device=device, dtype=float, shape=(10,))

--- a/slangpy/tests/slangpy_tests/test_vectorizing.py
+++ b/slangpy/tests/slangpy_tests/test_vectorizing.py
@@ -320,7 +320,9 @@ def test_fail_disabled_implicit_tensor_to_vector(device_type: DeviceType):
 def test_fail_implicit_dimension_adding_vectorization(device_type: DeviceType):
 
     device = helpers.get_device(device_type)
-    function = helpers.create_function_from_module(device, "add", SIMPLE_FUNC)
+    function = helpers.create_function_from_module(
+        device, "add", SIMPLE_FUNC, options={"strict_broadcasting": True}
+    )
 
     a = NDBuffer(device=device, dtype=float, shape=(10, 10))
     b = NDBuffer(device=device, dtype=float, shape=(10,))


### PR DESCRIPTION
Close #62.

For dimensionality mismatch issues, we did't provide a good error message, users have no idea what's going on and where to start debugging the issue.

This PR does the best effort to improve the error message in following way:

1. Diagnose the issue
2. Provide hint why this issue happens
3. Refer to potential solution and document