### PR TITLE
Enable merge-queue; add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shader-slang/dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths-ignore:
@@ -21,7 +22,9 @@ on:
       - .github/workflows/wheels.yml
       - .github/workflows/ci-gcp.yml
       - .github/workflows/ci-latest-slang.yml
-  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
This is needed to match slang commit workflow for slang-rhi.

Add a CODEOWNERS to enforce that code owners must approve changes before merging
Add merge_queue settings to CI

Closes: #365 