### PR TITLE
Switch slangpy to Slang 2025.13.1

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -58,7 +58,7 @@ set(SGL_LOCAL_SLANG OFF CACHE BOOL "Use a local build of slang instead of downlo
 set(SGL_LOCAL_SLANG_DIR "${CMAKE_SOURCE_DIR}/../slang" CACHE PATH "Path to a local slang build")
 set(SGL_LOCAL_SLANG_BUILD_DIR "build/Debug" CACHE STRING "Build directory of the local slang build")
 
-set(SLANG_VERSION "2025.12")
+set(SLANG_VERSION "2025.13.1")
 set(SLANG_URL_BASE "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}")
 
 if(SGL_WINDOWS)

--- a/slangpy/slang/atomics.slang
+++ b/slangpy/slang/atomics.slang
@@ -68,6 +68,9 @@ public extension half : IAtomicAddable
     }
 }
 
+#pragma warning(push)
+#pragma warning(disable: 30856)
+
 // Add atomic support for per element operations on arrays or vectors of atomics.
 public extension<S : IAtomicAddable, T : ISizedArray<S, D>, let D : int> T : IAtomicAddable
 {
@@ -93,6 +96,8 @@ public extension<S : IAtomicAddable, T : ISizedArray<S, D>, let D : int> T : IAt
         }
     }
 }
+
+#pragma warning(pop)
 
 // Extension of the storage traits object in slangpy/slang/core.slang that defines how to
 // store a buffer of atomics, and where appropriate uses IAtomicAddable to define the atomic add operation.

--- a/slangpy/slang/atomics.slang
+++ b/slangpy/slang/atomics.slang
@@ -109,13 +109,6 @@ public extension<T: IAtomicAddable> StorageTraits<T>
 #endif
 }
 
-void test()
-{
-    float3* floats;
-
-    float3::atomicAdd(floats, 0, 1.0f);
-}
-
 // 2xfloat16 -> uint tricks
 // This is lifted from Utils.Neural.TIN.TinCommon, where it was important for performance
 // in half precision MLP training.

--- a/slangpy/slang/callshape.slang
+++ b/slangpy/slang/callshape.slang
@@ -2,6 +2,11 @@
 
 implementing slangpy;
 
+#pragma warning(push)
+// disable warning about the `public extern static const int[call_data_len]` being
+// a WIP feature
+#pragma warning(disable: 31000)
+
 // Those are link-time constants, this constant can be generated during run-time
 public extern static const int call_data_len;
 public extern static const int call_group_size;
@@ -11,6 +16,8 @@ public extern static const int[call_data_len] call_group_shape_vector;
 static int[call_data_len] call_id;
 static int[call_data_len] call_group_id;
 static int[call_data_len] call_group_thread_id;
+
+#pragma warning(pop)
 
 // The reason we design the struct this way is because user will have no idea
 // about the value of the `call_data_len` when they are writing the code. Therefore,

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -486,10 +486,11 @@ public extension<let N:int> RWNDBuffer<uint64_t,N>
     public void store<T>(ContextND<N> context, in Ptr<T> value) { set(context.call_id, uint64_t(value)); };
 }
 
+#pragma warning(push)
+#pragma warning(disable: 30856)
 
 namespace impl
 {
-
     // Utility interface to check if a python type is safe to replace by the target
     // slang type. This works around mismatches between the type systems: Python e.g.
     // only knows float or int, but slang has a much wider array of scalar types;
@@ -533,5 +534,6 @@ namespace impl
     // We attempt to specialize allowedConversionWitness with types [A, B]
     // If it succeeds, the interface requirements are satisfied.
     struct AllowedConversionWitness<From, To : IConvertibleFrom<From>> {}
-
 }
+
+#pragma warning(pop)

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -42,6 +42,9 @@ namespace impl
     }
 }
 
+#pragma warning(push)
+#pragma warning(disable: 30856)
+
 public extension<T : IDifferentiable, let D : int, TensorType : ITensor<T, D>> TensorType
 {
     __generic<each Is : IInteger>
@@ -225,6 +228,8 @@ public extension<T : IDifferentiable, let D : int, TensorType : IRWTensor<T, D>>
     }
 #endif
 }
+
+#pragma warning(pop)
 
 public struct Tensor<T : IDifferentiable, let D : int> : ITensor<T, D>
 {


### PR DESCRIPTION
Moved to Slang 2025.13.1, to fix Slang bug with inheriting from IDifferentiable.

- Added pragma warning disable to newly identified places (consulted with the Slang team that the code itself was correct).
- The pragma does not fully work due to https://github.com/shader-slang/slang/pull/7942 so the warnings can still appear in the output for the time being.