### PR TITLE
Add synchronization before copy in copy_from_torch() tests

### DIFF
--- a/slangpy/tests/slangpy_tests/test_buffer_views.py
+++ b/slangpy/tests/slangpy_tests/test_buffer_views.py
@@ -205,6 +205,8 @@ def test_full_torch_copy(device_type: DeviceType, buffer_type: Union[Type[Tensor
     torch_ref = torch.randn(shape, dtype=torch.float32).cuda()
     usage = BufferUsage.shader_resource | BufferUsage.unordered_access | BufferUsage.shared
     buffer = buffer_type.zeros(device, dtype="float", shape=shape, usage=usage)
+    device.sync_to_cuda()
+    device.sync_to_device()
 
     buffer.copy_from_torch(torch_ref)
     device.sync_to_cuda()
@@ -256,6 +258,8 @@ def test_partial_torch_copy(
     torch_ref = torch.randn(shape, dtype=torch.float32).cuda()
     usage = BufferUsage.shader_resource | BufferUsage.unordered_access | BufferUsage.shared
     buffer = buffer_type.zeros(device, dtype="float", shape=shape, usage=usage)
+    device.sync_to_cuda()
+    device.sync_to_device()
 
     for i in range(shape[0]):
         buffer[i].copy_from_torch(torch_ref[i])
@@ -310,6 +314,8 @@ def test_torch_copy_errors(
 
     usage = BufferUsage.shader_resource | BufferUsage.unordered_access | BufferUsage.shared
     buffer = buffer_type.zeros(device, dtype="float", shape=shape, usage=usage)
+    device.sync_to_cuda()
+    device.sync_to_device()
 
     with pytest.raises(Exception, match=r"Tensor is larger"):
         tensor = torch.zeros((shape[0], shape[1] + 1), dtype=torch.float32)


### PR DESCRIPTION
Related to #113 

The tests for `copy_from_torch()` that I added in #363 are causing intermittent failures the Windows CI tests.
The failure appears to be specifically from the first partial copy in `test_partial_torch_copy()` in `test_buffer_views.py`, and only in Vulkan when copying to an `NDBuffer` (and not a `Tensor`), where the results are zeros instead of the copied data.

I suspect this to be the result of a race condition, so this change adds `sync_to_cuda()` and `sync_to_device()` calls before the `copy_from_torch()` calls. I think that will fix the failures because in #363 I was seeing multiple of the partial copies with zeroes until I added the sync calls in between the `copy_from_torch()` calls, and I suspect that something (perhaps `torch.randn(...).cuda()`?) is not finished before the first copy but is finished before the second copy due to those sync calls from #363.

I will test the Windows CI checks repeatedly to verify that this eliminates the intermittent failures.