### PR TITLE
Moved debug_printer string registration to include strings in imported modules.

### DIFF
--- a/slangpy/tests/device/test_print.py
+++ b/slangpy/tests/device/test_print.py
@@ -22,6 +22,7 @@ def test_print(device_type: spy.DeviceType):
     # print("result:", result)
     expected = {
         spy.DeviceType.d3d12: """Hello World!
+This is Print from Another Module: 7
 0
 01
 012
@@ -55,6 +56,7 @@ uint4x3: {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}
 float3x3: {{-4.00, -3.00, -1.00}, {+0.00, +1.00, +2.00}, {+3.00, +4.00, +5.00}}
 """,
         spy.DeviceType.vulkan: """Hello World!
+This is Print from Another Module: 7
 0
 01
 012
@@ -89,6 +91,7 @@ float64_tX: {999999995904, 1999999991808} {2999999987712, 3999999983616, 4999999
 float3x3: {{-4.00, -3.00, -1.00}, {+0.00, +1.00, +2.00}, {+3.00, +4.00, +5.00}}
 """,
         spy.DeviceType.metal: """Hello World!
+This is Print from Another Module: 7
 0
 01
 012
@@ -119,6 +122,7 @@ float32_tX: {-4000000, -3000000} {-2000000, -1000000, 0} {1000000, 2000000, 3000
 float3x3: {{-4.00, -3.00, -1.00}, {+0.00, +1.00, +2.00}, {+3.00, +4.00, +5.00}}
 """,
         spy.DeviceType.cuda: """Hello World!
+This is Print from Another Module: 7
 0
 01
 012

--- a/slangpy/tests/device/test_print.slang
+++ b/slangpy/tests/device/test_print.slang
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import sgl.device.print;
+import test_print_module2;
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
@@ -8,6 +9,9 @@ void compute_main(uint3 tid: SV_DispatchThreadID)
 {
     // print supports strings only
     print("Hello World!");
+
+    // Test check if strings from modules linked via `import` are handled correctly.
+    print_from_another_module(7);
 
     // print supports up to 8 arguments
     print("{}", 0);

--- a/slangpy/tests/device/test_print_module2.slang
+++ b/slangpy/tests/device/test_print_module2.slang
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+module test_print_module2;
+import sgl.device.print;
+
+public void print_from_another_module(int arg)
+{
+    print("This is Print from Another Module: {}", arg);
+}

--- a/src/sgl/device/shader.cpp
+++ b/src/sgl/device/shader.cpp
@@ -805,11 +805,6 @@ void SlangModule::load(SlangSessionBuild& build_data) const
     report_diagnostics(diagnostics);
     log_debug("Loading slang module \"{}\" took {}", desc.module_name, string::format_duration(timer.elapsed_s()));
 
-    // Register with debug printer.
-    if (m_session->device()->debug_printer()) {
-        ref<const ProgramLayout> layout = ProgramLayout::from_slang(ref(this), slang_module->getLayout());
-        m_session->device()->debug_printer()->add_hashed_strings(layout->hashed_strings_map());
-    }
 
     auto data = make_ref<SlangModuleData>();
 
@@ -1219,6 +1214,11 @@ void ShaderProgram::store_built_data(SlangSessionBuild& build_data)
     // Notify all registered pipelines that this program has rebuilt.
     for (auto pipeline : m_registered_pipelines)
         pipeline->notify_program_reloaded();
+
+    // Add all hashed strings from this program to debug printer.
+    if (m_device->debug_printer()) {
+        m_device->debug_printer()->add_hashed_strings(layout()->hashed_strings_map());
+    }
 }
 
 void ShaderProgram::_register_pipeline(Pipeline* pipeline)


### PR DESCRIPTION
Moved the `debug_printer` string registration to `ShaderProgram::store_built_data`. In the previous location, it obtained only strings from modules directly loaded using `sgl`, not from modules that were imported using the Slang's `import` keyword.

Added a `test_print_module2.slang` so `test_print.slang` has a module it can `import` and we test that the strings are loaded correctly from it as well.