### PR TITLE
Cleanups and doc updates

### DIFF
--- a/docs/generated/api.rst
+++ b/docs/generated/api.rst
@@ -175,7 +175,7 @@ Core
     .. py:property:: pixel_struct
         :type: slangpy.DataStruct
     
-        Struct describing the pixel layout.
+        DataStruct describing the pixel layout.
         
     .. py:property:: width
         :type: int
@@ -543,7 +543,7 @@ Core
 
 .. py:class:: slangpy.Timer
 
-    High resolution CPU timer.
+    
     
     .. py:method:: __init__(self) -> None
     
@@ -662,7 +662,7 @@ Constants
 
 .. py:data:: slangpy.SGL_GIT_VERSION
     :type: str
-    :value: "commit: d488b10 / branch: rename-struct (local changes)"
+    :value: "commit: 39c322b / branch: dev (local changes)"
 
 
 
@@ -882,7 +882,7 @@ Logging
 
     Base class: :py:class:`slangpy.Object`
     
-    Abstract base class for logger outputs.
+    
     
     .. py:method:: __init__(self) -> None
     
@@ -907,9 +907,7 @@ Logging
 
     Base class: :py:class:`slangpy.LoggerOutput`
     
-    Logger output that writes to the console. Error messages are printed
-    to stderr, all other messages to stdout. Messages are optionally
-    colored.
+    
     
     .. py:method:: __init__(self, colored: bool = True) -> None
     
@@ -921,7 +919,7 @@ Logging
 
     Base class: :py:class:`slangpy.LoggerOutput`
     
-    Logger output that writes to a file.
+    
     
     .. py:method:: __init__(self, path: str | os.PathLike) -> None
     
@@ -933,7 +931,7 @@ Logging
 
     Base class: :py:class:`slangpy.LoggerOutput`
     
-    Logger output that writes to the debug console (Windows only).
+    
     
     .. py:method:: __init__(self) -> None
     
@@ -1069,12 +1067,9 @@ Windowing
 
     Base class: :py:class:`slangpy.Object`
     
-    Window class.
     
-    Platform independent class for managing a window and handle input
-    events.
     
-    .. py:method:: __init__(self, width: int = 1024, height: int = 1024, title: str = 'sgl', mode: slangpy.WindowMode = WindowMode.normal, resizable: bool = True) -> None
+    .. py:method:: __init__(self, width: int = 1024, height: int = 1024, title: str = 'slangpy', mode: slangpy.WindowMode = WindowMode.normal, resizable: bool = True) -> None
     
         Constructor.
         
@@ -1713,7 +1708,7 @@ Windowing
 
 .. py:class:: slangpy.KeyboardEvent
 
-    Keyboard event.
+    
     
     .. py:property:: type
         :type: slangpy.KeyboardEventType
@@ -1787,7 +1782,7 @@ Windowing
 
 .. py:class:: slangpy.MouseEvent
 
-    Mouse event.
+    
     
     .. py:property:: type
         :type: slangpy.MouseEventType
@@ -1936,7 +1931,7 @@ Windowing
 
 .. py:class:: slangpy.GamepadEvent
 
-    Gamepad event.
+    
     
     .. py:property:: type
         :type: slangpy.GamepadEventType
@@ -1970,7 +1965,7 @@ Windowing
 
 .. py:class:: slangpy.GamepadState
 
-    Gamepad state.
+    
     
     .. py:property:: left_x
         :type: float
@@ -2454,7 +2449,7 @@ Device
 
 .. py:class:: slangpy.AccelerationStructureHandle
 
-    N/A
+    Acceleration structure handle.
     
     .. py:method:: __init__(self) -> None
     
@@ -2779,7 +2774,8 @@ Device
     .. py:property:: shared_handle
         :type: slangpy.NativeHandle
     
-        Get the shared resource handle.
+        Get the shared resource handle. Note: Buffer must be created with the
+        ``BufferUsage::shared`` usage flag.
         
     .. py:method:: to_numpy(self) -> numpy.ndarray[]
     
@@ -2860,6 +2856,8 @@ Device
     
         Get the resource this cursor represents (if any).
         
+    .. py:method:: write_from_numpy(self, data: object) -> None
+    
     .. py:method:: to_numpy(self) -> numpy.ndarray[]
     
     .. py:method:: copy_from_numpy(self, data: numpy.ndarray[]) -> None
@@ -3309,6 +3307,8 @@ Device
         Parameter ``filter``:
             Filtering mode to use.
         
+    .. py:method:: generate_mips(self, texture: slangpy.Texture, layer: int = 0) -> None
+    
     .. py:method:: resolve_query(self, query_pool: slangpy.QueryPool, index: int, count: int, buffer: slangpy.Buffer, offset: int) -> None
     
     .. py:method:: build_acceleration_structure(self, desc: slangpy.AccelerationStructureBuildDesc, dst: slangpy.AccelerationStructure, src: slangpy.AccelerationStructure | None, scratch_buffer: slangpy.BufferOffsetPair, queries: Sequence[slangpy.AccelerationStructureQueryDesc] = []) -> None
@@ -3346,6 +3346,10 @@ Device
     .. py:method:: set_texture_state(self, texture: slangpy.Texture, range: slangpy.SubresourceRange, state: slangpy.ResourceState) -> None
         :no-index:
     
+    .. py:method:: global_barrier(self) -> None
+    
+        N/A
+        
     .. py:method:: push_debug_group(self, name: str, color: slangpy.math.float3) -> None
     
         Push a debug group.
@@ -3379,6 +3383,8 @@ Device
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
+        Get the command encoder handle.
+        
 
 
 ----
@@ -3488,7 +3494,7 @@ Device
 
     Base class: :py:class:`slangpy.Pipeline`
     
-    Compute pipeline.
+    
     
     .. py:property:: thread_group_size
         :type: slangpy.math.uint3
@@ -3499,8 +3505,7 @@ Device
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
-        Returns the native API handle: - D3D12: ID3D12PipelineState* - Vulkan:
-        VkPipeline
+        Get the native pipeline handle.
         
 
 
@@ -3517,6 +3522,9 @@ Device
     
     .. py:property:: program
         :type: slangpy.ShaderProgram
+    
+    .. py:property:: label
+        :type: str
     
 
 
@@ -3685,7 +3693,7 @@ Device
 
 .. py:class:: slangpy.DeclReflectionChildList
 
-    DeclReflection lazy child list evaluation.
+    
     
 
 
@@ -3693,7 +3701,7 @@ Device
 
 .. py:class:: slangpy.DeclReflectionIndexedChildList
 
-    DeclReflection lazy search result evaluation.
+    
     
 
 
@@ -3764,13 +3772,27 @@ Device
 
 ----
 
+.. py:class:: slangpy.DescriptorHandle
+
+    
+    
+    .. py:property:: type
+        :type: slangpy.DescriptorHandleType
+    
+    .. py:property:: value
+        :type: int
+    
+
+
+----
+
 .. py:class:: slangpy.Device
 
     Base class: :py:class:`slangpy.Object`
     
     
     
-    .. py:method:: __init__(self, type: slangpy.DeviceType = DeviceType.automatic, enable_debug_layers: bool = False, enable_cuda_interop: bool = False, enable_print: bool = False, enable_hot_reload: bool = True, adapter_luid: collections.abc.Sequence[int] | None = None, compiler_options: slangpy.SlangCompilerOptions | None = None, shader_cache_path: str | os.PathLike | None = None) -> None
+    .. py:method:: __init__(self, type: slangpy.DeviceType = DeviceType.automatic, enable_debug_layers: bool = False, enable_cuda_interop: bool = False, enable_print: bool = False, enable_hot_reload: bool = True, enable_compilation_reports: bool = False, adapter_luid: collections.abc.Sequence[int] | None = None, compiler_options: slangpy.SlangCompilerOptions | None = None, shader_cache_path: str | os.PathLike | None = None, existing_device_handles: collections.abc.Sequence[slangpy.NativeHandle] | None = None) -> None
     
     .. py:method:: __init__(self, desc: slangpy.DeviceDesc) -> None
         :no-index:
@@ -3806,8 +3828,7 @@ Device
     .. py:property:: native_handles
         :type: list[slangpy.NativeHandle]
     
-        Returns the native API handle: - D3D12: ID3D12Device* (0) - Vulkan:
-        VkInstance (0), VkPhysicalDevice (1), VkDevice (2)
+        Get the native device handles.
         
     .. py:method:: has_feature(self, feature: slangpy.Feature) -> bool
     
@@ -3857,7 +3878,7 @@ Device
         Returns:
             New surface object.
         
-    .. py:method:: create_buffer(self, size: int = 0, element_count: int = 0, struct_size: int = 0, struct_type: object | None = None, format: slangpy.Format = Format.undefined, memory_type: slangpy.MemoryType = MemoryType.device_local, usage: slangpy.BufferUsage = 0, label: str = '', data: numpy.ndarray[] | None = None) -> slangpy.Buffer
+    .. py:method:: create_buffer(self, size: int = 0, element_count: int = 0, struct_size: int = 0, resource_type_layout: object | None = None, format: slangpy.Format = Format.undefined, memory_type: slangpy.MemoryType = MemoryType.device_local, usage: slangpy.BufferUsage = 0, default_state: slangpy.ResourceState = ResourceState.undefined, label: str = '', data: numpy.ndarray[] | None = None) -> slangpy.Buffer
     
         Create a new buffer.
         
@@ -3871,9 +3892,9 @@ Device
         Parameter ``struct_size``:
             Struct size in bytes.
         
-        Parameter ``struct_type``:
-            Struct type. Can be used instead of ``struct_size`` to specify the
-            size of the struct.
+        Parameter ``resource_type_layout``:
+            Resource type layout of the buffer. Can be used instead of
+            ``struct_size`` to specify the size of the struct.
         
         Parameter ``format``:
             Buffer format. Used when creating typed buffer views.
@@ -3902,7 +3923,7 @@ Device
     .. py:method:: create_buffer(self, desc: slangpy.BufferDesc) -> slangpy.Buffer
         :no-index:
     
-    .. py:method:: create_texture(self, type: slangpy.TextureType = TextureType.texture_2d, format: slangpy.Format = Format.undefined, width: int = 1, height: int = 1, depth: int = 1, array_length: int = 1, mip_count: int = 1, sample_count: int = 1, sample_quality: int = 0, memory_type: slangpy.MemoryType = MemoryType.device_local, usage: slangpy.TextureUsage = 0, label: str = '', data: numpy.ndarray[] | None = None) -> slangpy.Texture
+    .. py:method:: create_texture(self, type: slangpy.TextureType = TextureType.texture_2d, format: slangpy.Format = Format.undefined, width: int = 1, height: int = 1, depth: int = 1, array_length: int = 1, mip_count: int = 1, sample_count: int = 1, sample_quality: int = 0, memory_type: slangpy.MemoryType = MemoryType.device_local, usage: slangpy.TextureUsage = 0, default_state: slangpy.ResourceState = ResourceState.undefined, label: str = '', data: numpy.ndarray[] | None = None) -> slangpy.Texture
     
         Create a new texture.
         
@@ -4051,14 +4072,60 @@ Device
     
     .. py:method:: create_command_encoder(self, queue: slangpy.CommandQueueType = CommandQueueType.graphics) -> slangpy.CommandEncoder
     
-    .. py:method:: submit_command_buffers(self, command_buffers: Sequence[slangpy.CommandBuffer], wait_fences: Sequence[slangpy.Fence] = [], wait_fence_values: Sequence[int] = [], signal_fences: Sequence[slangpy.Fence] = [], signal_fence_values: Sequence[int] = [], queue: slangpy.CommandQueueType = CommandQueueType.graphics) -> int
+    .. py:method:: submit_command_buffers(self, command_buffers: Sequence[slangpy.CommandBuffer], wait_fences: Sequence[slangpy.Fence] = [], wait_fence_values: Sequence[int] = [], signal_fences: Sequence[slangpy.Fence] = [], signal_fence_values: Sequence[int] = [], queue: slangpy.CommandQueueType = CommandQueueType.graphics, cuda_stream: slangpy.NativeHandle = NativeHandle(type=undefined, value=0x00000000)) -> int
     
+        Submit a list of command buffers to the device.
+        
+        The returned submission ID can be used to wait for the submission to
+        complete.
+        
+        The wait fence values are optional. If not provided, the fence values
+        will be set to AUTO, which means waiting for the last signaled value.
+        
+        The signal fence values are optional. If not provided, the fence
+        values will be set to AUTO, which means incrementing the last signaled
+        value by 1. *
+        
+        Parameter ``command_buffers``:
+            List of command buffers to submit.
+        
+        Parameter ``wait_fences``:
+            List of fences to wait for before executing the command buffers.
+        
+        Parameter ``wait_fence_values``:
+            List of fence values to wait for before executing the command
+            buffers.
+        
+        Parameter ``signal_fences``:
+            List of fences to signal after executing the command buffers.
+        
+        Parameter ``signal_fence_values``:
+            List of fence values to signal after executing the command
+            buffers.
+        
+        Parameter ``queue``:
+            Command queue to submit to.
+        
+        Parameter ``cuda_stream``:
+            On none-CUDA backends, when interop is enabled, this is the stream
+            to sync with before/after submission (assuming any resources are
+            shared with CUDA) and use for internal copies. If not specified,
+            sync will happen with the NULL (default) CUDA stream. On CUDA
+            backends, this is the CUDA stream to use for the submission. If
+            not specified, the default stream of the command queue will be
+            used, which for CommandQueueType::graphics is the NULL stream. It
+            is an error to specify a stream for none-CUDA backends that have
+            interop disabled.
+        
+        Returns:
+            Submission ID.
+        
     .. py:method:: submit_command_buffer(self, command_buffer: slangpy.CommandBuffer, queue: slangpy.CommandQueueType = CommandQueueType.graphics) -> int
     
         Submit a command buffer to the device.
         
-        The returned submission ID can be used to wait for the command buffer
-        to complete.
+        The returned submission ID can be used to wait for the submission to
+        complete.
         
         Parameter ``command_buffer``:
             Command buffer to submit.
@@ -4071,17 +4138,17 @@ Device
         
     .. py:method:: is_submit_finished(self, id: int) -> bool
     
-        Check if a command buffer is complete.
+        Check if a submission is finished executing.
         
         Parameter ``id``:
             Submission ID.
         
         Returns:
-            True if the command buffer is complete.
+            True if the submission is finished executing.
         
     .. py:method:: wait_for_submit(self, id: int) -> None
     
-        Wait for a command buffer to complete.
+        Wait for a submission to finish execution.
         
         Parameter ``id``:
             Submission ID.
@@ -4206,31 +4273,19 @@ Device
         
     .. py:method:: coopvec_query_matrix_size(self, rows: int, cols: int, layout: slangpy.CoopVecMatrixLayout, element_type: slangpy.DataType) -> int
     
-        N/A
-        
     .. py:method:: coopvec_create_matrix_desc(self, rows: int, cols: int, layout: slangpy.CoopVecMatrixLayout, element_type: slangpy.DataType, offset: int = 0) -> slangpy.CoopVecMatrixDesc
     
-        N/A
-        
     .. py:method:: coopvec_convert_matrix_host(self, src: ndarray[device='cpu'], dst: ndarray[device='cpu'], src_layout: slangpy.CoopVecMatrixLayout | None = None, dst_layout: slangpy.CoopVecMatrixLayout | None = None) -> int
     
-        N/A
-        
     .. py:method:: coopvec_convert_matrix_device(self, src: slangpy.Buffer, src_desc: slangpy.CoopVecMatrixDesc, dst: slangpy.Buffer, dst_desc: slangpy.CoopVecMatrixDesc, encoder: slangpy.CommandEncoder | None = None) -> None
     
-        N/A
-        
     .. py:method:: coopvec_convert_matrix_device(self, src: slangpy.Buffer, src_desc: collections.abc.Sequence[slangpy.CoopVecMatrixDesc], dst: slangpy.Buffer, dst_desc: collections.abc.Sequence[slangpy.CoopVecMatrixDesc], encoder: slangpy.CommandEncoder | None = None) -> None
         :no-index:
     
     .. py:method:: coopvec_align_matrix_offset(self, offset: int) -> int
     
-        N/A
-        
     .. py:method:: coopvec_align_vector_offset(self, offset: int) -> int
     
-        N/A
-        
     .. py:staticmethod:: enumerate_adapters(type: slangpy.DeviceType = DeviceType.automatic) -> list[slangpy.AdapterInfo]
     
         Enumerates all available adapters of a given device type.
@@ -4278,6 +4333,11 @@ Device
     
         Adapter LUID to select adapter on which the device will be created.
         
+    .. py:property:: enable_compilation_reports
+        :type: bool
+    
+        Enable compilation reports.
+        
     .. py:property:: adapter_luid
         :type: list[int] | None
     
@@ -4293,6 +4353,11 @@ Device
     
         Path to the shader cache directory (optional). If a relative path is
         used, the cache is stored in the application data directory.
+        
+    .. py:property:: existing_device_handles
+        :type: list[slangpy.NativeHandle]
+    
+        N/A
         
 
 
@@ -4543,7 +4608,7 @@ Device
 
 .. py:class:: slangpy.EntryPointLayoutParameterList
 
-    EntryPointLayout lazy parameter list evaluation.
+    
     
 
 
@@ -4565,9 +4630,17 @@ Device
         :type: Feature
         :value: Feature.parameter_block
     
+    .. py:attribute:: slangpy.Feature.bindless
+        :type: Feature
+        :value: Feature.bindless
+    
     .. py:attribute:: slangpy.Feature.surface
         :type: Feature
         :value: Feature.surface
+    
+    .. py:attribute:: slangpy.Feature.pipeline_cache
+        :type: Feature
+        :value: Feature.pipeline_cache
     
     .. py:attribute:: slangpy.Feature.rasterization
         :type: Feature
@@ -4608,6 +4681,10 @@ Device
     .. py:attribute:: slangpy.Feature.acceleration_structure_spheres
         :type: Feature
         :value: Feature.acceleration_structure_spheres
+    
+    .. py:attribute:: slangpy.Feature.acceleration_structure_linear_swept_spheres
+        :type: Feature
+        :value: Feature.acceleration_structure_linear_swept_spheres
     
     .. py:attribute:: slangpy.Feature.ray_tracing
         :type: Feature
@@ -4803,14 +4880,13 @@ Device
     .. py:property:: shared_handle
         :type: slangpy.NativeHandle
     
-        Get the shared fence handle. Throws if the fence was not created with
-        the ``FenceDesc::shared`` flag.
+        Get the shared fence handle. Note: Fence must be created with the
+        ``FenceDesc::shared`` flag.
         
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
-        Returns the native API handle: - D3D12: ID3D12Fence* - Vulkan:
-        currently not supported
+        Get the native fence handle.
         
     .. py:attribute:: slangpy.Fence.AUTO
         :type: int
@@ -5308,53 +5384,69 @@ Device
         :type: FormatSupport
         :value: 0
     
-    .. py:attribute:: slangpy.FormatSupport.buffer
+    .. py:attribute:: slangpy.FormatSupport.copy_source
         :type: FormatSupport
         :value: 1
     
-    .. py:attribute:: slangpy.FormatSupport.index_buffer
+    .. py:attribute:: slangpy.FormatSupport.copy_destination
         :type: FormatSupport
         :value: 2
     
-    .. py:attribute:: slangpy.FormatSupport.vertex_buffer
+    .. py:attribute:: slangpy.FormatSupport.texture
         :type: FormatSupport
         :value: 4
     
-    .. py:attribute:: slangpy.FormatSupport.texture
+    .. py:attribute:: slangpy.FormatSupport.depth_stencil
         :type: FormatSupport
         :value: 8
     
-    .. py:attribute:: slangpy.FormatSupport.depth_stencil
+    .. py:attribute:: slangpy.FormatSupport.render_target
         :type: FormatSupport
         :value: 16
     
-    .. py:attribute:: slangpy.FormatSupport.render_target
+    .. py:attribute:: slangpy.FormatSupport.blendable
         :type: FormatSupport
         :value: 32
     
-    .. py:attribute:: slangpy.FormatSupport.blendable
+    .. py:attribute:: slangpy.FormatSupport.multisampling
         :type: FormatSupport
         :value: 64
     
-    .. py:attribute:: slangpy.FormatSupport.shader_load
+    .. py:attribute:: slangpy.FormatSupport.resolvable
         :type: FormatSupport
         :value: 128
     
-    .. py:attribute:: slangpy.FormatSupport.shader_sample
+    .. py:attribute:: slangpy.FormatSupport.shader_load
         :type: FormatSupport
         :value: 256
     
-    .. py:attribute:: slangpy.FormatSupport.shader_uav_load
+    .. py:attribute:: slangpy.FormatSupport.shader_sample
         :type: FormatSupport
         :value: 512
     
-    .. py:attribute:: slangpy.FormatSupport.shader_uav_store
+    .. py:attribute:: slangpy.FormatSupport.shader_uav_load
         :type: FormatSupport
         :value: 1024
     
-    .. py:attribute:: slangpy.FormatSupport.shader_atomic
+    .. py:attribute:: slangpy.FormatSupport.shader_uav_store
         :type: FormatSupport
         :value: 2048
+    
+    .. py:attribute:: slangpy.FormatSupport.shader_atomic
+        :type: FormatSupport
+        :value: 4096
+    
+    .. py:attribute:: slangpy.FormatSupport.buffer
+        :type: FormatSupport
+        :value: 8192
+    
+    .. py:attribute:: slangpy.FormatSupport.index_buffer
+        :type: FormatSupport
+        :value: 16384
+    
+    .. py:attribute:: slangpy.FormatSupport.vertex_buffer
+        :type: FormatSupport
+        :value: 32768
     
 
 
@@ -5463,7 +5555,7 @@ Device
 
 .. py:class:: slangpy.FunctionReflectionOverloadList
 
-    FunctionReflection lazy overload list evaluation.
+    
     
 
 
@@ -5471,7 +5563,7 @@ Device
 
 .. py:class:: slangpy.FunctionReflectionParameterList
 
-    FunctionReflection lazy parameter list evaluation.
+    
     
 
 
@@ -5764,6 +5856,11 @@ Device
 
     N/A
     
+    .. py:method:: __init__(self) -> None
+    
+    .. py:method:: __init__(self, arg0: slangpy.NativeHandleType, arg1: int, /) -> None
+        :no-index:
+    
     .. py:property:: type
         :type: slangpy.NativeHandleType
     
@@ -5771,6 +5868,10 @@ Device
         
     .. py:property:: value
         :type: int
+    
+        N/A
+        
+    .. py:staticmethod:: from_cuda_stream(stream: int) -> slangpy.NativeHandle
     
         N/A
         
@@ -5782,7 +5883,7 @@ Device
 
     Base class: :py:class:`enum.Enum`
     
-    N/A
+    
     
     .. py:attribute:: slangpy.NativeHandleType.undefined
         :type: NativeHandleType
@@ -5936,6 +6037,10 @@ Device
         :type: NativeHandleType
         :value: NativeHandleType.CUstream
     
+    .. py:attribute:: slangpy.NativeHandleType.CUcontext
+        :type: NativeHandleType
+        :value: NativeHandleType.CUcontext
+    
     .. py:attribute:: slangpy.NativeHandleType.OptixDeviceContext
         :type: NativeHandleType
         :value: NativeHandleType.OptixDeviceContext
@@ -6022,7 +6127,7 @@ Device
 
     Base class: :py:class:`slangpy.DeviceResource`
     
-    Pipeline base class.
+    
     
 
 
@@ -6121,7 +6226,7 @@ Device
 
 .. py:class:: slangpy.ProgramLayoutEntryPointList
 
-    ProgramLayout lazy entry point list evaluation.
+    
     
 
 
@@ -6129,7 +6234,7 @@ Device
 
 .. py:class:: slangpy.ProgramLayoutParameterList
 
-    ProgramLayout lazy parameter list evaluation.
+    
     
 
 
@@ -6275,13 +6380,12 @@ Device
 
     Base class: :py:class:`slangpy.Pipeline`
     
-    Ray tracing pipeline.
+    
     
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
-        Returns the native API handle: - D3D12: ID3D12PipelineState* - Vulkan:
-        VkPipeline
+        Get the native pipeline handle.
         
 
 
@@ -6313,6 +6417,9 @@ Device
     
     .. py:property:: flags
         :type: slangpy.RayTracingPipelineFlags
+    
+    .. py:property:: label
+        :type: str
     
 
 
@@ -6468,9 +6575,9 @@ Device
     
     .. py:method:: draw_indexed(self, args: slangpy.DrawArguments) -> None
     
-    .. py:method:: draw_indirect(self, max_draw_count: int, arg_buffer: slangpy.BufferOffsetPair, count_buffer: slangpy.BufferOffsetPair = <slangpy.BufferOffsetPair object at 0x000002A6A1F68780>) -> None
+    .. py:method:: draw_indirect(self, max_draw_count: int, arg_buffer: slangpy.BufferOffsetPair, count_buffer: slangpy.BufferOffsetPair = <slangpy.BufferOffsetPair object at 0x000001D52913AA60>) -> None
     
-    .. py:method:: draw_indexed_indirect(self, max_draw_count: int, arg_buffer: slangpy.BufferOffsetPair, count_buffer: slangpy.BufferOffsetPair = <slangpy.BufferOffsetPair object at 0x000002A6A225D080>) -> None
+    .. py:method:: draw_indexed_indirect(self, max_draw_count: int, arg_buffer: slangpy.BufferOffsetPair, count_buffer: slangpy.BufferOffsetPair = <slangpy.BufferOffsetPair object at 0x000001D5292AD410>) -> None
     
     .. py:method:: draw_mesh_tasks(self, dimensions: slangpy.math.uint3) -> None
     
@@ -6482,13 +6589,12 @@ Device
 
     Base class: :py:class:`slangpy.Pipeline`
     
-    Render pipeline.
+    
     
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
-        Returns the native API handle: - D3D12: ID3D12PipelineState* - Vulkan:
-        VkPipeline
+        Get the native pipeline handle.
         
 
 
@@ -6523,6 +6629,9 @@ Device
     
     .. py:property:: multisample
         :type: slangpy.MultisampleDesc
+    
+    .. py:property:: label
+        :type: str
     
 
 
@@ -6563,27 +6672,27 @@ Device
 
     Base class: :py:class:`enum.IntFlag`
     
-    .. py:attribute:: slangpy.RenderTargetWriteMask.enable_none
+    .. py:attribute:: slangpy.RenderTargetWriteMask.none
         :type: RenderTargetWriteMask
         :value: 0
     
-    .. py:attribute:: slangpy.RenderTargetWriteMask.enable_red
+    .. py:attribute:: slangpy.RenderTargetWriteMask.red
         :type: RenderTargetWriteMask
         :value: 1
     
-    .. py:attribute:: slangpy.RenderTargetWriteMask.enable_green
+    .. py:attribute:: slangpy.RenderTargetWriteMask.green
         :type: RenderTargetWriteMask
         :value: 2
     
-    .. py:attribute:: slangpy.RenderTargetWriteMask.enable_blue
+    .. py:attribute:: slangpy.RenderTargetWriteMask.blue
         :type: RenderTargetWriteMask
         :value: 4
     
-    .. py:attribute:: slangpy.RenderTargetWriteMask.enable_alpha
+    .. py:attribute:: slangpy.RenderTargetWriteMask.alpha
         :type: RenderTargetWriteMask
         :value: 8
     
-    .. py:attribute:: slangpy.RenderTargetWriteMask.enable_all
+    .. py:attribute:: slangpy.RenderTargetWriteMask.all
         :type: RenderTargetWriteMask
         :value: 15
     
@@ -6600,8 +6709,7 @@ Device
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
-        Returns the native API handle: - D3D12: ID3D12Resource* - Vulkan:
-        VkBuffer or VkImage
+        Get the native resource handle.
         
 
 
@@ -6700,11 +6808,13 @@ Device
     .. py:property:: desc
         :type: slangpy.SamplerDesc
     
+    .. py:property:: descriptor_handle
+        :type: slangpy.DescriptorHandle
+    
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
-        Returns the native API handle: - D3D12: D3D12_CPU_DESCRIPTOR_HANDLE -
-        Vulkan: VkSampler
+        Get the native sampler handle.
         
 
 
@@ -6817,12 +6927,7 @@ Device
 
 .. py:class:: slangpy.ShaderCursor
 
-    Cursor used for parsing and setting shader object fields. This class
-    does *NOT* use the SGL reflection wrappers for accessing due to the
-    performance implications of allocating/freeing them repeatedly. This
-    is far faster, however does introduce a risk of mem access problems if
-    the shader cursor is kept alive longer than the shader object it was
-    created from.
+    
     
     .. py:method:: __init__(self, shader_object: slangpy.ShaderObject) -> None
     
@@ -7383,7 +7488,7 @@ Device
 
     Base class: :py:class:`slangpy.Object`
     
-    A slang session, used to load modules and link programs.
+    
     
     .. py:property:: device
         :type: slangpy.Device
@@ -7419,7 +7524,7 @@ Device
 
 .. py:class:: slangpy.SlangSessionDesc
 
-    Descriptor for slang session initialization.
+    
     
     .. py:method:: __init__(self) -> None
     
@@ -7594,17 +7699,21 @@ Device
         Returns the surface info.
         
     .. py:property:: config
-        :type: slangpy.SurfaceConfig
+        :type: slangpy.SurfaceConfig | None
     
         Returns the surface config.
         
-    .. py:method:: configure(self, width: int, height: int, format: slangpy.Format = Format.undefined, usage: slangpy.TextureUsage = 4, desired_image_count: int = 3, vsync: bool = True) -> None
+    .. py:method:: configure(self, width: int, height: int, format: slangpy.Format = Format.undefined, usage: slangpy.TextureUsage = 0, desired_image_count: int = 3, vsync: bool = True) -> None
     
         Configure the surface.
         
     .. py:method:: configure(self, config: slangpy.SurfaceConfig) -> None
         :no-index:
     
+    .. py:method:: unconfigure(self) -> None
+    
+        Unconfigure the surface.
+        
     .. py:method:: acquire_next_image(self) -> slangpy.Texture
     
         Acquries the next surface image.
@@ -7722,7 +7831,8 @@ Device
     .. py:property:: shared_handle
         :type: slangpy.NativeHandle
     
-        Get the shared resource handle.
+        Get the shared resource handle. Note: Texture must be created with the
+        ``TextureUsage::shared`` usage flag.
         
     .. py:method:: get_mip_width(self, mip: int = 0) -> int
     
@@ -8040,9 +8150,17 @@ Device
     .. py:property:: label
         :type: str
     
+    .. py:property:: descriptor_handle_ro
+        :type: slangpy.DescriptorHandle
+    
+    .. py:property:: descriptor_handle_rw
+        :type: slangpy.DescriptorHandle
+    
     .. py:property:: native_handle
         :type: slangpy.NativeHandle
     
+        Get the native texture view handle.
+        
 
 
 ----
@@ -8143,7 +8261,7 @@ Device
 
 .. py:class:: slangpy.TypeLayoutReflectionFieldList
 
-    TypeLayoutReflection lazy field list evaluation.
+    
     
 
 
@@ -8537,7 +8655,7 @@ Device
 
 .. py:class:: slangpy.TypeReflectionFieldList
 
-    TypeReflection lazy field list evaluation.
+    
     
 
 
@@ -8758,7 +8876,7 @@ Application
     
     
     
-    .. py:method:: __init__(self, app: slangpy.App, width: int = 1920, height: int = 1280, title: str = 'sgl', mode: slangpy.WindowMode = WindowMode.normal, resizable: bool = True, surface_format: slangpy.Format = Format.undefined, enable_vsync: bool = False) -> None
+    .. py:method:: __init__(self, app: slangpy.App, width: int = 1920, height: int = 1280, title: str = 'slangpy', mode: slangpy.WindowMode = WindowMode.normal, resizable: bool = True, surface_format: slangpy.Format = Format.undefined, enable_vsync: bool = False) -> None
     
     .. py:class:: slangpy.AppWindow.RenderContext
     
@@ -9699,6 +9817,108 @@ Math
 
 ----
 
+.. py:class:: slangpy.math.float2x3
+
+    .. py:method:: __init__(self) -> None
+    
+    .. py:method:: __init__(self, arg: collections.abc.Sequence[float], /) -> None
+        :no-index:
+    
+    .. py:method:: __init__(self, arg: ndarray[dtype=float32, shape=(2, 3)], /) -> None
+        :no-index:
+    
+    .. py:staticmethod:: zeros() -> slangpy.math.float2x3
+    
+    .. py:staticmethod:: identity() -> slangpy.math.float2x3
+    
+    .. py:method:: get_row(self, row: int) -> slangpy.math.float3
+    
+    .. py:method:: set_row(self, row: int, value: slangpy.math.float3) -> None
+    
+    .. py:method:: get_col(self, col: int) -> slangpy.math.float2
+    
+    .. py:method:: set_col(self, col: int, value: slangpy.math.float2) -> None
+    
+    .. py:property:: shape
+        :type: tuple
+    
+    .. py:property:: element_type
+        :type: object
+    
+    .. py:method:: to_numpy(self) -> numpy.ndarray[dtype=float32, shape=(2, 3), writable=False]
+    
+
+
+----
+
+.. py:class:: slangpy.math.float2x4
+
+    .. py:method:: __init__(self) -> None
+    
+    .. py:method:: __init__(self, arg: collections.abc.Sequence[float], /) -> None
+        :no-index:
+    
+    .. py:method:: __init__(self, arg: ndarray[dtype=float32, shape=(2, 4)], /) -> None
+        :no-index:
+    
+    .. py:staticmethod:: zeros() -> slangpy.math.float2x4
+    
+    .. py:staticmethod:: identity() -> slangpy.math.float2x4
+    
+    .. py:method:: get_row(self, row: int) -> slangpy.math.float4
+    
+    .. py:method:: set_row(self, row: int, value: slangpy.math.float4) -> None
+    
+    .. py:method:: get_col(self, col: int) -> slangpy.math.float2
+    
+    .. py:method:: set_col(self, col: int, value: slangpy.math.float2) -> None
+    
+    .. py:property:: shape
+        :type: tuple
+    
+    .. py:property:: element_type
+        :type: object
+    
+    .. py:method:: to_numpy(self) -> numpy.ndarray[dtype=float32, shape=(2, 4), writable=False]
+    
+
+
+----
+
+.. py:class:: slangpy.math.float3x2
+
+    .. py:method:: __init__(self) -> None
+    
+    .. py:method:: __init__(self, arg: collections.abc.Sequence[float], /) -> None
+        :no-index:
+    
+    .. py:method:: __init__(self, arg: ndarray[dtype=float32, shape=(3, 2)], /) -> None
+        :no-index:
+    
+    .. py:staticmethod:: zeros() -> slangpy.math.float3x2
+    
+    .. py:staticmethod:: identity() -> slangpy.math.float3x2
+    
+    .. py:method:: get_row(self, row: int) -> slangpy.math.float2
+    
+    .. py:method:: set_row(self, row: int, value: slangpy.math.float2) -> None
+    
+    .. py:method:: get_col(self, col: int) -> slangpy.math.float3
+    
+    .. py:method:: set_col(self, col: int, value: slangpy.math.float3) -> None
+    
+    .. py:property:: shape
+        :type: tuple
+    
+    .. py:property:: element_type
+        :type: object
+    
+    .. py:method:: to_numpy(self) -> numpy.ndarray[dtype=float32, shape=(3, 2), writable=False]
+    
+
+
+----
+
 .. py:class:: slangpy.math.float3x3
 
     .. py:method:: __init__(self) -> None
@@ -9739,40 +9959,6 @@ Math
 
 ----
 
-.. py:class:: slangpy.math.float2x4
-
-    .. py:method:: __init__(self) -> None
-    
-    .. py:method:: __init__(self, arg: collections.abc.Sequence[float], /) -> None
-        :no-index:
-    
-    .. py:method:: __init__(self, arg: ndarray[dtype=float32, shape=(2, 4)], /) -> None
-        :no-index:
-    
-    .. py:staticmethod:: zeros() -> slangpy.math.float2x4
-    
-    .. py:staticmethod:: identity() -> slangpy.math.float2x4
-    
-    .. py:method:: get_row(self, row: int) -> slangpy.math.float4
-    
-    .. py:method:: set_row(self, row: int, value: slangpy.math.float4) -> None
-    
-    .. py:method:: get_col(self, col: int) -> slangpy.math.float2
-    
-    .. py:method:: set_col(self, col: int, value: slangpy.math.float2) -> None
-    
-    .. py:property:: shape
-        :type: tuple
-    
-    .. py:property:: element_type
-        :type: object
-    
-    .. py:method:: to_numpy(self) -> numpy.ndarray[dtype=float32, shape=(2, 4), writable=False]
-    
-
-
-----
-
 .. py:class:: slangpy.math.float3x4
 
     .. py:method:: __init__(self) -> None
@@ -9808,6 +9994,74 @@ Math
         :type: object
     
     .. py:method:: to_numpy(self) -> numpy.ndarray[dtype=float32, shape=(3, 4), writable=False]
+    
+
+
+----
+
+.. py:class:: slangpy.math.float4x2
+
+    .. py:method:: __init__(self) -> None
+    
+    .. py:method:: __init__(self, arg: collections.abc.Sequence[float], /) -> None
+        :no-index:
+    
+    .. py:method:: __init__(self, arg: ndarray[dtype=float32, shape=(4, 2)], /) -> None
+        :no-index:
+    
+    .. py:staticmethod:: zeros() -> slangpy.math.float4x2
+    
+    .. py:staticmethod:: identity() -> slangpy.math.float4x2
+    
+    .. py:method:: get_row(self, row: int) -> slangpy.math.float2
+    
+    .. py:method:: set_row(self, row: int, value: slangpy.math.float2) -> None
+    
+    .. py:method:: get_col(self, col: int) -> slangpy.math.float4
+    
+    .. py:method:: set_col(self, col: int, value: slangpy.math.float4) -> None
+    
+    .. py:property:: shape
+        :type: tuple
+    
+    .. py:property:: element_type
+        :type: object
+    
+    .. py:method:: to_numpy(self) -> numpy.ndarray[dtype=float32, shape=(4, 2), writable=False]
+    
+
+
+----
+
+.. py:class:: slangpy.math.float4x3
+
+    .. py:method:: __init__(self) -> None
+    
+    .. py:method:: __init__(self, arg: collections.abc.Sequence[float], /) -> None
+        :no-index:
+    
+    .. py:method:: __init__(self, arg: ndarray[dtype=float32, shape=(4, 3)], /) -> None
+        :no-index:
+    
+    .. py:staticmethod:: zeros() -> slangpy.math.float4x3
+    
+    .. py:staticmethod:: identity() -> slangpy.math.float4x3
+    
+    .. py:method:: get_row(self, row: int) -> slangpy.math.float3
+    
+    .. py:method:: set_row(self, row: int, value: slangpy.math.float3) -> None
+    
+    .. py:method:: get_col(self, col: int) -> slangpy.math.float4
+    
+    .. py:method:: set_col(self, col: int, value: slangpy.math.float4) -> None
+    
+    .. py:property:: shape
+        :type: tuple
+    
+    .. py:property:: element_type
+        :type: object
+    
+    .. py:method:: to_numpy(self) -> numpy.ndarray[dtype=float32, shape=(4, 3), writable=False]
     
 
 
@@ -9862,10 +10116,10 @@ Math
 
 ----
 
-.. py:class:: slangpy.float3x3
-    :canonical: slangpy.math.float3x3
+.. py:class:: slangpy.float2x3
+    :canonical: slangpy.math.float2x3
     
-    Alias class: :py:class:`slangpy.math.float3x3`
+    Alias class: :py:class:`slangpy.math.float2x3`
     
 
 
@@ -9880,10 +10134,46 @@ Math
 
 ----
 
+.. py:class:: slangpy.float3x2
+    :canonical: slangpy.math.float3x2
+    
+    Alias class: :py:class:`slangpy.math.float3x2`
+    
+
+
+----
+
+.. py:class:: slangpy.float3x3
+    :canonical: slangpy.math.float3x3
+    
+    Alias class: :py:class:`slangpy.math.float3x3`
+    
+
+
+----
+
 .. py:class:: slangpy.float3x4
     :canonical: slangpy.math.float3x4
     
     Alias class: :py:class:`slangpy.math.float3x4`
+    
+
+
+----
+
+.. py:class:: slangpy.float4x2
+    :canonical: slangpy.math.float4x2
+    
+    Alias class: :py:class:`slangpy.math.float4x2`
+    
+
+
+----
+
+.. py:class:: slangpy.float4x3
+    :canonical: slangpy.math.float4x3
+    
+    Alias class: :py:class:`slangpy.math.float4x3`
     
 
 
@@ -11150,13 +11440,25 @@ Math
 
 .. py:function:: slangpy.math.transpose(x: slangpy.math.float2x2) -> slangpy.math.float2x2
 
+.. py:function:: slangpy.math.transpose(x: slangpy.math.float2x3) -> slangpy.math.float3x2
+    :no-index:
+
+.. py:function:: slangpy.math.transpose(x: slangpy.math.float2x4) -> slangpy.math.float4x2
+    :no-index:
+
+.. py:function:: slangpy.math.transpose(x: slangpy.math.float3x2) -> slangpy.math.float2x3
+    :no-index:
+
 .. py:function:: slangpy.math.transpose(x: slangpy.math.float3x3) -> slangpy.math.float3x3
     :no-index:
 
-.. py:function:: slangpy.math.transpose(x: slangpy.math.float2x4) -> sgl::math::matrix<float,4,2>
+.. py:function:: slangpy.math.transpose(x: slangpy.math.float3x4) -> slangpy.math.float4x3
     :no-index:
 
-.. py:function:: slangpy.math.transpose(x: slangpy.math.float3x4) -> sgl::math::matrix<float,4,3>
+.. py:function:: slangpy.math.transpose(x: slangpy.math.float4x2) -> slangpy.math.float2x4
+    :no-index:
+
+.. py:function:: slangpy.math.transpose(x: slangpy.math.float4x3) -> slangpy.math.float3x4
     :no-index:
 
 .. py:function:: slangpy.math.transpose(x: slangpy.math.float4x4) -> slangpy.math.float4x4
@@ -11201,6 +11503,33 @@ Math
 .. py:function:: slangpy.math.mul(x: slangpy.math.float2, y: slangpy.math.float2x2) -> slangpy.math.float2
     :no-index:
 
+.. py:function:: slangpy.math.mul(x: slangpy.math.float2x3, y: slangpy.math.float3x2) -> slangpy.math.float2x2
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float2x3, y: slangpy.math.float3) -> slangpy.math.float2
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float2, y: slangpy.math.float2x3) -> slangpy.math.float3
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float2x4, y: slangpy.math.float4x2) -> slangpy.math.float2x2
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float2x4, y: slangpy.math.float4) -> slangpy.math.float2
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float2, y: slangpy.math.float2x4) -> slangpy.math.float4
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float3x2, y: slangpy.math.float2x3) -> slangpy.math.float3x3
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float3x2, y: slangpy.math.float2) -> slangpy.math.float3
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float3, y: slangpy.math.float3x2) -> slangpy.math.float2
+    :no-index:
+
 .. py:function:: slangpy.math.mul(x: slangpy.math.float3x3, y: slangpy.math.float3x3) -> slangpy.math.float3x3
     :no-index:
 
@@ -11210,22 +11539,31 @@ Math
 .. py:function:: slangpy.math.mul(x: slangpy.math.float3, y: slangpy.math.float3x3) -> slangpy.math.float3
     :no-index:
 
-.. py:function:: slangpy.math.mul(x: slangpy.math.float2x4, y: sgl::math::matrix<float,4,2>) -> slangpy.math.float2x2
-    :no-index:
-
-.. py:function:: slangpy.math.mul(x: slangpy.math.float2x4, y: slangpy.math.float4) -> slangpy.math.float2
-    :no-index:
-
-.. py:function:: slangpy.math.mul(x: slangpy.math.float2, y: slangpy.math.float2x4) -> slangpy.math.float4
-    :no-index:
-
-.. py:function:: slangpy.math.mul(x: slangpy.math.float3x4, y: sgl::math::matrix<float,4,3>) -> slangpy.math.float3x3
+.. py:function:: slangpy.math.mul(x: slangpy.math.float3x4, y: slangpy.math.float4x3) -> slangpy.math.float3x3
     :no-index:
 
 .. py:function:: slangpy.math.mul(x: slangpy.math.float3x4, y: slangpy.math.float4) -> slangpy.math.float3
     :no-index:
 
 .. py:function:: slangpy.math.mul(x: slangpy.math.float3, y: slangpy.math.float3x4) -> slangpy.math.float4
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float4x2, y: slangpy.math.float2x4) -> slangpy.math.float4x4
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float4x2, y: slangpy.math.float2) -> slangpy.math.float4
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float4, y: slangpy.math.float4x2) -> slangpy.math.float2
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float4x3, y: slangpy.math.float3x4) -> slangpy.math.float4x4
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float4x3, y: slangpy.math.float3) -> slangpy.math.float4
+    :no-index:
+
+.. py:function:: slangpy.math.mul(x: slangpy.math.float4, y: slangpy.math.float4x3) -> slangpy.math.float3
     :no-index:
 
 .. py:function:: slangpy.math.mul(x: slangpy.math.float4x4, y: slangpy.math.float4x4) -> slangpy.math.float4x4
@@ -11352,6 +11690,12 @@ Math
 
 ----
 
+.. py:function:: slangpy.math.decompose(model_matrix: slangpy.math.float4x4, scale: slangpy.math.float3, orientation: slangpy.math.quatf, translation: slangpy.math.float3, skew: slangpy.math.float3, perspective: slangpy.math.float4) -> bool
+
+
+
+----
+
 .. py:function:: slangpy.math.conjugate(x: slangpy.math.quatf) -> slangpy.math.quatf
 
 
@@ -11453,7 +11797,7 @@ UI
 
     Base class: :py:class:`slangpy.Object`
     
-    Base class for Python UI widgets. Widgets own their children.
+    
     
     .. py:property:: parent
         :type: slangpy.ui.Widget
@@ -11487,8 +11831,7 @@ UI
 
     Base class: :py:class:`slangpy.ui.Widget`
     
-    This is the main widget that represents the screen. It is intended to
-    be used as the parent for ``Window`` widgets.
+    
     
     .. py:method:: dispatch_events(self) -> None
     
@@ -12484,7 +12827,7 @@ Utilities
 
     Base class: :py:class:`slangpy.Object`
     
-    Utility class for loading textures from bitmaps and image files.
+    
     
     .. py:method:: __init__(self, device: slangpy.Device) -> None
     
@@ -13009,6 +13352,10 @@ SlangPy
     
         N/A
         
+    .. py:method:: build_shader_object(self, context: object, data: object) -> slangpy.ShaderObject
+    
+        N/A
+        
 
 
 ----
@@ -13043,6 +13390,11 @@ SlangPy
         
     .. py:property:: shape
         :type: slangpy.slangpy.Shape
+    
+        N/A
+        
+    .. py:property:: is_param_block
+        :type: bool
     
         N/A
         
@@ -13184,6 +13536,11 @@ SlangPy
         N/A
         
     .. py:method:: append_to(self, opts: slangpy.slangpy.NativeCallRuntimeOptions, command_buffer: slangpy.CommandEncoder, *args, **kwargs) -> object
+    
+        N/A
+        
+    .. py:property:: call_group_shape
+        :type: slangpy.slangpy.Shape
     
         N/A
         
@@ -13389,6 +13746,10 @@ SlangPy
     
         N/A
         
+    .. py:method:: point_to(self, target: slangpy.slangpy.StridedBufferView) -> None
+    
+        N/A
+        
 
 
 ----
@@ -13494,6 +13855,33 @@ SlangPy
         N/A
         
     .. py:method:: gather_runtime_options(self, options: slangpy.slangpy.NativeCallRuntimeOptions) -> None
+    
+        N/A
+        
+
+
+----
+
+.. py:class:: slangpy.slangpy.NativePackedArg
+
+    Base class: :py:class:`slangpy.slangpy.NativeObject`
+    
+    .. py:method:: __init__(self, python: slangpy.slangpy.NativeMarshall, shader_object: slangpy.ShaderObject, python_object: object) -> None
+    
+        N/A
+        
+    .. py:property:: python
+        :type: slangpy.slangpy.NativeMarshall
+    
+        N/A
+        
+    .. py:property:: shader_object
+        :type: slangpy.ShaderObject
+    
+        N/A
+        
+    .. py:property:: python_object
+        :type: object
     
         N/A
         
@@ -13610,6 +13998,8 @@ SlangPy
     
     .. py:method:: with_grads(self, grad_in: slangpy.slangpy.NativeTensor | None = None, grad_out: slangpy.slangpy.NativeTensor | None = None, zero: bool = False) -> slangpy.slangpy.NativeTensor
     
+    .. py:method:: detach(self) -> slangpy.slangpy.NativeTensor
+    
 
 
 ----
@@ -13662,7 +14052,7 @@ Miscellaneous
 
 .. py:data:: slangpy.package_dir
     :type: str
-    :value: "C:\src\slangpy\slangpy"
+    :value: "C:\sbf\slangpy\slangpy"
 
 
 
@@ -13670,8 +14060,52 @@ Miscellaneous
 
 .. py:data:: slangpy.build_dir
     :type: str
-    :value: "C:/src/slangpy/build/windows-msvc/Release"
+    :value: "C:/sbf/slangpy/build/windows-msvc/Release"
 
+
+
+----
+
+.. py:class:: slangpy.DescriptorHandleType
+
+    Base class: :py:class:`enum.IntEnum`
+    
+    .. py:attribute:: slangpy.DescriptorHandleType.undefined
+        :type: DescriptorHandleType
+        :value: DescriptorHandleType.undefined
+    
+    .. py:attribute:: slangpy.DescriptorHandleType.buffer
+        :type: DescriptorHandleType
+        :value: DescriptorHandleType.buffer
+    
+    .. py:attribute:: slangpy.DescriptorHandleType.rw_buffer
+        :type: DescriptorHandleType
+        :value: DescriptorHandleType.rw_buffer
+    
+    .. py:attribute:: slangpy.DescriptorHandleType.texture
+        :type: DescriptorHandleType
+        :value: DescriptorHandleType.texture
+    
+    .. py:attribute:: slangpy.DescriptorHandleType.rw_texture
+        :type: DescriptorHandleType
+        :value: DescriptorHandleType.rw_texture
+    
+    .. py:attribute:: slangpy.DescriptorHandleType.sampler
+        :type: DescriptorHandleType
+        :value: DescriptorHandleType.sampler
+    
+    .. py:attribute:: slangpy.DescriptorHandleType.acceleration_structure
+        :type: DescriptorHandleType
+        :value: DescriptorHandleType.acceleration_structure
+    
+
+
+----
+
+.. py:function:: slangpy.get_cuda_current_context_native_handles() -> list[slangpy.NativeHandle]
+
+    N/A
+    
 
 
 ----
@@ -13954,6 +14388,15 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.core.native.NativePackedArg
+    :canonical: slangpy.slangpy.NativePackedArg
+    
+    Alias class: :py:class:`slangpy.slangpy.NativePackedArg`
+    
+
+
+----
+
 .. py:function:: slangpy.core.native.get_texture_shape(texture: slangpy.Texture, mip: int = 0) -> slangpy.slangpy.Shape
 
     N/A
@@ -14074,6 +14517,15 @@ Miscellaneous
     :canonical: slangpy.Device
     
     Alias class: :py:class:`slangpy.Device`
+    
+
+
+----
+
+.. py:class:: slangpy.core.utils.NativeHandle
+    :canonical: slangpy.NativeHandle
+    
+    Alias class: :py:class:`slangpy.NativeHandle`
     
 
 
@@ -14213,17 +14665,26 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.core.function.Shape
+    :canonical: slangpy.slangpy.Shape
+    
+    Alias class: :py:class:`slangpy.slangpy.Shape`
+    
+
+
+----
+
 .. py:class:: slangpy.core.function.IThis
 
     Base class: :py:class:`typing.Protocol`
     
     .. py:attribute:: slangpy.core.function.IThis.get_this
         :type: function
-        :value: <function IThis.get_this at 0x000002A6D15D5A80>
+        :value: <function IThis.get_this at 0x000001D538961620>
     
     .. py:attribute:: slangpy.core.function.IThis.update_this
         :type: function
-        :value: <function IThis.update_this at 0x000002A6D15D5BC0>
+        :value: <function IThis.update_this at 0x000001D538961120>
     
 
 
@@ -14241,67 +14702,71 @@ Miscellaneous
     
     .. py:attribute:: slangpy.core.function.FunctionNode.torch
         :type: function
-        :value: <function FunctionNode.torch at 0x000002A6D1611260>
+        :value: <function FunctionNode.torch at 0x000001D53897D120>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.bind
         :type: function
-        :value: <function FunctionNode.bind at 0x000002A6D1611300>
+        :value: <function FunctionNode.bind at 0x000001D53897D1C0>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.map
         :type: function
-        :value: <function FunctionNode.map at 0x000002A6D16113A0>
+        :value: <function FunctionNode.map at 0x000001D53897D260>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.set
         :type: function
-        :value: <function FunctionNode.set at 0x000002A6D1611440>
+        :value: <function FunctionNode.set at 0x000001D53897D300>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.constants
         :type: function
-        :value: <function FunctionNode.constants at 0x000002A6D16114E0>
+        :value: <function FunctionNode.constants at 0x000001D53897D3A0>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.type_conformances
         :type: function
-        :value: <function FunctionNode.type_conformances at 0x000002A6D1611580>
+        :value: <function FunctionNode.type_conformances at 0x000001D53897D440>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.return_type
         :type: function
-        :value: <function FunctionNode.return_type at 0x000002A6D16116C0>
+        :value: <function FunctionNode.return_type at 0x000001D53897D580>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.thread_group_size
         :type: function
-        :value: <function FunctionNode.thread_group_size at 0x000002A6D1611760>
+        :value: <function FunctionNode.thread_group_size at 0x000001D53897D620>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.as_func
         :type: function
-        :value: <function FunctionNode.as_func at 0x000002A6D1611800>
+        :value: <function FunctionNode.as_func at 0x000001D53897D6C0>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.as_struct
         :type: function
-        :value: <function FunctionNode.as_struct at 0x000002A6D16118A0>
+        :value: <function FunctionNode.as_struct at 0x000001D53897D760>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.debug_build_call_data
         :type: function
-        :value: <function FunctionNode.debug_build_call_data at 0x000002A6D1611940>
+        :value: <function FunctionNode.debug_build_call_data at 0x000001D53897D800>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.call
         :type: function
-        :value: <function FunctionNode.call at 0x000002A6D16119E0>
+        :value: <function FunctionNode.call at 0x000001D53897D8A0>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.append_to
         :type: function
-        :value: <function FunctionNode.append_to at 0x000002A6D1611A80>
+        :value: <function FunctionNode.append_to at 0x000001D53897D940>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.dispatch
         :type: function
-        :value: <function FunctionNode.dispatch at 0x000002A6D1611B20>
+        :value: <function FunctionNode.dispatch at 0x000001D53897D9E0>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.calc_build_info
         :type: function
-        :value: <function FunctionNode.calc_build_info at 0x000002A6D1611BC0>
+        :value: <function FunctionNode.calc_build_info at 0x000001D53897DA80>
     
     .. py:attribute:: slangpy.core.function.FunctionNode.generate_call_data
         :type: function
-        :value: <function FunctionNode.generate_call_data at 0x000002A6D1611EE0>
+        :value: <function FunctionNode.generate_call_data at 0x000001D53897DDA0>
+    
+    .. py:attribute:: slangpy.core.function.FunctionNode.call_group_shape
+        :type: function
+        :value: <function FunctionNode.call_group_shape at 0x000001D53897DE40>
     
 
 
@@ -14379,6 +14844,14 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.core.function.FunctionNodeCallGroupShape
+
+    Base class: :py:class:`slangpy.core.function.FunctionNode`
+    
+
+
+----
+
 .. py:class:: slangpy.core.function.Function
 
     Base class: :py:class:`slangpy.core.function.FunctionNode`
@@ -14408,25 +14881,25 @@ Miscellaneous
 .. py:class:: slangpy.core.struct.Struct
 
     
-        A Slang struct, typically created by accessing it via a module or parent struct. i.e. mymodule.Foo,
-        or mymodule.Foo.Bar.
-        
+    A Slang struct, typically created by accessing it via a module or parent struct. i.e. mymodule.Foo,
+    or mymodule.Foo.Bar.
+    
     
     .. py:attribute:: slangpy.core.struct.Struct.torch
         :type: function
-        :value: <function Struct.torch at 0x000002A6D1613A60>
+        :value: <function Struct.torch at 0x000001D53897FBA0>
     
     .. py:attribute:: slangpy.core.struct.Struct.try_get_child
         :type: function
-        :value: <function Struct.try_get_child at 0x000002A6D1613B00>
+        :value: <function Struct.try_get_child at 0x000001D53897FC40>
     
     .. py:attribute:: slangpy.core.struct.Struct.as_func
         :type: function
-        :value: <function Struct.as_func at 0x000002A6D1613D80>
+        :value: <function Struct.as_func at 0x000001D53897FEC0>
     
     .. py:attribute:: slangpy.core.struct.Struct.as_struct
         :type: function
-        :value: <function Struct.as_struct at 0x000002A6D1613E20>
+        :value: <function Struct.as_struct at 0x000001D53897FF60>
     
 
 
@@ -14519,7 +14992,7 @@ Miscellaneous
     
     .. py:attribute:: slangpy.core.module.CallDataCache.lookup_value_signature
         :type: function
-        :value: <function CallDataCache.lookup_value_signature at 0x000002A6DC19D940>
+        :value: <function CallDataCache.lookup_value_signature at 0x000001D5389C67A0>
     
 
 
@@ -14528,48 +15001,48 @@ Miscellaneous
 .. py:class:: slangpy.core.module.Module
 
     
-        A Slang module, created either by loading a slang file or providing a loaded SGL module.
-        
+    A Slang module, created either by loading a slang file or providing a loaded SGL module.
+    
     
     .. py:attribute:: slangpy.core.module.Module.load_from_source
         :type: function
-        :value: <function Module.load_from_source at 0x000002A6DC19DBC0>
+        :value: <function Module.load_from_source at 0x000001D5389C6A20>
     
     .. py:attribute:: slangpy.core.module.Module.load_from_file
         :type: function
-        :value: <function Module.load_from_file at 0x000002A6DC19DB20>
+        :value: <function Module.load_from_file at 0x000001D5389C6980>
     
     .. py:attribute:: slangpy.core.module.Module.load_from_module
         :type: function
-        :value: <function Module.load_from_module at 0x000002A6DC19DC60>
+        :value: <function Module.load_from_module at 0x000001D5389C6AC0>
     
     .. py:attribute:: slangpy.core.module.Module.torch
         :type: function
-        :value: <function Module.torch at 0x000002A6DC19DF80>
+        :value: <function Module.torch at 0x000001D5389C6DE0>
     
     .. py:attribute:: slangpy.core.module.Module.find_struct
         :type: function
-        :value: <function Module.find_struct at 0x000002A6DC19E020>
+        :value: <function Module.find_struct at 0x000001D5389C6E80>
     
     .. py:attribute:: slangpy.core.module.Module.require_struct
         :type: function
-        :value: <function Module.require_struct at 0x000002A6DC19E0C0>
+        :value: <function Module.require_struct at 0x000001D5389C6F20>
     
     .. py:attribute:: slangpy.core.module.Module.find_function
         :type: function
-        :value: <function Module.find_function at 0x000002A6DC19E160>
+        :value: <function Module.find_function at 0x000001D5389C6FC0>
     
     .. py:attribute:: slangpy.core.module.Module.require_function
         :type: function
-        :value: <function Module.require_function at 0x000002A6DC19E200>
+        :value: <function Module.require_function at 0x000001D5389C7060>
     
     .. py:attribute:: slangpy.core.module.Module.find_function_in_struct
         :type: function
-        :value: <function Module.find_function_in_struct at 0x000002A6DC19E2A0>
+        :value: <function Module.find_function_in_struct at 0x000001D5389C7100>
     
     .. py:attribute:: slangpy.core.module.Module.on_hot_reload
         :type: function
-        :value: <function Module.on_hot_reload at 0x000002A6DC19E340>
+        :value: <function Module.on_hot_reload at 0x000001D5389C71A0>
     
 
 
@@ -14777,6 +15250,15 @@ Miscellaneous
     :canonical: slangpy.reflection.reflectiontypes.VoidType
     
     Alias class: :py:class:`slangpy.reflection.reflectiontypes.VoidType`
+    
+
+
+----
+
+.. py:class:: slangpy.core.callsignature.slr.reflectiontypes.PointerType
+    :canonical: slangpy.reflection.reflectiontypes.PointerType
+    
+    Alias class: :py:class:`slangpy.reflection.reflectiontypes.PointerType`
     
 
 
@@ -15038,6 +15520,15 @@ Miscellaneous
     :canonical: slangpy.reflection.reflectiontypes.TextureType
     
     Alias class: :py:class:`slangpy.reflection.reflectiontypes.TextureType`
+    
+
+
+----
+
+.. py:class:: slangpy.core.callsignature.slr.PointerType
+    :canonical: slangpy.reflection.reflectiontypes.PointerType
+    
+    Alias class: :py:class:`slangpy.reflection.reflectiontypes.PointerType`
     
 
 
@@ -15351,9 +15842,9 @@ Miscellaneous
 ----
 
 .. py:class:: slangpy.core.calldata.Path
-    :canonical: pathlib.Path
+    :canonical: pathlib._local.Path
     
-    Alias class: :py:class:`pathlib.Path`
+    Alias class: :py:class:`pathlib._local.Path`
     
 
 
@@ -15640,26 +16131,30 @@ Miscellaneous
 .. py:class:: slangpy.core.instance.InstanceList
 
     
-        Represents a list of instances of a struct, either as a single buffer
-        or an SOA style set of buffers for each field. data can either
-        be a dictionary of field names to buffers, or a single buffer.
-        
+    Represents a list of instances of a struct, either as a single buffer
+    or an SOA style set of buffers for each field. data can either
+    be a dictionary of field names to buffers, or a single buffer.
+    
     
     .. py:attribute:: slangpy.core.instance.InstanceList.set_data
         :type: function
-        :value: <function InstanceList.set_data at 0x000002A6DC1A4B80>
+        :value: <function InstanceList.set_data at 0x000001D5389D9800>
     
     .. py:attribute:: slangpy.core.instance.InstanceList.get_this
         :type: function
-        :value: <function InstanceList.get_this at 0x000002A6DC1A4C20>
+        :value: <function InstanceList.get_this at 0x000001D5389D98A0>
     
     .. py:attribute:: slangpy.core.instance.InstanceList.update_this
         :type: function
-        :value: <function InstanceList.update_this at 0x000002A6DC1A4CC0>
+        :value: <function InstanceList.update_this at 0x000001D5389D9940>
     
     .. py:attribute:: slangpy.core.instance.InstanceList.construct
         :type: function
-        :value: <function InstanceList.construct at 0x000002A6DC1A4D60>
+        :value: <function InstanceList.construct at 0x000001D5389D99E0>
+    
+    .. py:attribute:: slangpy.core.instance.InstanceList.pack
+        :type: function
+        :value: <function InstanceList.pack at 0x000001D5389D9A80>
     
 
 
@@ -15670,17 +16165,91 @@ Miscellaneous
     Base class: :py:class:`slangpy.core.instance.InstanceList`
     
     
-        Simplified implementation of InstanceList that uses a single buffer for all instances and
-        provides buffer convenience functions for accessing its data.
-        
+    Simplified implementation of InstanceList that uses a single buffer for all instances and
+    provides buffer convenience functions for accessing its data.
+    
     
     .. py:attribute:: slangpy.core.instance.InstanceBuffer.to_numpy
         :type: function
-        :value: <function InstanceBuffer.to_numpy at 0x000002A6DC1A51C0>
+        :value: <function InstanceBuffer.to_numpy at 0x000001D5389D9EE0>
     
     .. py:attribute:: slangpy.core.instance.InstanceBuffer.copy_from_numpy
         :type: function
-        :value: <function InstanceBuffer.copy_from_numpy at 0x000002A6DC1A5260>
+        :value: <function InstanceBuffer.copy_from_numpy at 0x000001D5389D9F80>
+    
+
+
+----
+
+.. py:class:: slangpy.core.packedarg.Any
+    :canonical: typing.Any
+    
+    Alias class: :py:class:`typing.Any`
+    
+
+
+----
+
+.. py:class:: slangpy.core.packedarg.Module
+    :canonical: slangpy.core.module.Module
+    
+    Alias class: :py:class:`slangpy.core.module.Module`
+    
+
+
+----
+
+.. py:function:: slangpy.core.packedarg.get_value_signature(o: object) -> str
+
+    N/A
+    
+
+
+----
+
+.. py:class:: slangpy.core.packedarg.CallMode
+    :canonical: slangpy.slangpy.CallMode
+    
+    Alias class: :py:class:`slangpy.slangpy.CallMode`
+    
+
+
+----
+
+.. py:class:: slangpy.core.packedarg.NativePackedArg
+    :canonical: slangpy.slangpy.NativePackedArg
+    
+    Alias class: :py:class:`slangpy.slangpy.NativePackedArg`
+    
+
+
+----
+
+.. py:function:: slangpy.core.packedarg.unpack_arg(arg: object) -> object
+
+    N/A
+    
+
+
+----
+
+.. py:class:: slangpy.core.packedarg.BindContext
+    :canonical: slangpy.bindings.marshall.BindContext
+    
+    Alias class: :py:class:`slangpy.bindings.marshall.BindContext`
+    
+
+
+----
+
+.. py:class:: slangpy.core.packedarg.PackedArg
+
+    Base class: :py:class:`slangpy.slangpy.NativePackedArg`
+    
+    
+    Represents an argument that has been efficiently packed into
+    a shader object for use in later functionc alls.
+    
     
 
 
@@ -15690,87 +16259,87 @@ Miscellaneous
 
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.add_import
         :type: function
-        :value: <function CodeGenBlock.add_import at 0x000002A6D15D6480>
+        :value: <function CodeGenBlock.add_import at 0x000001D538961D00>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.inc_indent
         :type: function
-        :value: <function CodeGenBlock.inc_indent at 0x000002A6D15D6520>
+        :value: <function CodeGenBlock.inc_indent at 0x000001D538961DA0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.dec_indent
         :type: function
-        :value: <function CodeGenBlock.dec_indent at 0x000002A6D15D65C0>
+        :value: <function CodeGenBlock.dec_indent at 0x000001D538961E40>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.append_indent
         :type: function
-        :value: <function CodeGenBlock.append_indent at 0x000002A6D15D6660>
+        :value: <function CodeGenBlock.append_indent at 0x000001D538961EE0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.append_code
         :type: function
-        :value: <function CodeGenBlock.append_code at 0x000002A6D15D6700>
+        :value: <function CodeGenBlock.append_code at 0x000001D538961F80>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.append_code_indented
         :type: function
-        :value: <function CodeGenBlock.append_code_indented at 0x000002A6D15D67A0>
+        :value: <function CodeGenBlock.append_code_indented at 0x000001D538962020>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.empty_line
         :type: function
-        :value: <function CodeGenBlock.empty_line at 0x000002A6D15D6840>
+        :value: <function CodeGenBlock.empty_line at 0x000001D5389620C0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.append_line
         :type: function
-        :value: <function CodeGenBlock.append_line at 0x000002A6D15D68E0>
+        :value: <function CodeGenBlock.append_line at 0x000001D538962160>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.append_statement
         :type: function
-        :value: <function CodeGenBlock.append_statement at 0x000002A6D15D6980>
+        :value: <function CodeGenBlock.append_statement at 0x000001D538962200>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.begin_block
         :type: function
-        :value: <function CodeGenBlock.begin_block at 0x000002A6D15D6A20>
+        :value: <function CodeGenBlock.begin_block at 0x000001D5389622A0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.end_block
         :type: function
-        :value: <function CodeGenBlock.end_block at 0x000002A6D15D6AC0>
+        :value: <function CodeGenBlock.end_block at 0x000001D538962340>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.begin_struct
         :type: function
-        :value: <function CodeGenBlock.begin_struct at 0x000002A6D15D6B60>
+        :value: <function CodeGenBlock.begin_struct at 0x000001D5389623E0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.end_struct
         :type: function
-        :value: <function CodeGenBlock.end_struct at 0x000002A6D15D6C00>
+        :value: <function CodeGenBlock.end_struct at 0x000001D538962480>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.type_alias
         :type: function
-        :value: <function CodeGenBlock.type_alias at 0x000002A6D15D6CA0>
+        :value: <function CodeGenBlock.type_alias at 0x000001D538962520>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.diff_pair
         :type: function
-        :value: <function CodeGenBlock.diff_pair at 0x000002A6D15D6D40>
+        :value: <function CodeGenBlock.diff_pair at 0x000001D5389625C0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.declare
         :type: function
-        :value: <function CodeGenBlock.declare at 0x000002A6D15D6DE0>
+        :value: <function CodeGenBlock.declare at 0x000001D538962660>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.assign
         :type: function
-        :value: <function CodeGenBlock.assign at 0x000002A6D15D6E80>
+        :value: <function CodeGenBlock.assign at 0x000001D538962700>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.declarevar
         :type: function
-        :value: <function CodeGenBlock.declarevar at 0x000002A6D15D6F20>
+        :value: <function CodeGenBlock.declarevar at 0x000001D5389627A0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.statement
         :type: function
-        :value: <function CodeGenBlock.statement at 0x000002A6D15D6FC0>
+        :value: <function CodeGenBlock.statement at 0x000001D538962840>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.add_snippet
         :type: function
-        :value: <function CodeGenBlock.add_snippet at 0x000002A6D15D7060>
+        :value: <function CodeGenBlock.add_snippet at 0x000001D5389628E0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGenBlock.finish
         :type: function
-        :value: <function CodeGenBlock.finish at 0x000002A6D15D7100>
+        :value: <function CodeGenBlock.finish at 0x000001D538962980>
     
 
 
@@ -15779,22 +16348,26 @@ Miscellaneous
 .. py:class:: slangpy.bindings.codegen.CodeGen
 
     
-        Tool for generating the code for a SlangPy kernel. Contains a set of
-        different code blocks that can be filled in and then combined to
-        generate the final code.
-        
+    Tool for generating the code for a SlangPy kernel. Contains a set of
+    different code blocks that can be filled in and then combined to
+    generate the final code.
+    
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGen.add_snippet
         :type: function
-        :value: <function CodeGen.add_snippet at 0x000002A6D15D7240>
+        :value: <function CodeGen.add_snippet at 0x000001D538962AC0>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGen.add_import
         :type: function
-        :value: <function CodeGen.add_import at 0x000002A6D15D72E0>
+        :value: <function CodeGen.add_import at 0x000001D538962B60>
+    
+    .. py:attribute:: slangpy.bindings.codegen.CodeGen.add_parameter_block
+        :type: function
+        :value: <function CodeGen.add_parameter_block at 0x000001D538962C00>
     
     .. py:attribute:: slangpy.bindings.codegen.CodeGen.finish
         :type: function
-        :value: <function CodeGen.finish at 0x000002A6D15D7380>
+        :value: <function CodeGen.finish at 0x000001D538962CA0>
     
 
 
@@ -15839,8 +16412,8 @@ Miscellaneous
 .. py:class:: slangpy.bindings.marshall.BindContext
 
     
-        Contextual information passed around during kernel generation process.
-        
+    Contextual information passed around during kernel generation process.
+    
     
 
 
@@ -15849,8 +16422,8 @@ Miscellaneous
 .. py:class:: slangpy.bindings.marshall.ReturnContext
 
     
-        Internal structure used to store information about return type of a function during generation.
-        
+    Internal structure used to store information about return type of a function during generation.
+    
     
 
 
@@ -15861,27 +16434,31 @@ Miscellaneous
     Base class: :py:class:`slangpy.slangpy.NativeMarshall`
     
     
-        Base class for a type marshall that describes how to pass a given type to/from a
-        SlangPy kernel. When a kernel is generated, a marshall is instantiated for each
-        Python value. Future calls to the kernel verify type signatures match and then
-        re-use the existing marshalls.
-        
+    Base class for a type marshall that describes how to pass a given type to/from a
+    SlangPy kernel. When a kernel is generated, a marshall is instantiated for each
+    Python value. Future calls to the kernel verify type signatures match and then
+    re-use the existing marshalls.
+    
     
     .. py:attribute:: slangpy.bindings.marshall.Marshall.gen_calldata
         :type: function
-        :value: <function Marshall.gen_calldata at 0x000002A6D15D7600>
+        :value: <function Marshall.gen_calldata at 0x000001D538962FC0>
     
     .. py:attribute:: slangpy.bindings.marshall.Marshall.reduce_type
         :type: function
-        :value: <function Marshall.reduce_type at 0x000002A6D15D76A0>
+        :value: <function Marshall.reduce_type at 0x000001D538963060>
     
     .. py:attribute:: slangpy.bindings.marshall.Marshall.resolve_type
         :type: function
-        :value: <function Marshall.resolve_type at 0x000002A6D15D7740>
+        :value: <function Marshall.resolve_type at 0x000001D538963100>
     
     .. py:attribute:: slangpy.bindings.marshall.Marshall.resolve_dimensionality
         :type: function
-        :value: <function Marshall.resolve_dimensionality at 0x000002A6D15D77E0>
+        :value: <function Marshall.resolve_dimensionality at 0x000001D5389631A0>
+    
+    .. py:attribute:: slangpy.bindings.marshall.Marshall.build_shader_object
+        :type: function
+        :value: <function Marshall.build_shader_object at 0x000001D538963240>
     
 
 
@@ -15959,6 +16536,15 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.bindings.boundvariable.NativeMarshall
+    :canonical: slangpy.slangpy.NativeMarshall
+    
+    Alias class: :py:class:`slangpy.slangpy.NativeMarshall`
+    
+
+
+----
+
 .. py:class:: slangpy.bindings.boundvariable.ModifierID
     :canonical: slangpy.ModifierID
     
@@ -16027,9 +16613,9 @@ Miscellaneous
     Base class: :py:class:`builtins.Exception`
     
     
-        Custom exception type that carries a message and the variable that caused
-        the exception.
-        
+    Custom exception type that carries a message and the variable that caused
+    the exception.
+    
     
 
 
@@ -16038,30 +16624,30 @@ Miscellaneous
 .. py:class:: slangpy.bindings.boundvariable.BoundCall
 
     
-        Stores the binding of python arguments to slang parameters during kernel
-        generation. This is initialized purely with a set of python arguments and
-        later bound to corresponding slang parameters during function resolution.
-        
+    Stores the binding of python arguments to slang parameters during kernel
+    generation. This is initialized purely with a set of python arguments and
+    later bound to corresponding slang parameters during function resolution.
+    
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundCall.bind
         :type: function
-        :value: <function BoundCall.bind at 0x000002A6D15D79C0>
+        :value: <function BoundCall.bind at 0x000001D5389637E0>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundCall.apply_explicit_vectorization
         :type: function
-        :value: <function BoundCall.apply_explicit_vectorization at 0x000002A6D15D7D80>
+        :value: <function BoundCall.apply_explicit_vectorization at 0x000001D538963BA0>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundCall.values
         :type: function
-        :value: <function BoundCall.values at 0x000002A6D15D7E20>
+        :value: <function BoundCall.values at 0x000001D538963C40>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundCall.apply_implicit_vectorization
         :type: function
-        :value: <function BoundCall.apply_implicit_vectorization at 0x000002A6D15D7EC0>
+        :value: <function BoundCall.apply_implicit_vectorization at 0x000001D538963CE0>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundCall.finalize_mappings
         :type: function
-        :value: <function BoundCall.finalize_mappings at 0x000002A6D15D7F60>
+        :value: <function BoundCall.finalize_mappings at 0x000001D538963D80>
     
 
 
@@ -16070,37 +16656,37 @@ Miscellaneous
 .. py:class:: slangpy.bindings.boundvariable.BoundVariable
 
     
-        Node in a built signature tree, maintains a pairing of python+slang marshall,
-        and a potential set of child nodes for use during kernel generation.
-        
+    Node in a built signature tree, maintains a pairing of python+slang marshall,
+    and a potential set of child nodes for use during kernel generation.
+    
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundVariable.bind
         :type: function
-        :value: <function BoundVariable.bind at 0x000002A6D1610180>
+        :value: <function BoundVariable.bind at 0x000001D538963F60>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundVariable.apply_explicit_vectorization
         :type: function
-        :value: <function BoundVariable.apply_explicit_vectorization at 0x000002A6D1610360>
+        :value: <function BoundVariable.apply_explicit_vectorization at 0x000001D53897C180>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundVariable.apply_implicit_vectorization
         :type: function
-        :value: <function BoundVariable.apply_implicit_vectorization at 0x000002A6D16104A0>
+        :value: <function BoundVariable.apply_implicit_vectorization at 0x000001D53897C2C0>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundVariable.finalize_mappings
         :type: function
-        :value: <function BoundVariable.finalize_mappings at 0x000002A6D16105E0>
+        :value: <function BoundVariable.finalize_mappings at 0x000001D53897C400>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundVariable.calculate_differentiability
         :type: function
-        :value: <function BoundVariable.calculate_differentiability at 0x000002A6D1610720>
+        :value: <function BoundVariable.calculate_differentiability at 0x000001D53897C540>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundVariable.get_input_list
         :type: function
-        :value: <function BoundVariable.get_input_list at 0x000002A6D16107C0>
+        :value: <function BoundVariable.get_input_list at 0x000001D53897C5E0>
     
     .. py:attribute:: slangpy.bindings.boundvariable.BoundVariable.gen_call_data_code
         :type: function
-        :value: <function BoundVariable.gen_call_data_code at 0x000002A6D1610A40>
+        :value: <function BoundVariable.gen_call_data_code at 0x000001D53897C860>
     
 
 
@@ -16165,9 +16751,9 @@ Miscellaneous
     Base class: :py:class:`slangpy.slangpy.NativeBoundCallRuntime`
     
     
-        Minimal call data stored after kernel generation required to
-        dispatch a call to a SlangPy kernel.
-        
+    Minimal call data stored after kernel generation required to
+    dispatch a call to a SlangPy kernel.
+    
     
 
 
@@ -16178,9 +16764,9 @@ Miscellaneous
     Base class: :py:class:`slangpy.slangpy.NativeBoundVariableRuntime`
     
     
-        Minimal variable data stored after kernel generation required to
-        dispatch a call to a SlangPy kernel.
-        
+    Minimal variable data stored after kernel generation required to
+    dispatch a call to a SlangPy kernel.
+    
     
 
 
@@ -16371,8 +16957,8 @@ Miscellaneous
     Base class: :py:class:`slangpy.slangpy.NativeObject`
     
     
-        Passes the thread id as an argument to a SlangPy function.
-        
+    Passes the thread id as an argument to a SlangPy function.
+    
     
 
 
@@ -16392,23 +16978,23 @@ Miscellaneous
     
     .. py:attribute:: slangpy.experimental.gridarg.GridArgMarshall.gen_calldata
         :type: function
-        :value: <function GridArgMarshall.gen_calldata at 0x000002A6D161E840>
+        :value: <function GridArgMarshall.gen_calldata at 0x000001D538987420>
     
     .. py:attribute:: slangpy.experimental.gridarg.GridArgMarshall.create_calldata
         :type: function
-        :value: <function GridArgMarshall.create_calldata at 0x000002A6D161E8E0>
+        :value: <function GridArgMarshall.create_calldata at 0x000001D5389874C0>
     
     .. py:attribute:: slangpy.experimental.gridarg.GridArgMarshall.get_shape
         :type: function
-        :value: <function GridArgMarshall.get_shape at 0x000002A6D161E980>
+        :value: <function GridArgMarshall.get_shape at 0x000001D538987560>
     
     .. py:attribute:: slangpy.experimental.gridarg.GridArgMarshall.resolve_type
         :type: function
-        :value: <function GridArgMarshall.resolve_type at 0x000002A6D161EA20>
+        :value: <function GridArgMarshall.resolve_type at 0x000001D538987600>
     
     .. py:attribute:: slangpy.experimental.gridarg.GridArgMarshall.resolve_dimensionality
         :type: function
-        :value: <function GridArgMarshall.resolve_dimensionality at 0x000002A6D161EAC0>
+        :value: <function GridArgMarshall.resolve_dimensionality at 0x000001D5389876A0>
     
 
 
@@ -16473,45 +17059,54 @@ Miscellaneous
     Base class: :py:class:`slangpy.types.buffer.NDBuffer`
     
     
-        WIP: Use slangpy.Tensor instead.
+    WIP: Use slangpy.Tensor instead.
     
-        An N dimensional buffer of a given slang type, with optional additional buffer of gradients.
-        The supplied type can come from a SlangType (via reflection), a struct read from a Module,
-        or simply a name. If unspecified, the type of the gradient is assumed to match that of the
-        primal.
+    An N dimensional buffer of a given slang type, with optional additional buffer of gradients.
+    The supplied type can come from a SlangType (via reflection), a struct read from a Module,
+    or simply a name. If unspecified, the type of the gradient is assumed to match that of the
+    primal.
     
-        When specifying just a type name, it is advisable to also supply the program_layout for the
-        module in question (see Module.layout), as this ensures type information is looked up from
-        the right place.
-        
+    When specifying just a type name, it is advisable to also supply the program_layout for the
+    module in question (see Module.layout), as this ensures type information is looked up from
+    the right place.
+    
     
     .. py:attribute:: slangpy.experimental.diffbuffer.NDDifferentiableBuffer.primal_to_numpy
         :type: function
-        :value: <function NDDifferentiableBuffer.primal_to_numpy at 0x000002A6D162FC40>
+        :value: <function NDDifferentiableBuffer.primal_to_numpy at 0x000001D5389B4E00>
     
     .. py:attribute:: slangpy.experimental.diffbuffer.NDDifferentiableBuffer.primal_from_numpy
         :type: function
-        :value: <function NDDifferentiableBuffer.primal_from_numpy at 0x000002A6D162FCE0>
+        :value: <function NDDifferentiableBuffer.primal_from_numpy at 0x000001D5389B4EA0>
     
     .. py:attribute:: slangpy.experimental.diffbuffer.NDDifferentiableBuffer.primal_to_torch
         :type: function
-        :value: <function NDDifferentiableBuffer.primal_to_torch at 0x000002A6D162FD80>
+        :value: <function NDDifferentiableBuffer.primal_to_torch at 0x000001D5389B4F40>
     
     .. py:attribute:: slangpy.experimental.diffbuffer.NDDifferentiableBuffer.grad_to_numpy
         :type: function
-        :value: <function NDDifferentiableBuffer.grad_to_numpy at 0x000002A6D162FE20>
+        :value: <function NDDifferentiableBuffer.grad_to_numpy at 0x000001D5389B4FE0>
     
     .. py:attribute:: slangpy.experimental.diffbuffer.NDDifferentiableBuffer.grad_from_numpy
         :type: function
-        :value: <function NDDifferentiableBuffer.grad_from_numpy at 0x000002A6D162FEC0>
+        :value: <function NDDifferentiableBuffer.grad_from_numpy at 0x000001D5389B5080>
     
     .. py:attribute:: slangpy.experimental.diffbuffer.NDDifferentiableBuffer.grad_to_torch
         :type: function
-        :value: <function NDDifferentiableBuffer.grad_to_torch at 0x000002A6D162FF60>
+        :value: <function NDDifferentiableBuffer.grad_to_torch at 0x000001D5389B5120>
     
     .. py:attribute:: slangpy.experimental.diffbuffer.NDDifferentiableBuffer.get_grad
         :type: function
-        :value: <function NDDifferentiableBuffer.get_grad at 0x000002A6D1658040>
+        :value: <function NDDifferentiableBuffer.get_grad at 0x000001D5389B51C0>
+    
+
+
+----
+
+.. py:class:: slangpy.types.buffer.PathLike
+    :canonical: os.PathLike
+    
+    Alias class: :py:class:`os.PathLike`
     
 
 
@@ -16625,6 +17220,24 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.types.buffer.Bitmap
+    :canonical: slangpy.Bitmap
+    
+    Alias class: :py:class:`slangpy.Bitmap`
+    
+
+
+----
+
+.. py:class:: slangpy.types.buffer.DataStruct
+    :canonical: slangpy.DataStruct
+    
+    Alias class: :py:class:`slangpy.DataStruct`
+    
+
+
+----
+
 .. py:class:: slangpy.types.buffer.Marshall
     :canonical: slangpy.bindings.marshall.Marshall
     
@@ -16661,46 +17274,71 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.types.buffer.ST
+    :canonical: slangpy.TypeReflection.ScalarType
+    
+    Alias class: :py:class:`slangpy.TypeReflection.ScalarType`
+    
+
+
+----
+
 .. py:class:: slangpy.types.buffer.NDBuffer
 
     Base class: :py:class:`slangpy.slangpy.NativeNDBuffer`
     
     
-        An N dimensional buffer of a given slang type. The supplied type can come from a SlangType (via
-        reflection), a struct read from a Module, or simply a name.
+    An N dimensional buffer of a given slang type. The supplied type can come from a SlangType (via
+    reflection), a struct read from a Module, or simply a name.
     
-        When specifying just a type name, it is advisable to also supply the program_layout for the
-        module in question (see Module.layout), as this ensures type information is looked up from
-        the right place.
-        
+    When specifying just a type name, it is advisable to also supply the program_layout for the
+    module in question (see Module.layout), as this ensures type information is looked up from
+    the right place.
+    
     
     .. py:attribute:: slangpy.types.buffer.NDBuffer.broadcast_to
         :type: function
-        :value: <function NDBuffer.broadcast_to at 0x000002A6D161C180>
+        :value: <function NDBuffer.broadcast_to at 0x000001D538984540>
     
     .. py:attribute:: slangpy.types.buffer.NDBuffer.view
         :type: function
-        :value: <function NDBuffer.view at 0x000002A6D161C220>
+        :value: <function NDBuffer.view at 0x000001D5389845E0>
     
     .. py:attribute:: slangpy.types.buffer.NDBuffer.to_numpy
         :type: function
-        :value: <function NDBuffer.to_numpy at 0x000002A6D161C2C0>
+        :value: <function NDBuffer.to_numpy at 0x000001D538984680>
     
     .. py:attribute:: slangpy.types.buffer.NDBuffer.to_torch
         :type: function
-        :value: <function NDBuffer.to_torch at 0x000002A6D161C360>
+        :value: <function NDBuffer.to_torch at 0x000001D538984720>
     
     .. py:attribute:: slangpy.types.buffer.NDBuffer.clear
         :type: function
-        :value: <function NDBuffer.clear at 0x000002A6D161C400>
+        :value: <function NDBuffer.clear at 0x000001D5389847C0>
+    
+    .. py:attribute:: slangpy.types.buffer.NDBuffer.from_numpy
+        :type: function
+        :value: <function NDBuffer.from_numpy at 0x000001D538984860>
+    
+    .. py:attribute:: slangpy.types.buffer.NDBuffer.empty
+        :type: function
+        :value: <function NDBuffer.empty at 0x000001D538984900>
     
     .. py:attribute:: slangpy.types.buffer.NDBuffer.zeros
         :type: function
-        :value: <function NDBuffer.zeros at 0x000002A6D161C4A0>
+        :value: <function NDBuffer.zeros at 0x000001D5389849A0>
+    
+    .. py:attribute:: slangpy.types.buffer.NDBuffer.empty_like
+        :type: function
+        :value: <function NDBuffer.empty_like at 0x000001D538984A40>
     
     .. py:attribute:: slangpy.types.buffer.NDBuffer.zeros_like
         :type: function
-        :value: <function NDBuffer.zeros_like at 0x000002A6D161C540>
+        :value: <function NDBuffer.zeros_like at 0x000001D538984AE0>
+    
+    .. py:attribute:: slangpy.types.buffer.NDBuffer.load_from_image
+        :type: function
+        :value: <function NDBuffer.load_from_image at 0x000001D538984B80>
     
 
 
@@ -16736,17 +17374,17 @@ Miscellaneous
 .. py:class:: slangpy.types.diffpair.DiffPair
 
     
-        A pair of values, one representing the primal value and the other representing the gradient value.
-        Typically only required when wanting to output gradients from scalar calls to a function.
-        
+    A pair of values, one representing the primal value and the other representing the gradient value.
+    Typically only required when wanting to output gradients from scalar calls to a function.
+    
     
     .. py:attribute:: slangpy.types.diffpair.DiffPair.get
         :type: function
-        :value: <function DiffPair.get at 0x000002A6D161C720>
+        :value: <function DiffPair.get at 0x000001D538984E00>
     
     .. py:attribute:: slangpy.types.diffpair.DiffPair.set
         :type: function
-        :value: <function DiffPair.set at 0x000002A6D161C7C0>
+        :value: <function DiffPair.set at 0x000001D538984EA0>
     
 
 
@@ -16926,9 +17564,9 @@ Miscellaneous
 .. py:class:: slangpy.types.wanghasharg.WangHashArg
 
     
-        Generates a random int/vector per thread when passed as an argument using a wang
-        hash of the thread id.
-        
+    Generates a random int/vector per thread when passed as an argument using a wang
+    hash of the thread id.
+    
     
 
 
@@ -16940,19 +17578,19 @@ Miscellaneous
     
     .. py:attribute:: slangpy.types.wanghasharg.WangHashArgMarshall.gen_calldata
         :type: function
-        :value: <function WangHashArgMarshall.gen_calldata at 0x000002A6D161D580>
+        :value: <function WangHashArgMarshall.gen_calldata at 0x000001D538985F80>
     
     .. py:attribute:: slangpy.types.wanghasharg.WangHashArgMarshall.create_calldata
         :type: function
-        :value: <function WangHashArgMarshall.create_calldata at 0x000002A6D161D620>
+        :value: <function WangHashArgMarshall.create_calldata at 0x000001D538986020>
     
     .. py:attribute:: slangpy.types.wanghasharg.WangHashArgMarshall.resolve_type
         :type: function
-        :value: <function WangHashArgMarshall.resolve_type at 0x000002A6D161D6C0>
+        :value: <function WangHashArgMarshall.resolve_type at 0x000001D5389860C0>
     
     .. py:attribute:: slangpy.types.wanghasharg.WangHashArgMarshall.resolve_dimensionality
         :type: function
-        :value: <function WangHashArgMarshall.resolve_dimensionality at 0x000002A6D161D760>
+        :value: <function WangHashArgMarshall.resolve_dimensionality at 0x000001D538986160>
     
 
 
@@ -17069,9 +17707,9 @@ Miscellaneous
 .. py:class:: slangpy.types.randfloatarg.RandFloatArg
 
     
-        Generates a random float/vector per thread when passed as an argument
-        to a SlangPy function. The min and max values are inclusive.
-        
+    Generates a random float/vector per thread when passed as an argument
+    to a SlangPy function. The min and max values are inclusive.
+    
     
 
 
@@ -17083,19 +17721,19 @@ Miscellaneous
     
     .. py:attribute:: slangpy.types.randfloatarg.RandFloatArgMarshall.gen_calldata
         :type: function
-        :value: <function RandFloatArgMarshall.gen_calldata at 0x000002A6D161DBC0>
+        :value: <function RandFloatArgMarshall.gen_calldata at 0x000001D538986520>
     
     .. py:attribute:: slangpy.types.randfloatarg.RandFloatArgMarshall.create_calldata
         :type: function
-        :value: <function RandFloatArgMarshall.create_calldata at 0x000002A6D161DC60>
+        :value: <function RandFloatArgMarshall.create_calldata at 0x000001D5389865C0>
     
     .. py:attribute:: slangpy.types.randfloatarg.RandFloatArgMarshall.resolve_type
         :type: function
-        :value: <function RandFloatArgMarshall.resolve_type at 0x000002A6D161DD00>
+        :value: <function RandFloatArgMarshall.resolve_type at 0x000001D538986660>
     
     .. py:attribute:: slangpy.types.randfloatarg.RandFloatArgMarshall.resolve_dimensionality
         :type: function
-        :value: <function RandFloatArgMarshall.resolve_dimensionality at 0x000002A6D161DDA0>
+        :value: <function RandFloatArgMarshall.resolve_dimensionality at 0x000001D538986700>
     
 
 
@@ -17205,8 +17843,8 @@ Miscellaneous
     Base class: :py:class:`slangpy.slangpy.NativeObject`
     
     
-        Passes the thread id as an argument to a SlangPy function.
-        
+    Passes the thread id as an argument to a SlangPy function.
+    
     
 
 
@@ -17218,15 +17856,15 @@ Miscellaneous
     
     .. py:attribute:: slangpy.types.threadidarg.ThreadIdArgMarshall.gen_calldata
         :type: function
-        :value: <function ThreadIdArgMarshall.gen_calldata at 0x000002A6D161E0C0>
+        :value: <function ThreadIdArgMarshall.gen_calldata at 0x000001D538986AC0>
     
     .. py:attribute:: slangpy.types.threadidarg.ThreadIdArgMarshall.resolve_type
         :type: function
-        :value: <function ThreadIdArgMarshall.resolve_type at 0x000002A6D161E160>
+        :value: <function ThreadIdArgMarshall.resolve_type at 0x000001D538986B60>
     
     .. py:attribute:: slangpy.types.threadidarg.ThreadIdArgMarshall.resolve_dimensionality
         :type: function
-        :value: <function ThreadIdArgMarshall.resolve_dimensionality at 0x000002A6D161E200>
+        :value: <function ThreadIdArgMarshall.resolve_dimensionality at 0x000001D538986C00>
     
 
 
@@ -17307,8 +17945,8 @@ Miscellaneous
 .. py:class:: slangpy.types.callidarg.CallIdArg
 
     
-        Passes the thread id as an argument to a SlangPy function.
-        
+    Passes the thread id as an argument to a SlangPy function.
+    
     
 
 
@@ -17320,15 +17958,15 @@ Miscellaneous
     
     .. py:attribute:: slangpy.types.callidarg.CallIdArgMarshall.gen_calldata
         :type: function
-        :value: <function CallIdArgMarshall.gen_calldata at 0x000002A6D161ED40>
+        :value: <function CallIdArgMarshall.gen_calldata at 0x000001D538987920>
     
     .. py:attribute:: slangpy.types.callidarg.CallIdArgMarshall.resolve_type
         :type: function
-        :value: <function CallIdArgMarshall.resolve_type at 0x000002A6D161EDE0>
+        :value: <function CallIdArgMarshall.resolve_type at 0x000001D5389879C0>
     
     .. py:attribute:: slangpy.types.callidarg.CallIdArgMarshall.resolve_dimensionality
         :type: function
-        :value: <function CallIdArgMarshall.resolve_dimensionality at 0x000002A6D161EE80>
+        :value: <function CallIdArgMarshall.resolve_dimensionality at 0x000001D538987A60>
     
 
 
@@ -17355,9 +17993,9 @@ Miscellaneous
 .. py:class:: slangpy.types.valueref.ValueRef
 
     
-        Minimal class to hold a reference to a scalar value, allowing user to get outputs
-        from scalar inout/out arguments.
-        
+    Minimal class to hold a reference to a scalar value, allowing user to get outputs
+    from scalar inout/out arguments.
+    
     
 
 
@@ -17376,6 +18014,15 @@ Miscellaneous
     :canonical: slangpy.types.wanghasharg.WangHashArg
     
     Alias class: :py:class:`slangpy.types.wanghasharg.WangHashArg`
+    
+
+
+----
+
+.. py:class:: slangpy.types.tensor.PathLike
+    :canonical: os.PathLike
+    
+    Alias class: :py:class:`os.PathLike`
     
 
 
@@ -17426,19 +18073,19 @@ Miscellaneous
 
 ----
 
-.. py:class:: slangpy.types.tensor.SlangType
-    :canonical: slangpy.reflection.reflectiontypes.SlangType
+.. py:class:: slangpy.types.tensor.MemoryType
+    :canonical: slangpy.MemoryType
     
-    Alias class: :py:class:`slangpy.reflection.reflectiontypes.SlangType`
+    Alias class: :py:class:`slangpy.MemoryType`
     
 
 
 ----
 
-.. py:class:: slangpy.types.tensor.ScalarType
-    :canonical: slangpy.reflection.reflectiontypes.ScalarType
+.. py:class:: slangpy.types.tensor.SlangType
+    :canonical: slangpy.reflection.reflectiontypes.SlangType
     
-    Alias class: :py:class:`slangpy.reflection.reflectiontypes.ScalarType`
+    Alias class: :py:class:`slangpy.reflection.reflectiontypes.SlangType`
     
 
 
@@ -17511,60 +18158,68 @@ Miscellaneous
     Base class: :py:class:`slangpy.slangpy.NativeTensor`
     
     
-        Represents an N-D view of an underlying buffer with given shape and element type,
-        and has optional gradient information attached. Element type must be differentiable.
+    Represents an N-D view of an underlying buffer with given shape and element type,
+    and has optional gradient information attached. Element type must be differentiable.
     
-        Strides and offset can optionally be specified and are given in terms of elements, not bytes.
-        If omitted, a dense N-D grid is assumed (row-major).
-        
+    Strides and offset can optionally be specified and are given in terms of elements, not bytes.
+    If omitted, a dense N-D grid is assumed (row-major).
+    
     
     .. py:attribute:: slangpy.types.tensor.Tensor.broadcast_to
         :type: function
-        :value: <function Tensor.broadcast_to at 0x000002A6D161F880>
+        :value: <function Tensor.broadcast_to at 0x000001D538998220>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.view
         :type: function
-        :value: <function Tensor.view at 0x000002A6D161F920>
+        :value: <function Tensor.view at 0x000001D5389982C0>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.to_numpy
         :type: function
-        :value: <function Tensor.to_numpy at 0x000002A6D161FA60>
+        :value: <function Tensor.to_numpy at 0x000001D538998400>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.to_torch
         :type: function
-        :value: <function Tensor.to_torch at 0x000002A6D161FB00>
+        :value: <function Tensor.to_torch at 0x000001D5389984A0>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.with_grads
         :type: function
-        :value: <function Tensor.with_grads at 0x000002A6D161FBA0>
+        :value: <function Tensor.with_grads at 0x000001D538998540>
+    
+    .. py:attribute:: slangpy.types.tensor.Tensor.detach
+        :type: function
+        :value: <function Tensor.detach at 0x000001D5389985E0>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.clear
         :type: function
-        :value: <function Tensor.clear at 0x000002A6D161FC40>
+        :value: <function Tensor.clear at 0x000001D538998680>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.numpy
         :type: function
-        :value: <function Tensor.numpy at 0x000002A6D161FCE0>
+        :value: <function Tensor.numpy at 0x000001D538998720>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.from_numpy
         :type: function
-        :value: <function Tensor.from_numpy at 0x000002A6D161FD80>
+        :value: <function Tensor.from_numpy at 0x000001D5389987C0>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.empty
         :type: function
-        :value: <function Tensor.empty at 0x000002A6D161FE20>
+        :value: <function Tensor.empty at 0x000001D538998860>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.zeros
         :type: function
-        :value: <function Tensor.zeros at 0x000002A6D161FEC0>
+        :value: <function Tensor.zeros at 0x000001D538998900>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.empty_like
         :type: function
-        :value: <function Tensor.empty_like at 0x000002A6D161FF60>
+        :value: <function Tensor.empty_like at 0x000001D5389989A0>
     
     .. py:attribute:: slangpy.types.tensor.Tensor.zeros_like
         :type: function
-        :value: <function Tensor.zeros_like at 0x000002A6D162C040>
+        :value: <function Tensor.zeros_like at 0x000001D538998A40>
+    
+    .. py:attribute:: slangpy.types.tensor.Tensor.load_from_image
+        :type: function
+        :value: <function Tensor.load_from_image at 0x000001D538998AE0>
     
 
 
@@ -17687,6 +18342,14 @@ Miscellaneous
 
 ----
 
+.. py:function:: slangpy.builtin.value.unpack_arg(arg: object) -> object
+
+    N/A
+    
+
+
+----
+
 .. py:class:: slangpy.builtin.value.TypeReflection
     :canonical: slangpy.TypeReflection
     
@@ -17747,35 +18410,39 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.gen_calldata
         :type: function
-        :value: <function ValueMarshall.gen_calldata at 0x000002A6D162C5E0>
+        :value: <function ValueMarshall.gen_calldata at 0x000001D538999120>
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.create_calldata
         :type: function
-        :value: <function ValueMarshall.create_calldata at 0x000002A6D162C680>
+        :value: <function ValueMarshall.create_calldata at 0x000001D5389991C0>
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.create_dispatchdata
         :type: function
-        :value: <function ValueMarshall.create_dispatchdata at 0x000002A6D162C720>
+        :value: <function ValueMarshall.create_dispatchdata at 0x000001D538999260>
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.create_output
         :type: function
-        :value: <function ValueMarshall.create_output at 0x000002A6D162C7C0>
+        :value: <function ValueMarshall.create_output at 0x000001D538999300>
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.read_output
         :type: function
-        :value: <function ValueMarshall.read_output at 0x000002A6D162C860>
+        :value: <function ValueMarshall.read_output at 0x000001D5389993A0>
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.resolve_type
         :type: function
-        :value: <function ValueMarshall.resolve_type at 0x000002A6D162C900>
+        :value: <function ValueMarshall.resolve_type at 0x000001D538999440>
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.reduce_type
         :type: function
-        :value: <function ValueMarshall.reduce_type at 0x000002A6D162C9A0>
+        :value: <function ValueMarshall.reduce_type at 0x000001D5389994E0>
     
     .. py:attribute:: slangpy.builtin.value.ValueMarshall.resolve_dimensionality
         :type: function
-        :value: <function ValueMarshall.resolve_dimensionality at 0x000002A6D162CA40>
+        :value: <function ValueMarshall.resolve_dimensionality at 0x000001D538999580>
+    
+    .. py:attribute:: slangpy.builtin.value.ValueMarshall.build_shader_object
+        :type: function
+        :value: <function ValueMarshall.build_shader_object at 0x000001D538999620>
     
 
 
@@ -17787,7 +18454,7 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.value.ScalarMarshall.reduce_type
         :type: function
-        :value: <function ScalarMarshall.reduce_type at 0x000002A6D162CC20>
+        :value: <function ScalarMarshall.reduce_type at 0x000001D538999800>
     
 
 
@@ -17799,7 +18466,7 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.value.NoneMarshall.resolve_dimensionality
         :type: function
-        :value: <function NoneMarshall.resolve_dimensionality at 0x000002A6D162CE00>
+        :value: <function NoneMarshall.resolve_dimensionality at 0x000001D5389999E0>
     
 
 
@@ -17811,15 +18478,19 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.value.VectorMarshall.reduce_type
         :type: function
-        :value: <function VectorMarshall.reduce_type at 0x000002A6D162CF40>
+        :value: <function VectorMarshall.reduce_type at 0x000001D538999B20>
     
     .. py:attribute:: slangpy.builtin.value.VectorMarshall.resolve_type
         :type: function
-        :value: <function VectorMarshall.resolve_type at 0x000002A6D162CFE0>
+        :value: <function VectorMarshall.resolve_type at 0x000001D538999BC0>
     
     .. py:attribute:: slangpy.builtin.value.VectorMarshall.gen_calldata
         :type: function
-        :value: <function VectorMarshall.gen_calldata at 0x000002A6D162D080>
+        :value: <function VectorMarshall.gen_calldata at 0x000001D538999C60>
+    
+    .. py:attribute:: slangpy.builtin.value.VectorMarshall.build_shader_object
+        :type: function
+        :value: <function VectorMarshall.build_shader_object at 0x000001D538999D00>
     
 
 
@@ -17831,7 +18502,7 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.value.MatrixMarshall.reduce_type
         :type: function
-        :value: <function MatrixMarshall.reduce_type at 0x000002A6D162D1C0>
+        :value: <function MatrixMarshall.reduce_type at 0x000001D538999E40>
     
 
 
@@ -17874,15 +18545,6 @@ Miscellaneous
     :type: int
     :value: 4
 
-
-
-----
-
-.. py:class:: slangpy.builtin.value.mat_type
-    :canonical: slangpy.math.float4x4
-    
-    Alias class: :py:class:`slangpy.math.float4x4`
-    
 
 
 ----
@@ -18028,35 +18690,35 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.resolve_type
         :type: function
-        :value: <function ValueRefMarshall.resolve_type at 0x000002A6D162E7A0>
+        :value: <function ValueRefMarshall.resolve_type at 0x000001D53899B880>
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.resolve_dimensionality
         :type: function
-        :value: <function ValueRefMarshall.resolve_dimensionality at 0x000002A6D162E840>
+        :value: <function ValueRefMarshall.resolve_dimensionality at 0x000001D53899B920>
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.gen_calldata
         :type: function
-        :value: <function ValueRefMarshall.gen_calldata at 0x000002A6D162E8E0>
+        :value: <function ValueRefMarshall.gen_calldata at 0x000001D53899B9C0>
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.create_calldata
         :type: function
-        :value: <function ValueRefMarshall.create_calldata at 0x000002A6D162E980>
+        :value: <function ValueRefMarshall.create_calldata at 0x000001D53899BA60>
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.create_dispatchdata
         :type: function
-        :value: <function ValueRefMarshall.create_dispatchdata at 0x000002A6D162EA20>
+        :value: <function ValueRefMarshall.create_dispatchdata at 0x000001D53899BB00>
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.read_calldata
         :type: function
-        :value: <function ValueRefMarshall.read_calldata at 0x000002A6D162EAC0>
+        :value: <function ValueRefMarshall.read_calldata at 0x000001D53899BBA0>
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.create_output
         :type: function
-        :value: <function ValueRefMarshall.create_output at 0x000002A6D162EB60>
+        :value: <function ValueRefMarshall.create_output at 0x000001D53899BC40>
     
     .. py:attribute:: slangpy.builtin.valueref.ValueRefMarshall.read_output
         :type: function
-        :value: <function ValueRefMarshall.read_output at 0x000002A6D162EC00>
+        :value: <function ValueRefMarshall.read_output at 0x000001D53899BCE0>
     
 
 
@@ -18212,35 +18874,35 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.resolve_type
         :type: function
-        :value: <function DiffPairMarshall.resolve_type at 0x000002A6D162F060>
+        :value: <function DiffPairMarshall.resolve_type at 0x000001D5389B4220>
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.resolve_dimensionality
         :type: function
-        :value: <function DiffPairMarshall.resolve_dimensionality at 0x000002A6D162F100>
+        :value: <function DiffPairMarshall.resolve_dimensionality at 0x000001D5389B42C0>
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.gen_calldata
         :type: function
-        :value: <function DiffPairMarshall.gen_calldata at 0x000002A6D162F1A0>
+        :value: <function DiffPairMarshall.gen_calldata at 0x000001D5389B4360>
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.get_type
         :type: function
-        :value: <function DiffPairMarshall.get_type at 0x000002A6D162F240>
+        :value: <function DiffPairMarshall.get_type at 0x000001D5389B4400>
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.create_calldata
         :type: function
-        :value: <function DiffPairMarshall.create_calldata at 0x000002A6D162F2E0>
+        :value: <function DiffPairMarshall.create_calldata at 0x000001D5389B44A0>
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.read_calldata
         :type: function
-        :value: <function DiffPairMarshall.read_calldata at 0x000002A6D162F380>
+        :value: <function DiffPairMarshall.read_calldata at 0x000001D5389B4540>
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.create_output
         :type: function
-        :value: <function DiffPairMarshall.create_output at 0x000002A6D162F420>
+        :value: <function DiffPairMarshall.create_output at 0x000001D5389B45E0>
     
     .. py:attribute:: slangpy.builtin.diffpair.DiffPairMarshall.read_output
         :type: function
-        :value: <function DiffPairMarshall.read_output at 0x000002A6D162F4C0>
+        :value: <function DiffPairMarshall.read_output at 0x000001D5389B4680>
     
 
 
@@ -18345,6 +19007,24 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.builtin.ndbuffer.ShaderCursor
+    :canonical: slangpy.ShaderCursor
+    
+    Alias class: :py:class:`slangpy.ShaderCursor`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.ndbuffer.ShaderObject
+    :canonical: slangpy.ShaderObject
+    
+    Alias class: :py:class:`slangpy.ShaderObject`
+    
+
+
+----
+
 .. py:class:: slangpy.builtin.ndbuffer.Marshall
     :canonical: slangpy.bindings.marshall.Marshall
     
@@ -18426,10 +19106,28 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.builtin.ndbuffer.MatrixType
+    :canonical: slangpy.reflection.reflectiontypes.MatrixType
+    
+    Alias class: :py:class:`slangpy.reflection.reflectiontypes.MatrixType`
+    
+
+
+----
+
 .. py:class:: slangpy.builtin.ndbuffer.StructuredBufferType
     :canonical: slangpy.reflection.reflectiontypes.StructuredBufferType
     
     Alias class: :py:class:`slangpy.reflection.reflectiontypes.StructuredBufferType`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.ndbuffer.PointerType
+    :canonical: slangpy.reflection.reflectiontypes.PointerType
+    
+    Alias class: :py:class:`slangpy.reflection.reflectiontypes.PointerType`
     
 
 
@@ -18483,19 +19181,23 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDBufferMarshall.reduce_type
         :type: function
-        :value: <function NDBufferMarshall.reduce_type at 0x000002A6D1658680>
+        :value: <function NDBufferMarshall.reduce_type at 0x000001D5389B5800>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDBufferMarshall.resolve_type
         :type: function
-        :value: <function NDBufferMarshall.resolve_type at 0x000002A6D1658720>
+        :value: <function NDBufferMarshall.resolve_type at 0x000001D5389B58A0>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDBufferMarshall.resolve_dimensionality
         :type: function
-        :value: <function NDBufferMarshall.resolve_dimensionality at 0x000002A6D16587C0>
+        :value: <function NDBufferMarshall.resolve_dimensionality at 0x000001D5389B5940>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDBufferMarshall.gen_calldata
         :type: function
-        :value: <function NDBufferMarshall.gen_calldata at 0x000002A6D1658860>
+        :value: <function NDBufferMarshall.gen_calldata at 0x000001D5389B59E0>
+    
+    .. py:attribute:: slangpy.builtin.ndbuffer.NDBufferMarshall.build_shader_object
+        :type: function
+        :value: <function NDBufferMarshall.build_shader_object at 0x000001D5389B5A80>
     
 
 
@@ -18507,39 +19209,39 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.reduce_type
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.reduce_type at 0x000002A6D1658B80>
+        :value: <function NDDifferentiableBufferMarshall.reduce_type at 0x000001D5389B5DA0>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.resolve_type
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.resolve_type at 0x000002A6D1658C20>
+        :value: <function NDDifferentiableBufferMarshall.resolve_type at 0x000001D5389B5E40>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.resolve_dimensionality
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.resolve_dimensionality at 0x000002A6D1658CC0>
+        :value: <function NDDifferentiableBufferMarshall.resolve_dimensionality at 0x000001D5389B5EE0>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.gen_calldata
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.gen_calldata at 0x000002A6D1658D60>
+        :value: <function NDDifferentiableBufferMarshall.gen_calldata at 0x000001D5389B5F80>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.create_calldata
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.create_calldata at 0x000002A6D1658E00>
+        :value: <function NDDifferentiableBufferMarshall.create_calldata at 0x000001D5389B6020>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.create_output
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.create_output at 0x000002A6D1658EA0>
+        :value: <function NDDifferentiableBufferMarshall.create_output at 0x000001D5389B60C0>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.read_output
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.read_output at 0x000002A6D1658F40>
+        :value: <function NDDifferentiableBufferMarshall.read_output at 0x000001D5389B6160>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.create_dispatchdata
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.create_dispatchdata at 0x000002A6D1658FE0>
+        :value: <function NDDifferentiableBufferMarshall.create_dispatchdata at 0x000001D5389B6200>
     
     .. py:attribute:: slangpy.builtin.ndbuffer.NDDifferentiableBufferMarshall.get_shape
         :type: function
-        :value: <function NDDifferentiableBufferMarshall.get_shape at 0x000002A6D1659080>
+        :value: <function NDDifferentiableBufferMarshall.get_shape at 0x000001D5389B62A0>
     
 
 
@@ -18641,15 +19343,15 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.struct.StructMarshall.resolve_type
         :type: function
-        :value: <function StructMarshall.resolve_type at 0x000002A6D16594E0>
+        :value: <function StructMarshall.resolve_type at 0x000001D5389B67A0>
     
     .. py:attribute:: slangpy.builtin.struct.StructMarshall.resolve_dimensionality
         :type: function
-        :value: <function StructMarshall.resolve_dimensionality at 0x000002A6D1659580>
+        :value: <function StructMarshall.resolve_dimensionality at 0x000001D5389B6840>
     
     .. py:attribute:: slangpy.builtin.struct.StructMarshall.create_dispatchdata
         :type: function
-        :value: <function StructMarshall.create_dispatchdata at 0x000002A6D1659620>
+        :value: <function StructMarshall.create_dispatchdata at 0x000001D5389B68E0>
     
 
 
@@ -18718,6 +19420,15 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.builtin.structuredbuffer.PointerType
+    :canonical: slangpy.reflection.reflectiontypes.PointerType
+    
+    Alias class: :py:class:`slangpy.reflection.reflectiontypes.PointerType`
+    
+
+
+----
+
 .. py:class:: slangpy.builtin.structuredbuffer.Buffer
     :canonical: slangpy.Buffer
     
@@ -18769,19 +19480,19 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.structuredbuffer.BufferMarshall.resolve_type
         :type: function
-        :value: <function BufferMarshall.resolve_type at 0x000002A6D16598A0>
+        :value: <function BufferMarshall.resolve_type at 0x000001D5389B6CA0>
     
     .. py:attribute:: slangpy.builtin.structuredbuffer.BufferMarshall.resolve_dimensionality
         :type: function
-        :value: <function BufferMarshall.resolve_dimensionality at 0x000002A6D1659940>
+        :value: <function BufferMarshall.resolve_dimensionality at 0x000001D5389B6D40>
     
     .. py:attribute:: slangpy.builtin.structuredbuffer.BufferMarshall.gen_calldata
         :type: function
-        :value: <function BufferMarshall.gen_calldata at 0x000002A6D16599E0>
+        :value: <function BufferMarshall.gen_calldata at 0x000001D5389B6DE0>
     
     .. py:attribute:: slangpy.builtin.structuredbuffer.BufferMarshall.reduce_type
         :type: function
-        :value: <function BufferMarshall.reduce_type at 0x000002A6D1659B20>
+        :value: <function BufferMarshall.reduce_type at 0x000001D5389B6F20>
     
 
 
@@ -18970,23 +19681,23 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.texture.TextureMarshall.reduce_type
         :type: function
-        :value: <function TextureMarshall.reduce_type at 0x000002A6D165A020>
+        :value: <function TextureMarshall.reduce_type at 0x000001D5389B7420>
     
     .. py:attribute:: slangpy.builtin.texture.TextureMarshall.resolve_type
         :type: function
-        :value: <function TextureMarshall.resolve_type at 0x000002A6D165A0C0>
+        :value: <function TextureMarshall.resolve_type at 0x000001D5389B74C0>
     
     .. py:attribute:: slangpy.builtin.texture.TextureMarshall.build_type_name
         :type: function
-        :value: <function TextureMarshall.build_type_name at 0x000002A6D165A200>
+        :value: <function TextureMarshall.build_type_name at 0x000001D5389B7600>
     
     .. py:attribute:: slangpy.builtin.texture.TextureMarshall.build_accessor_name
         :type: function
-        :value: <function TextureMarshall.build_accessor_name at 0x000002A6D165A2A0>
+        :value: <function TextureMarshall.build_accessor_name at 0x000001D5389B76A0>
     
     .. py:attribute:: slangpy.builtin.texture.TextureMarshall.gen_calldata
         :type: function
-        :value: <function TextureMarshall.gen_calldata at 0x000002A6D165A340>
+        :value: <function TextureMarshall.gen_calldata at 0x000001D5389B7740>
     
 
 
@@ -18998,15 +19709,15 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.texture.SamplerMarshall.gen_calldata
         :type: function
-        :value: <function SamplerMarshall.gen_calldata at 0x000002A6D165A7A0>
+        :value: <function SamplerMarshall.gen_calldata at 0x000001D5389B7BA0>
     
     .. py:attribute:: slangpy.builtin.texture.SamplerMarshall.create_calldata
         :type: function
-        :value: <function SamplerMarshall.create_calldata at 0x000002A6D165A840>
+        :value: <function SamplerMarshall.create_calldata at 0x000001D5389B7C40>
     
     .. py:attribute:: slangpy.builtin.texture.SamplerMarshall.create_dispatchdata
         :type: function
-        :value: <function SamplerMarshall.create_dispatchdata at 0x000002A6D165A8E0>
+        :value: <function SamplerMarshall.create_dispatchdata at 0x000001D5389B7CE0>
     
 
 
@@ -19066,9 +19777,114 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.builtin.array.BindContext
+    :canonical: slangpy.bindings.marshall.BindContext
+    
+    Alias class: :py:class:`slangpy.bindings.marshall.BindContext`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.BoundVariable
+    :canonical: slangpy.bindings.boundvariable.BoundVariable
+    
+    Alias class: :py:class:`slangpy.bindings.boundvariable.BoundVariable`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.BoundVariableRuntime
+    :canonical: slangpy.bindings.boundvariableruntime.BoundVariableRuntime
+    
+    Alias class: :py:class:`slangpy.bindings.boundvariableruntime.BoundVariableRuntime`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.CodeGenBlock
+    :canonical: slangpy.bindings.codegen.CodeGenBlock
+    
+    Alias class: :py:class:`slangpy.bindings.codegen.CodeGenBlock`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.ShaderCursor
+    :canonical: slangpy.ShaderCursor
+    
+    Alias class: :py:class:`slangpy.ShaderCursor`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.ShaderObject
+    :canonical: slangpy.ShaderObject
+    
+    Alias class: :py:class:`slangpy.ShaderObject`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.AccessType
+    :canonical: slangpy.slangpy.AccessType
+    
+    Alias class: :py:class:`slangpy.slangpy.AccessType`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.CallContext
+    :canonical: slangpy.slangpy.CallContext
+    
+    Alias class: :py:class:`slangpy.slangpy.CallContext`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.array.NativeValueMarshall
+    :canonical: slangpy.slangpy.NativeValueMarshall
+    
+    Alias class: :py:class:`slangpy.slangpy.NativeValueMarshall`
+    
+
+
+----
+
+.. py:function:: slangpy.builtin.array.unpack_arg(arg: object) -> object
+
+    N/A
+    
+
+
+----
+
 .. py:class:: slangpy.builtin.array.ArrayMarshall
 
     Base class: :py:class:`slangpy.builtin.value.ValueMarshall`
+    
+    .. py:attribute:: slangpy.builtin.array.ArrayMarshall.reduce_type
+        :type: function
+        :value: <function ArrayMarshall.reduce_type at 0x000001D5389C4040>
+    
+    .. py:attribute:: slangpy.builtin.array.ArrayMarshall.resolve_type
+        :type: function
+        :value: <function ArrayMarshall.resolve_type at 0x000001D5389C40E0>
+    
+    .. py:attribute:: slangpy.builtin.array.ArrayMarshall.gen_calldata
+        :type: function
+        :value: <function ArrayMarshall.gen_calldata at 0x000001D5389C4180>
+    
+    .. py:attribute:: slangpy.builtin.array.ArrayMarshall.build_shader_object
+        :type: function
+        :value: <function ArrayMarshall.build_shader_object at 0x000001D5389C4220>
     
 
 
@@ -19233,15 +20049,15 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.accelerationstructure.AccelerationStructureMarshall.gen_calldata
         :type: function
-        :value: <function AccelerationStructureMarshall.gen_calldata at 0x000002A6D165AD40>
+        :value: <function AccelerationStructureMarshall.gen_calldata at 0x000001D5389C4680>
     
     .. py:attribute:: slangpy.builtin.accelerationstructure.AccelerationStructureMarshall.create_calldata
         :type: function
-        :value: <function AccelerationStructureMarshall.create_calldata at 0x000002A6D165ADE0>
+        :value: <function AccelerationStructureMarshall.create_calldata at 0x000001D5389C4720>
     
     .. py:attribute:: slangpy.builtin.accelerationstructure.AccelerationStructureMarshall.create_dispatchdata
         :type: function
-        :value: <function AccelerationStructureMarshall.create_dispatchdata at 0x000002A6D165AE80>
+        :value: <function AccelerationStructureMarshall.create_dispatchdata at 0x000001D5389C47C0>
     
 
 
@@ -19370,23 +20186,23 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.range.RangeMarshall.gen_calldata
         :type: function
-        :value: <function RangeMarshall.gen_calldata at 0x000002A6D165B060>
+        :value: <function RangeMarshall.gen_calldata at 0x000001D5389C49A0>
     
     .. py:attribute:: slangpy.builtin.range.RangeMarshall.create_calldata
         :type: function
-        :value: <function RangeMarshall.create_calldata at 0x000002A6D165B100>
+        :value: <function RangeMarshall.create_calldata at 0x000001D5389C4A40>
     
     .. py:attribute:: slangpy.builtin.range.RangeMarshall.get_shape
         :type: function
-        :value: <function RangeMarshall.get_shape at 0x000002A6D165B1A0>
+        :value: <function RangeMarshall.get_shape at 0x000001D5389C4AE0>
     
     .. py:attribute:: slangpy.builtin.range.RangeMarshall.resolve_type
         :type: function
-        :value: <function RangeMarshall.resolve_type at 0x000002A6D165B240>
+        :value: <function RangeMarshall.resolve_type at 0x000001D5389C4B80>
     
     .. py:attribute:: slangpy.builtin.range.RangeMarshall.resolve_dimensionality
         :type: function
-        :value: <function RangeMarshall.resolve_dimensionality at 0x000002A6D165B2E0>
+        :value: <function RangeMarshall.resolve_dimensionality at 0x000001D5389C4C20>
     
 
 
@@ -19506,19 +20322,19 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.numpy.NumpyMarshall.reduce_type
         :type: function
-        :value: <function NumpyMarshall.reduce_type at 0x000002A6D165B600>
+        :value: <function NumpyMarshall.reduce_type at 0x000001D5389C4FE0>
     
     .. py:attribute:: slangpy.builtin.numpy.NumpyMarshall.resolve_type
         :type: function
-        :value: <function NumpyMarshall.resolve_type at 0x000002A6D165B6A0>
+        :value: <function NumpyMarshall.resolve_type at 0x000001D5389C5080>
     
     .. py:attribute:: slangpy.builtin.numpy.NumpyMarshall.resolve_dimensionality
         :type: function
-        :value: <function NumpyMarshall.resolve_dimensionality at 0x000002A6D165B740>
+        :value: <function NumpyMarshall.resolve_dimensionality at 0x000001D5389C5120>
     
     .. py:attribute:: slangpy.builtin.numpy.NumpyMarshall.gen_calldata
         :type: function
-        :value: <function NumpyMarshall.gen_calldata at 0x000002A6D165B7E0>
+        :value: <function NumpyMarshall.gen_calldata at 0x000001D5389C51C0>
     
 
 
@@ -19605,6 +20421,24 @@ Miscellaneous
 
 ----
 
+.. py:class:: slangpy.builtin.tensor.ShaderObject
+    :canonical: slangpy.ShaderObject
+    
+    Alias class: :py:class:`slangpy.ShaderObject`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.tensor.ShaderCursor
+    :canonical: slangpy.ShaderCursor
+    
+    Alias class: :py:class:`slangpy.ShaderCursor`
+    
+
+
+----
+
 .. py:class:: slangpy.builtin.tensor.SlangProgramLayout
     :canonical: slangpy.reflection.reflectiontypes.SlangProgramLayout
     
@@ -19636,6 +20470,15 @@ Miscellaneous
     :canonical: slangpy.reflection.reflectiontypes.ScalarType
     
     Alias class: :py:class:`slangpy.reflection.reflectiontypes.ScalarType`
+    
+
+
+----
+
+.. py:class:: slangpy.builtin.tensor.MatrixType
+    :canonical: slangpy.reflection.reflectiontypes.MatrixType
+    
+    Alias class: :py:class:`slangpy.reflection.reflectiontypes.MatrixType`
     
 
 
@@ -19691,23 +20534,23 @@ Miscellaneous
     
     .. py:attribute:: slangpy.builtin.tensor.TensorMarshall.resolve_type
         :type: function
-        :value: <function TensorMarshall.resolve_type at 0x000002A6D1670220>
+        :value: <function TensorMarshall.resolve_type at 0x000001D5389C5C60>
     
     .. py:attribute:: slangpy.builtin.tensor.TensorMarshall.reduce_type
         :type: function
-        :value: <function TensorMarshall.reduce_type at 0x000002A6D16702C0>
+        :value: <function TensorMarshall.reduce_type at 0x000001D5389C5D00>
     
     .. py:attribute:: slangpy.builtin.tensor.TensorMarshall.resolve_dimensionality
         :type: function
-        :value: <function TensorMarshall.resolve_dimensionality at 0x000002A6D1670360>
-    
-    .. py:attribute:: slangpy.builtin.tensor.TensorMarshall.get_shape
-        :type: function
-        :value: <function TensorMarshall.get_shape at 0x000002A6D1670400>
+        :value: <function TensorMarshall.resolve_dimensionality at 0x000001D5389C5DA0>
     
     .. py:attribute:: slangpy.builtin.tensor.TensorMarshall.gen_calldata
         :type: function
-        :value: <function TensorMarshall.gen_calldata at 0x000002A6D16704A0>
+        :value: <function TensorMarshall.gen_calldata at 0x000001D5389C5E40>
+    
+    .. py:attribute:: slangpy.builtin.tensor.TensorMarshall.build_shader_object
+        :type: function
+        :value: <function TensorMarshall.build_shader_object at 0x000001D5389C5EE0>
     
 
 
@@ -19717,406 +20560,6 @@ Miscellaneous
     :canonical: slangpy.builtin.tensor.TensorMarshall
     
     Alias class: :py:class:`slangpy.builtin.tensor.TensorMarshall`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.Any
-    :canonical: typing.Any
-    
-    Alias class: :py:class:`typing.Any`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.ScalarType
-    :canonical: slangpy.reflection.reflectiontypes.ScalarType
-    
-    Alias class: :py:class:`slangpy.reflection.reflectiontypes.ScalarType`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.DataType
-    :canonical: slangpy.DataType
-    
-    Alias class: :py:class:`slangpy.DataType`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.Device
-    :canonical: slangpy.Device
-    
-    Alias class: :py:class:`slangpy.Device`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.BufferUsage
-    :canonical: slangpy.BufferUsage
-    
-    Alias class: :py:class:`slangpy.BufferUsage`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.TypeReflection
-    :canonical: slangpy.TypeReflection
-    
-    Alias class: :py:class:`slangpy.TypeReflection`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.AccessType
-    :canonical: slangpy.slangpy.AccessType
-    
-    Alias class: :py:class:`slangpy.slangpy.AccessType`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.CallContext
-    :canonical: slangpy.slangpy.CallContext
-    
-    Alias class: :py:class:`slangpy.slangpy.CallContext`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.CallMode
-    :canonical: slangpy.slangpy.CallMode
-    
-    Alias class: :py:class:`slangpy.slangpy.CallMode`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.Shape
-    :canonical: slangpy.slangpy.Shape
-    
-    Alias class: :py:class:`slangpy.slangpy.Shape`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.BoundVariableRuntime
-    :canonical: slangpy.bindings.boundvariableruntime.BoundVariableRuntime
-    
-    Alias class: :py:class:`slangpy.bindings.boundvariableruntime.BoundVariableRuntime`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.ReturnContext
-    :canonical: slangpy.bindings.marshall.ReturnContext
-    
-    Alias class: :py:class:`slangpy.bindings.marshall.ReturnContext`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.TensorMarshall
-    :canonical: slangpy.builtin.tensor.TensorMarshall
-    
-    Alias class: :py:class:`slangpy.builtin.tensor.TensorMarshall`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.Buffer
-    :canonical: slangpy.Buffer
-    
-    Alias class: :py:class:`slangpy.Buffer`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.SlangProgramLayout
-    :canonical: slangpy.reflection.reflectiontypes.SlangProgramLayout
-    
-    Alias class: :py:class:`slangpy.reflection.reflectiontypes.SlangProgramLayout`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.SlangType
-    :canonical: slangpy.reflection.reflectiontypes.SlangType
-    
-    Alias class: :py:class:`slangpy.reflection.reflectiontypes.SlangType`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.VectorType
-    :canonical: slangpy.reflection.reflectiontypes.VectorType
-    
-    Alias class: :py:class:`slangpy.reflection.reflectiontypes.VectorType`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.ST
-    :canonical: slangpy.TypeReflection.ScalarType
-    
-    Alias class: :py:class:`slangpy.TypeReflection.ScalarType`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.WrappedTensor
-
-    .. py:attribute:: slangpy.torchintegration.wrappedtensor.WrappedTensor.collect_streams
-        :type: function
-        :value: <function WrappedTensor.collect_streams at 0x000002A6DC19C360>
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.wrappedtensor.WrappedTensorMarshall
-
-    Base class: :py:class:`slangpy.builtin.tensor.TensorMarshall`
-    
-    .. py:attribute:: slangpy.torchintegration.wrappedtensor.WrappedTensorMarshall.get_shape
-        :type: function
-        :value: <function WrappedTensorMarshall.get_shape at 0x000002A6DC19C400>
-    
-    .. py:attribute:: slangpy.torchintegration.wrappedtensor.WrappedTensorMarshall.create_calldata
-        :type: function
-        :value: <function WrappedTensorMarshall.create_calldata at 0x000002A6DC19C540>
-    
-    .. py:attribute:: slangpy.torchintegration.wrappedtensor.WrappedTensorMarshall.read_calldata
-        :type: function
-        :value: <function WrappedTensorMarshall.read_calldata at 0x000002A6DC19C5E0>
-    
-    .. py:attribute:: slangpy.torchintegration.wrappedtensor.WrappedTensorMarshall.create_output
-        :type: function
-        :value: <function WrappedTensorMarshall.create_output at 0x000002A6DC19C680>
-    
-    .. py:attribute:: slangpy.torchintegration.wrappedtensor.WrappedTensorMarshall.read_output
-        :type: function
-        :value: <function WrappedTensorMarshall.read_output at 0x000002A6DC19C720>
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.Any
-    :canonical: typing.Any
-    
-    Alias class: :py:class:`typing.Any`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.AccessType
-    :canonical: slangpy.slangpy.AccessType
-    
-    Alias class: :py:class:`slangpy.slangpy.AccessType`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.WrappedTensor
-    :canonical: slangpy.torchintegration.wrappedtensor.WrappedTensor
-    
-    Alias class: :py:class:`slangpy.torchintegration.wrappedtensor.WrappedTensor`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.Function
-    :canonical: slangpy.core.function.Function
-    
-    Alias class: :py:class:`slangpy.core.function.Function`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.FunctionNode
-    :canonical: slangpy.core.function.FunctionNode
-    
-    Alias class: :py:class:`slangpy.core.function.FunctionNode`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.IThis
-    :canonical: slangpy.core.function.IThis
-    
-    Alias class: :py:class:`slangpy.core.function.IThis`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.TypeConformance
-    :canonical: slangpy.TypeConformance
-    
-    Alias class: :py:class:`slangpy.TypeConformance`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.Device
-    :canonical: slangpy.Device
-    
-    Alias class: :py:class:`slangpy.Device`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.TorchAutoGradFunction
-
-    Base class: :py:class:`torch.autograd.function.Function`
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchAutoGradFunction.forward
-        :type: function
-        :value: <function TorchAutoGradFunction.forward at 0x000002A6DC19CD60>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchAutoGradFunction.backward
-        :type: function
-        :value: <function TorchAutoGradFunction.backward at 0x000002A6DC19CE00>
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchfunction.TorchFunction
-
-    Base class: :py:class:`torch.nn.modules.module.Module`
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.forward
-        :type: function
-        :value: <function TorchFunction.forward at 0x000002A6DC19CF40>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.bind
-        :type: function
-        :value: <function TorchFunction.bind at 0x000002A6DC19CFE0>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.map
-        :type: function
-        :value: <function TorchFunction.map at 0x000002A6DC19D080>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.set
-        :type: function
-        :value: <function TorchFunction.set at 0x000002A6DC19D120>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.constants
-        :type: function
-        :value: <function TorchFunction.constants at 0x000002A6DC19D1C0>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.type_conformances
-        :type: function
-        :value: <function TorchFunction.type_conformances at 0x000002A6DC19D260>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.return_type
-        :type: function
-        :value: <function TorchFunction.return_type at 0x000002A6DC19D300>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.as_func
-        :type: function
-        :value: <function TorchFunction.as_func at 0x000002A6DC19D440>
-    
-    .. py:attribute:: slangpy.torchintegration.torchfunction.TorchFunction.as_struct
-        :type: function
-        :value: <function TorchFunction.as_struct at 0x000002A6DC19D4E0>
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.TorchFunction
-    :canonical: slangpy.torchintegration.torchfunction.TorchFunction
-    
-    Alias class: :py:class:`slangpy.torchintegration.torchfunction.TorchFunction`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchstruct.Any
-    :canonical: typing.Any
-    
-    Alias class: :py:class:`typing.Any`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchstruct.Function
-    :canonical: slangpy.core.function.Function
-    
-    Alias class: :py:class:`slangpy.core.function.Function`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchstruct.Struct
-    :canonical: slangpy.core.struct.Struct
-    
-    Alias class: :py:class:`slangpy.core.struct.Struct`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchstruct.TorchFunction
-    :canonical: slangpy.torchintegration.torchfunction.TorchFunction
-    
-    Alias class: :py:class:`slangpy.torchintegration.torchfunction.TorchFunction`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchstruct.TorchStruct
-
-    
-        A Slang struct, typically created by accessing it via a module or parent struct. i.e. mymodule.Foo,
-        or mymodule.Foo.Bar.
-        
-    
-    .. py:attribute:: slangpy.torchintegration.torchstruct.TorchStruct.try_get_child
-        :type: function
-        :value: <function TorchStruct.try_get_child at 0x000002A6DC19E840>
-    
-    .. py:attribute:: slangpy.torchintegration.torchstruct.TorchStruct.as_func
-        :type: function
-        :value: <function TorchStruct.as_func at 0x000002A6DC19EAC0>
-    
-    .. py:attribute:: slangpy.torchintegration.torchstruct.TorchStruct.as_struct
-        :type: function
-        :value: <function TorchStruct.as_struct at 0x000002A6DC19EB60>
     
 
 
@@ -20176,61 +20619,43 @@ Miscellaneous
 
 ----
 
-.. py:class:: slangpy.torchintegration.torchmodule.TorchFunction
-    :canonical: slangpy.torchintegration.torchfunction.TorchFunction
-    
-    Alias class: :py:class:`slangpy.torchintegration.torchfunction.TorchFunction`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.torchmodule.TorchStruct
-    :canonical: slangpy.torchintegration.torchstruct.TorchStruct
-    
-    Alias class: :py:class:`slangpy.torchintegration.torchstruct.TorchStruct`
-    
-
-
-----
-
 .. py:class:: slangpy.torchintegration.torchmodule.TorchModule
 
     
-        A Slang module, created either by loading a slang file or providing a loaded SGL module.
-        
+    A Slang module, created either by loading a slang file or providing a loaded SGL module.
+    
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.load_from_source
         :type: function
-        :value: <function TorchModule.load_from_source at 0x000002A6DC19D8A0>
+        :value: <function TorchModule.load_from_source at 0x000001D5389C6700>
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.load_from_file
         :type: function
-        :value: <function TorchModule.load_from_file at 0x000002A6DC19EC00>
+        :value: <function TorchModule.load_from_file at 0x000001D5389C7380>
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.load_from_module
         :type: function
-        :value: <function TorchModule.load_from_module at 0x000002A6DC19ECA0>
+        :value: <function TorchModule.load_from_module at 0x000001D5389C7420>
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.find_struct
         :type: function
-        :value: <function TorchModule.find_struct at 0x000002A6DC19EF20>
+        :value: <function TorchModule.find_struct at 0x000001D5389C76A0>
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.require_struct
         :type: function
-        :value: <function TorchModule.require_struct at 0x000002A6DC19EFC0>
+        :value: <function TorchModule.require_struct at 0x000001D5389C7740>
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.find_function
         :type: function
-        :value: <function TorchModule.find_function at 0x000002A6DC19F060>
+        :value: <function TorchModule.find_function at 0x000001D5389C77E0>
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.require_function
         :type: function
-        :value: <function TorchModule.require_function at 0x000002A6DC19F100>
+        :value: <function TorchModule.require_function at 0x000001D5389C7880>
     
     .. py:attribute:: slangpy.torchintegration.torchmodule.TorchModule.find_function_in_struct
         :type: function
-        :value: <function TorchModule.find_function_in_struct at 0x000002A6DC19F1A0>
+        :value: <function TorchModule.find_function_in_struct at 0x000001D5389C7920>
     
 
 
@@ -20240,15 +20665,6 @@ Miscellaneous
     :canonical: slangpy.torchintegration.torchmodule.TorchModule
     
     Alias class: :py:class:`slangpy.torchintegration.torchmodule.TorchModule`
-    
-
-
-----
-
-.. py:class:: slangpy.torchintegration.TorchStruct
-    :canonical: slangpy.torchintegration.torchstruct.TorchStruct
-    
-    Alias class: :py:class:`slangpy.torchintegration.torchstruct.TorchStruct`
     
 
 
@@ -20308,27 +20724,9 @@ Miscellaneous
 
 ----
 
-.. py:class:: slangpy.TorchFunction
-    :canonical: slangpy.torchintegration.torchfunction.TorchFunction
-    
-    Alias class: :py:class:`slangpy.torchintegration.torchfunction.TorchFunction`
-    
-
-
-----
-
-.. py:class:: slangpy.TorchStruct
-    :canonical: slangpy.torchintegration.torchstruct.TorchStruct
-    
-    Alias class: :py:class:`slangpy.torchintegration.torchstruct.TorchStruct`
-    
-
-
-----
-
 .. py:data:: slangpy.SHADER_PATH
     :type: str
-    :value: "C:\src\slangpy\slangpy\slang"
+    :value: "C:\sbf\slangpy\slangpy\slang"
 
 
 

--- a/docs/src/basics/buffers.rst
+++ b/docs/src/basics/buffers.rst
@@ -1,7 +1,7 @@
 Buffers
 =======
 
-SlangPy provides two key wrappers around classic structured buffers (represented in SGL as `Buffer` objects): ``NDBuffer`` and ``Tensor``.
+SlangPy provides two key wrappers around classic structured buffers (represented in SlangPy as `Buffer` objects): ``NDBuffer`` and ``Tensor``.
 
 The ``NDBuffer`` type takes a structured buffer with a defined stride and size and adds:
 
@@ -46,7 +46,7 @@ Initialization follows the same steps as in the previous example:
     import pathlib
     import numpy as np
 
-    # Create an SGL device with the local folder for slangpy includes
+    # Create a SlangPy device and use the local folder for Slang includes
     device = spy.create_device(include_paths=[
             pathlib.Path(__file__).parent.absolute(),
     ])

--- a/docs/src/basics/firstfunctions.rst
+++ b/docs/src/basics/firstfunctions.rst
@@ -26,7 +26,7 @@ Next, we'll create a Python script to initialize SlangPy, load the Slang module,
     import slangpy as spy
     import pathlib
 
-    # Create a device and use the local folder for Slang includes
+    # Create a SlangPy device; it will look in the local folder for any Slang includes
     device = spy.create_device(include_paths=[
             pathlib.Path(__file__).parent.absolute(),
     ])

--- a/docs/src/basics/firstfunctions.rst
+++ b/docs/src/basics/firstfunctions.rst
@@ -1,7 +1,7 @@
 Your First Function
 ===================
 
-In this example, we'll initialize SGL, create a simple Slang function, and call it from Python.
+In this example, we'll initialize SlangPy, create a simple Slang function, and call it from Python.
 
 You can find the complete code for this example `here <https://github.com/shader-slang/slangpy-samples/tree/main/examples/first_function/>`_.
 
@@ -17,17 +17,16 @@ First, let's define a simple Slang function to add two numbers together:
         return a + b;
     }
 
-Next, we'll create a Python script to initialize SGL, load the Slang module, and call the function:
+Next, we'll create a Python script to initialize SlangPy, load the Slang module, and call the function:
 
 .. code-block:: python
 
-    ## main.py
+    ## main_scalar.py
 
     import slangpy as spy
     import pathlib
-    import numpy as np
 
-    # Create an SGL device with the local folder for slangpy includes
+    # Create a device and use the local folder for Slang includes
     device = spy.create_device(include_paths=[
             pathlib.Path(__file__).parent.absolute(),
     ])
@@ -49,15 +48,15 @@ While this is a fun demonstration, dispatching a compute kernel just to add two 
 
 .. code-block:: python
 
-    ## main.py
+    ## main_numpy.py
 
     # ... initialization here ...
 
-    # Create a couple of buffers with 1,000,000 random floats
+    # Create a couple of buffers containing 1,000,000 random floats
     a = np.random.rand(1000000).astype(np.float32)
     b = np.random.rand(1000000).astype(np.float32)
 
-    # Call our function and request a numpy array as the result (default would be a buffer)
+    # Call our function and request a numpy array as the result (the default would be a buffer)
     result = module.add(a, b, _result='numpy')
 
     # Print the first 10 results

--- a/docs/src/basics/nested.rst
+++ b/docs/src/basics/nested.rst
@@ -15,12 +15,11 @@ Let's start with a straightforward function that copies the value of one `float4
         dest = src;
     }
 
-We could directly use the ``copy`` function to copy a NumPy array into a texture, though this is
-relatively pointless since we can manually set the texture's data using SGL's ``from_numpy`` function.
+We could directly use the ``copy`` function to copy a NumPy array into a texture. (This is for demonstration purposes only; normally we would initialize the texture's data using SlangPy's ``from_numpy`` function.)
 
 .. code-block:: python
 
-    # Create a texture to store results
+    # Create a texture to store the results
     tex = device.create_texture(
         width=128,
         height=128,

--- a/docs/src/basics/returntype.rst
+++ b/docs/src/basics/returntype.rst
@@ -42,4 +42,4 @@ Here we use ``_result`` to specify that we want the result to be a texture.
 
 The ``_result`` can be ``'numpy'``, ``'texture'``, or ``'tensor'``. You can also use ``_result`` to specify the type directly, like ``numpy.ndarray``, ``slangpy.Texture``, or ``slangpy.Tensor``. Or you can reuse an existing variable of one of those types by passing it directly.
 
-You'll see more examples using ``_result`` in the rest of this documentation!
+You'll see more examples using ``_result`` as you continue through the documentation.

--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -10,6 +10,11 @@ required:
 * Python ``>= 3.8``
 * git
 
+.. tip::
+
+    You may want to consider setting up and using a Python virtual environment
+    (e.g., ``venv``) to isolate your development activities.
+
 
 Cloning the repository
 ----------------------
@@ -176,7 +181,7 @@ can be specified on the command line when running CMake, for example:
 
 .. code-block:: bash
 
-    cmake --preset windows-msvc -DSGL_BUILD_DOCS=ON -DSGL_BUILD_EXAMPLES=OFF -DSGL_BUILD_TESTS=OFF
+    cmake --preset windows-msvc -DSGL_BUILD_DOC=ON -DSGL_BUILD_EXAMPLES=OFF -DSGL_BUILD_TESTS=OFF
 
 
 The following table lists the available configuration options:
@@ -198,7 +203,7 @@ The following table lists the available configuration options:
     * - ``SGL_BUILD_TESTS``
       - ``ON``
       - Build sgl tests
-    * - ``SGL_BUILD_DOCS``
+    * - ``SGL_BUILD_DOC``
       - ``OFF``
       - Build sgl documentation
     * - ``SGL_USE_DYNAMIC_CUDA``
@@ -216,6 +221,42 @@ The following table lists the available configuration options:
     * - ``SGL_ENABLE_HEADER_VALIDATION``
       - ``OFF``
       - Enable header validation
+
+
+
+Updating the API Reference
+--------------------------
+
+SlangPy uses ``pybind11_mkdoc`` to extract documentation strings from the C++
+source code. These comments are then used by ``nanobind`` to generate Python
+documentation comments. These comments are then used when building the API
+Reference document.
+
+To run ``pybind11_mkdoc``, specify the ``pydoc`` target when invoking cmake:
+
+.. code-block:: bash
+
+    # Install Python build prerequisites
+    pip install -r requirements-dev.txt
+
+    # Install Python documentation build prerequisites
+    pip install -r requirements-docs.txt
+
+    # Configure
+    cmake --preset windows-msvc
+
+    # Build with pydoc target
+    cmake --build --preset windows-msvc-release --target pydoc
+
+The generated API Reference page can then be updated by invoking the html build
+of the SlangPy docs. (It's regenerated as part of running ``sphinx-build``.)
+
+**Tested on:**
+
+* Windows 10 (build 19045)
+* Visual Studio 2022 (Version 17.13.6)
+* CMake 4.0.2
+* Ninja 1.12.1
 
 
 VS Code

--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -3,7 +3,7 @@
 Compiling
 =========
 
-In order to compile ``sgl`` from source, the following prerequisites are
+In order to compile ``slangpy`` from source, the following prerequisites are
 required:
 
 * A C++20 compliant compiler (tested with Visual Studio 2022, GCC 11 and Clang 14)

--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -3,7 +3,7 @@
 Compiling
 =========
 
-In order to compile ``slangpy`` from source, the following prerequisites are
+In order to compile SlangPy from source, the following prerequisites are
 required:
 
 * A C++20 compliant compiler (tested with Visual Studio 2022, GCC 11 and Clang 14)

--- a/docs/src/developer_guide/testing.rst
+++ b/docs/src/developer_guide/testing.rst
@@ -3,9 +3,10 @@
 Testing
 =======
 
-Because ``sgl`` strives to expose all of its API to Python, most unit tests
-should be written in Python. However, some C++ unit tests are still needed for
-parts that are not exposed to Python.
+Because ``slangpy`` aims to expose the entire API of its internal C++ library
+(``sgl``) to Python, most unit tests should be written in Python. However,
+some C++ unit tests are still needed for parts of ``sgl`` that are not exposed
+to Python.
 
 Python Unit Tests
 -----------------

--- a/docs/src/developer_guide/testing.rst
+++ b/docs/src/developer_guide/testing.rst
@@ -3,7 +3,7 @@
 Testing
 =======
 
-Because ``slangpy`` aims to expose the entire API of its internal C++ library
+Because SlangPy aims to expose the entire API of its internal C++ library
 (``sgl``) to Python, most unit tests should be written in Python. However,
 some C++ unit tests are still needed for parts of ``sgl`` that are not exposed
 to Python.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+pybind11_mkdoc
+sphinx-build

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,4 @@
 pybind11_mkdoc
-sphinx-build
+nbsphinx
+sphinx
+furo

--- a/src/sgl/app/app.h
+++ b/src/sgl/app/app.h
@@ -53,7 +53,7 @@ struct AppWindowDesc {
     /// Height of the window in pixels.
     uint32_t height{1280};
     /// Title of the window.
-    std::string title{"sgl"};
+    std::string title{"slangpy"};
     /// Window mode.
     WindowMode mode{WindowMode::normal};
     /// Whether the window is resizable.

--- a/src/slangpy_ext/CMakeLists.txt
+++ b/src/slangpy_ext/CMakeLists.txt
@@ -189,23 +189,35 @@ if(SGL_MASTER_PROJECT)
         endforeach()
     endif()
 
-    # Note: The current version of pybind11_mkdoc does not support C++20.
-    # Running this will result in the following error:
-    # ValueError: Unknown template argument kind 604
-    # To fix this, we need to manually change the cindex.py file in the
-    # clang package and add the following lines:
+    set(SGL_HEADER_DIRS
+        "${CMAKE_CURRENT_SOURCE_DIR}/../sgl/app"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../sgl/core"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../sgl/device"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../sgl/math"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../sgl/ui"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../sgl/utils"
+    )
+    set(SGL_HEADER_FILES "")
+    foreach(sgl_dir IN ITEMS ${SGL_HEADER_DIRS})
+        file(GLOB FOUND_HEADERS "${sgl_dir}/*.h")
+        list(APPEND SGL_HEADER_FILES ${FOUND_HEADERS})
+    endforeach()
+
+    # Note: Older versions of python packages pybind11_mkdoc and clang
+    # may not support C++20. If you see the following error:
+    #   ValueError: Unknown template argument kind 604
+    # Upgrade to:
+    #   pybind_mkdoc >= 2.6.2
+    #   clang >= 20.1.5
+    # Or manually change the cindex.py file in your
+    # clang python package to add the following lines:
     # > # A concept declaration
     # > CursorKind.CONCEPT_DECL = CursorKind(604)
     add_custom_target(pydoc USES_TERMINAL COMMAND
         COMMAND ${Python_EXECUTABLE} -m pybind11_mkdoc -std=c++20 -stdlib=libc++
         ${MKDOC_ARGS}
         -I${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/../sgl/app/*.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/../sgl/core/*.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/../sgl/device/*.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/../sgl/math/*.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/../sgl/ui/*.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/../sgl/utils/*.h
+        ${SGL_HEADER_FILES}
         -o ${CMAKE_CURRENT_SOURCE_DIR}/py_doc.h
     )
 endif()

--- a/src/slangpy_ext/core/window.cpp
+++ b/src/slangpy_ext/core/window.cpp
@@ -46,7 +46,7 @@ SGL_PY_EXPORT(core_window)
         },
         "width"_a = 1024,
         "height"_a = 1024,
-        "title"_a = "sgl",
+        "title"_a = "slangpy",
         "mode"_a = WindowMode::normal,
         "resizable"_a = true,
         D(Window, Window)

--- a/src/slangpy_ext/device/reflection.cpp
+++ b/src/slangpy_ext/device/reflection.cpp
@@ -95,6 +95,8 @@ SGL_PY_EXPORT(device_reflection)
         D(TypeReflection, ParameterCategory)
     );
 
+    bind_list_type<TypeReflectionFieldList>(m, "TypeReflectionFieldList", D(TypeReflectionFieldList));
+
     type_reflection //
         .def_prop_ro("kind", &TypeReflection::kind, D(TypeReflection, kind))
         .def_prop_ro("name", &TypeReflection::name, D(TypeReflection, name))
@@ -115,9 +117,15 @@ SGL_PY_EXPORT(device_reflection)
         .def("unwrap_array", &TypeReflection::unwrap_array, D(TypeReflection, unwrap_array))
         .def("__repr__", &TypeReflection::to_string);
 
-    bind_list_type<TypeReflectionFieldList>(m, "TypeReflectionFieldList", D(TypeReflectionFieldList));
+    nb::class_<TypeLayoutReflection, BaseReflectionObject> type_layout_reflection(
+        m,
+        "TypeLayoutReflection",
+        D(TypeLayoutReflection)
+    );
 
-    nb::class_<TypeLayoutReflection, BaseReflectionObject>(m, "TypeLayoutReflection", D(TypeLayoutReflection))
+    bind_list_type<TypeLayoutReflectionFieldList>(m, "TypeLayoutReflectionFieldList", D(TypeLayoutReflectionFieldList));
+
+    type_layout_reflection //
         .def_prop_ro("kind", &TypeLayoutReflection::kind, D(TypeLayoutReflection, kind))
         .def_prop_ro("name", &TypeLayoutReflection::name, D(TypeLayoutReflection, name))
         .def_prop_ro("size", &TypeLayoutReflection::size, D(TypeLayoutReflection, size))
@@ -132,8 +140,6 @@ SGL_PY_EXPORT(device_reflection)
         )
         .def("unwrap_array", &TypeLayoutReflection::unwrap_array, D(TypeLayoutReflection, unwrap_array))
         .def("__repr__", &TypeLayoutReflection::to_string);
-
-    bind_list_type<TypeLayoutReflectionFieldList>(m, "TypeLayoutReflectionFieldList", D(TypeLayoutReflectionFieldList));
 
     nb::class_<FunctionReflection, BaseReflectionObject>(m, "FunctionReflection", D(FunctionReflection))
         .def_prop_ro("name", &FunctionReflection::name, D(FunctionReflection, name))
@@ -178,7 +184,11 @@ SGL_PY_EXPORT(device_reflection)
         .def_prop_ro("offset", &VariableLayoutReflection::offset, D(VariableLayoutReflection, offset))
         .def("__repr__", &VariableLayoutReflection::to_string);
 
-    nb::class_<EntryPointLayout, BaseReflectionObject>(m, "EntryPointLayout", D(EntryPointLayout))
+    nb::class_<EntryPointLayout, BaseReflectionObject> entry_point_layout(m, "EntryPointLayout", D(EntryPointLayout));
+
+    bind_list_type<EntryPointLayoutParameterList>(m, "EntryPointLayoutParameterList", D(EntryPointLayoutParameterList));
+
+    entry_point_layout //
         .def_prop_ro("name", &EntryPointLayout::name, D(EntryPointLayout, name))
         .def_prop_ro("name_override", &EntryPointLayout::name_override, D(EntryPointLayout, name_override))
         .def_prop_ro("stage", &EntryPointLayout::stage, D(EntryPointLayout, stage))
@@ -190,13 +200,14 @@ SGL_PY_EXPORT(device_reflection)
         .def_prop_ro("parameters", &EntryPointLayout::parameters, D(EntryPointLayout, parameters))
         .def("__repr__", &EntryPointLayout::to_string);
 
-    bind_list_type<EntryPointLayoutParameterList>(m, "EntryPointLayoutParameterList", D(EntryPointLayoutParameterList));
-
     nb::class_<ProgramLayout, BaseReflectionObject> program_layout(m, "ProgramLayout", D(ProgramLayout));
 
     nb::class_<ProgramLayout::HashedString>(program_layout, "HashedString", D(ProgramLayout, HashedString))
         .def_ro("string", &ProgramLayout::HashedString::string, D(ProgramLayout, HashedString, string))
         .def_ro("hash", &ProgramLayout::HashedString::hash, D(ProgramLayout, HashedString, hash));
+
+    bind_list_type<ProgramLayoutParameterList>(m, "ProgramLayoutParameterList", D(ProgramLayoutParameterList));
+    bind_list_type<ProgramLayoutEntryPointList>(m, "ProgramLayoutEntryPointList", D(ProgramLayoutEntryPointList));
 
     program_layout //
         .def_prop_ro("globals_type_layout", &ProgramLayout::globals_type_layout, D(ProgramLayout, globals_type_layout))
@@ -225,9 +236,6 @@ SGL_PY_EXPORT(device_reflection)
         .def("is_sub_type", &ProgramLayout::is_sub_type, "sub_type"_a, "super_type"_a, D(ProgramLayout, is_sub_type))
         .def_prop_ro("hashed_strings", &ProgramLayout::hashed_strings, D(ProgramLayout, hashed_strings))
         .def("__repr__", &ProgramLayout::to_string);
-
-    bind_list_type<ProgramLayoutParameterList>(m, "ProgramLayoutParameterList", D(ProgramLayoutParameterList));
-    bind_list_type<ProgramLayoutEntryPointList>(m, "ProgramLayoutEntryPointList", D(ProgramLayoutEntryPointList));
 
     nb::class_<ReflectionCursor>(m, "ReflectionCursor", D(ReflectionCursor))
         .def(nb::init<const ShaderProgram*>(), "shader_program"_a)

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -23,253 +23,9 @@
 #endif
 
 
-static const char *__doc_DXGI_FORMAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_420_OPAQUE = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_A8P8 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_A8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_AI44 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_AYUV = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B4G4R4A4_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B5G5R5A1_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B5G6R5_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B8G8R8A8_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B8G8R8A8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B8G8R8A8_UNORM_SRGB = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B8G8R8X8_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B8G8R8X8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_B8G8R8X8_UNORM_SRGB = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC1_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC1_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC1_UNORM_SRGB = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC2_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC2_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC2_UNORM_SRGB = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC3_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC3_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC3_UNORM_SRGB = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC4_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC4_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC4_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC5_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC5_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC5_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC6H_SF16 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC6H_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC6H_UF16 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC7_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC7_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_BC7_UNORM_SRGB = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_D16_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_D24_UNORM_S8_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_D32_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_D32_FLOAT_S8X24_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_FORCE_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_G8R8_G8B8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_IA44 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_NV11 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_NV12 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_P010 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_P016 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_P208 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_P8 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R10G10B10A2_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R10G10B10A2_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R10G10B10A2_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R11G11B10_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16B16A16_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16B16A16_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16B16A16_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16B16A16_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16B16A16_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16B16A16_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16G16_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R16_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R1_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R24G8_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R24_UNORM_X8_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32A32_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32A32_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32A32_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32A32_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32B32_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G32_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32G8X24_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32_FLOAT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R32_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8B8A8_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8B8A8_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8B8A8_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8B8A8_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8B8A8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8B8A8_UNORM_SRGB = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8_B8G8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8G8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8_SINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8_SNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8_TYPELESS = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R8_UNORM = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_R9G9B9E5_SHAREDEXP = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_UNKNOWN = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_V208 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_V408 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_X24_TYPELESS_G8_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_X32_TYPELESS_G8X24_UINT = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_Y210 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_Y216 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_Y410 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_Y416 = R"doc()doc";
-
-static const char *__doc_DXGI_FORMAT_DXGI_FORMAT_YUY2 = R"doc()doc";
-
 static const char *__doc_GLFWwindow = R"doc()doc";
+
+static const char *__doc_HWND = R"doc()doc";
 
 static const char *__doc_ImFont = R"doc()doc";
 
@@ -1650,6 +1406,14 @@ static const char *__doc_sgl_CommandEncoder_generate_mips = R"doc()doc";
 
 static const char *__doc_sgl_CommandEncoder_get_root_object = R"doc()doc";
 
+static const char *__doc_sgl_CommandEncoder_global_barrier =
+R"doc(Insert a global barrier that ensures all previous writes are visible
+to subsequent reads. Note: This is not necessary for typical bindings,
+as state management is automatic, however global barriers are useful
+for cross-api synchronization (eg 2 slangpy devices constructed from
+the same native handle), or as brute force tools for synchronizing
+pointer/bindless operations.)doc";
+
 static const char *__doc_sgl_CommandEncoder_insert_debug_marker =
 R"doc(Insert a debug marker.
 
@@ -2556,6 +2320,10 @@ Currently windows and linux only.)doc";
 
 static const char *__doc_sgl_DeviceDesc_enable_print = R"doc(Enable device side printing (adds performance overhead).)doc";
 
+static const char *__doc_sgl_DeviceDesc_existing_device_handles =
+R"doc(Native device handles for initializing with externally created device.
+Currenlty only used for CUDA interoperability.)doc";
+
 static const char *__doc_sgl_DeviceDesc_shader_cache_path =
 R"doc(Path to the shader cache directory (optional). If a relative path is
 used, the cache is stored in the application data directory.)doc";
@@ -3119,6 +2887,17 @@ Parameter ``signal_fence_values``:
 Parameter ``queue``:
     Command queue to submit to.
 
+Parameter ``cuda_stream``:
+    On none-CUDA backends, when interop is enabled, this is the stream
+    to sync with before/after submission (assuming any resources are
+    shared with CUDA) and use for internal copies. If not specified,
+    sync will happen with the NULL (default) CUDA stream. On CUDA
+    backends, this is the CUDA stream to use for the submission. If
+    not specified, the default stream of the command queue will be
+    used, which for CommandQueueType::graphics is the NULL stream. It
+    is an error to specify a stream for none-CUDA backends that have
+    interop disabled.
+
 Returns:
     Submission ID.)doc";
 
@@ -3564,8 +3343,6 @@ static const char *__doc_sgl_FileSystemWatcher_class_name = R"doc()doc";
 
 static const char *__doc_sgl_FileSystemWatcher_delay = R"doc(Delay period before queued events are output.)doc";
 
-static const char *__doc_sgl_FileSystemWatcher_m_inotify_file_descriptor = R"doc(File descriptor for linux inotify watcher.)doc";
-
 static const char *__doc_sgl_FileSystemWatcher_m_last_event = R"doc(Time last event was recorded.)doc";
 
 static const char *__doc_sgl_FileSystemWatcher_m_next_id = R"doc(Next unique id to be assigned to a given watch.)doc";
@@ -3576,7 +3353,15 @@ static const char *__doc_sgl_FileSystemWatcher_m_output_delay_ms = R"doc(Delay b
 
 static const char *__doc_sgl_FileSystemWatcher_m_queued_events = R"doc(Events reported since last call to watch event callback.)doc";
 
+static const char *__doc_sgl_FileSystemWatcher_m_queued_events_mutex = R"doc(Mutex to protect the queued events.)doc";
+
+static const char *__doc_sgl_FileSystemWatcher_m_stop_thread = R"doc()doc";
+
+static const char *__doc_sgl_FileSystemWatcher_m_thread = R"doc(Thread to poll for file system changes.)doc";
+
 static const char *__doc_sgl_FileSystemWatcher_m_watches = R"doc(Map of id->watch.)doc";
+
+static const char *__doc_sgl_FileSystemWatcher_m_watches_mutex = R"doc(Mutex to protect the watch map.)doc";
 
 static const char *__doc_sgl_FileSystemWatcher_notify_change = R"doc(Internal function called when OS reports an event.)doc";
 
@@ -3591,6 +3376,8 @@ static const char *__doc_sgl_FileSystemWatcher_set_delay = R"doc(Set delay perio
 static const char *__doc_sgl_FileSystemWatcher_set_on_change = R"doc(Set callback for file system events.)doc";
 
 static const char *__doc_sgl_FileSystemWatcher_stop_watch = R"doc(Releases OS monitoring for a given watch.)doc";
+
+static const char *__doc_sgl_FileSystemWatcher_thread_func = R"doc()doc";
 
 static const char *__doc_sgl_FileSystemWatcher_update = R"doc(Update function to poll the watcher + report events.)doc";
 
@@ -4726,6 +4513,8 @@ static const char *__doc_sgl_MemoryMappedFile_m_file = R"doc()doc";
 
 static const char *__doc_sgl_MemoryMappedFile_m_mapped_data = R"doc()doc";
 
+static const char *__doc_sgl_MemoryMappedFile_m_mapped_file = R"doc()doc";
+
 static const char *__doc_sgl_MemoryMappedFile_m_mapped_size = R"doc()doc";
 
 static const char *__doc_sgl_MemoryMappedFile_m_path = R"doc()doc";
@@ -4955,6 +4744,26 @@ static const char *__doc_sgl_NativeHandleTrait_11 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_12 = R"doc()doc";
 
+static const char *__doc_sgl_NativeHandleTrait_13 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_14 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_15 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_16 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_17 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_18 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_19 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_20 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_21 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_22 = R"doc()doc";
+
 static const char *__doc_sgl_NativeHandleTrait_pack = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_pack_2 = R"doc()doc";
@@ -4974,6 +4783,26 @@ static const char *__doc_sgl_NativeHandleTrait_pack_8 = R"doc()doc";
 static const char *__doc_sgl_NativeHandleTrait_pack_9 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_pack_10 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_11 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_12 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_13 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_14 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_15 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_16 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_17 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_18 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_19 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_pack_20 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_unpack = R"doc()doc";
 
@@ -4995,7 +4824,29 @@ static const char *__doc_sgl_NativeHandleTrait_unpack_9 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_unpack_10 = R"doc()doc";
 
+static const char *__doc_sgl_NativeHandleTrait_unpack_11 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_12 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_13 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_14 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_15 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_16 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_17 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_18 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_19 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_20 = R"doc()doc";
+
 static const char *__doc_sgl_NativeHandleType = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleType_CUcontext = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleType_CUdevice = R"doc()doc";
 
@@ -5105,6 +4956,8 @@ static const char *__doc_sgl_NativeHandle_NativeHandle_2 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandle_NativeHandle_3 = R"doc()doc";
 
+static const char *__doc_sgl_NativeHandle_NativeHandle_4 = R"doc()doc";
+
 static const char *__doc_sgl_NativeHandle_as = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandle_is_valid = R"doc()doc";
@@ -5114,6 +4967,8 @@ static const char *__doc_sgl_NativeHandle_m_type = R"doc()doc";
 static const char *__doc_sgl_NativeHandle_m_value = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandle_operator_bool = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandle_to_rhi = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandle_to_string = R"doc()doc";
 
@@ -7795,9 +7650,7 @@ static const char *__doc_sgl_WindowDesc_width = R"doc(Width of the window in pix
 
 static const char *__doc_sgl_WindowHandle = R"doc(Native window handle.)doc";
 
-static const char *__doc_sgl_WindowHandle_xdisplay = R"doc()doc";
-
-static const char *__doc_sgl_WindowHandle_xwindow = R"doc()doc";
+static const char *__doc_sgl_WindowHandle_hwnd = R"doc()doc";
 
 static const char *__doc_sgl_WindowMode = R"doc(Window modes.)doc";
 
@@ -8376,6 +8229,12 @@ static const char *__doc_sgl_flip_bit_11 = R"doc()doc";
 static const char *__doc_sgl_flip_bit_12 = R"doc()doc";
 
 static const char *__doc_sgl_flip_bit_13 = R"doc()doc";
+
+static const char *__doc_sgl_get_cuda_current_context_native_handles =
+R"doc(Gets the device and context handles for the current CUDA context. Use
+to retrieve an existing context (eg from PyTorch) to pass as the
+existing_device_handles from which to create a device in the
+DeviceDesc.)doc";
 
 static const char *__doc_sgl_get_dxgi_format = R"doc(Convert from sgl to DXGI format.)doc";
 

--- a/src/slangpy_ext/slangpy_ext.cpp
+++ b/src/slangpy_ext/slangpy_ext.cpp
@@ -115,8 +115,8 @@ NB_MODULE(slangpy_ext, m_)
     SGL_PY_IMPORT(math_quaternion);
 
     SGL_PY_IMPORT(device_native_handle);
-    SGL_PY_IMPORT(device_types);
     SGL_PY_IMPORT(device_formats);
+    SGL_PY_IMPORT(device_types);
     SGL_PY_IMPORT(device_device_resource);
     SGL_PY_IMPORT(device_resource);
     SGL_PY_IMPORT(device_sampler);
@@ -124,9 +124,9 @@ NB_MODULE(slangpy_ext, m_)
     SGL_PY_IMPORT(device_query);
     SGL_PY_IMPORT(device_input_layout);
     SGL_PY_IMPORT(device_pipeline);
-    SGL_PY_IMPORT(device_raytracing);
     SGL_PY_IMPORT(device_reflection);
     SGL_PY_IMPORT(device_shader);
+    SGL_PY_IMPORT(device_raytracing);
     SGL_PY_IMPORT(device_buffer_cursor);
     SGL_PY_IMPORT(device_shader_object);
     SGL_PY_IMPORT(device_shader_cursor);


### PR DESCRIPTION
Fixes #226

- Update repository name in developer guide
- Tweaks to Basics docs section
- Update firstfunctions samples documentation
- Fix some pydoc wrapper name resolution order issues
- Rename default window name to slangpy
- Document steps to regen py_doc.h, fix type
- Fix cmake rules for py_doc.h update for windows, update C++20 caveat comment
- Update py_doc.h and API Reference