### PR TITLE
Fix exception for multi-dimensional indexing on buffers

### DIFF
--- a/slangpy/tests/slangpy_tests/test_buffer_views.py
+++ b/slangpy/tests/slangpy_tests/test_buffer_views.py
@@ -20,7 +20,7 @@ struct RGB {
 
 TEST_INDICES = [
     # Partial indexing
-    (3,),
+    3,
     (3, 4, 2, 1),
     # Ellipses
     (3, 4, ...),
@@ -56,7 +56,7 @@ def test_indexing(
     buffer = buffer_type.zeros(device, dtype="float", shape=shape)
     buffer.copy_from_numpy(numpy_ref)
 
-    indexed_buffer = buffer.__getitem__(*index)
+    indexed_buffer = buffer.__getitem__(index)
     indexed_ndarray = numpy_ref.__getitem__(index)
 
     if isinstance(indexed_ndarray, np.number):

--- a/src/slangpy_ext/utils/slangpybuffer.cpp
+++ b/src/slangpy_ext/utils/slangpybuffer.cpp
@@ -35,10 +35,10 @@ ref<NativeNDBuffer> NativeNDBuffer::broadcast_to(const Shape& shape) const
     result->broadcast_to_inplace(shape);
     return result;
 }
-ref<NativeNDBuffer> NativeNDBuffer::index(nb::args args) const
+ref<NativeNDBuffer> NativeNDBuffer::index(nb::object index_arg) const
 {
     auto result = make_ref<NativeNDBuffer>(device(), desc(), storage());
-    result->index_inplace(args);
+    result->index_inplace(index_arg);
     return result;
 }
 

--- a/src/slangpy_ext/utils/slangpybuffer.h
+++ b/src/slangpy_ext/utils/slangpybuffer.h
@@ -32,7 +32,7 @@ public:
 
     ref<NativeNDBuffer> view(Shape shape, Shape strides = Shape(), int offset = 0) const;
     ref<NativeNDBuffer> broadcast_to(const Shape& shape) const;
-    ref<NativeNDBuffer> index(nb::args args) const;
+    ref<NativeNDBuffer> index(nb::object index_arg) const;
 
 private:
     NativeNDBufferDesc m_desc;

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -181,19 +181,30 @@ void StridedBufferView::broadcast_to_inplace(const Shape& new_shape)
     view_inplace(new_shape, Shape(new_strides));
 }
 
-void StridedBufferView::index_inplace(nb::args args)
+void StridedBufferView::index_inplace(nb::object index_arg)
 {
     // This implements python indexing (i.e. __getitem__)
     // Like numpy or torch, this supports a number of different ways of indexing:
     // - Indexing with a positive index (e.g. buffer[3, 2])
     // - Indexing with a negative index, for 'from the end' indexing (e.g. buffer[-1])
-    // - Indexing with a slize (e.g. buffer[3:], buffer[:-3], buffer[::2])
+    // - Indexing with a slice (e.g. buffer[3:], buffer[:-3], buffer[::2])
     // - Inserting singleton dimensions (e.g. buffer[3, None, 2])
     // - Skipping dimensions with ellipsis (e.g. buffer[..., 3])
     //
     // A buffer may be partially indexed. E.g. for a 2D buffer of shape (64, 32),
     // doing buffer[5] is valid and will return a 1D buffer of shape (32, ) that is
     // the 1D slice of the full 2D buffer at index 5
+
+    // We might receive a single argument (e.g. tensor[4]) or a tuple (e.g. tensor[3, 4])
+    // in case of multiple indices. Unpack into a consistent argument vector.
+    std::vector<nb::handle> args;
+    if (nb::isinstance<nb::tuple>(index_arg)) {
+        nb::tuple t = nb::cast<nb::tuple>(index_arg);
+        args.insert(args.end(), t.begin(), t.end());
+    } else {
+        args.push_back(index_arg);
+    }
+
 
     // Step 1: Figure out the number of 'real' indices, i.e. indices that
     // access an existing dimension, as opposed to inserting/skipping them

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -283,7 +283,12 @@ void StridedBufferView::index_inplace(nb::object index_arg)
             shape.push_back(1);
             strides.push_back(0);
         } else {
-            SGL_THROW("Illegal argument at dimension {}", i);
+            auto type_name = nb::str(arg.type());
+            SGL_THROW(
+                "Illegal argument at dimension {}: Allowed are int, slice, ..., or None; found {} instead",
+                i,
+                type_name.c_str()
+            );
         }
     }
 

--- a/src/slangpy_ext/utils/slangpystridedbufferview.h
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.h
@@ -75,7 +75,7 @@ protected:
     // with the same buffer/view, call the inplace method on the copy, and return it
     void view_inplace(Shape shape, Shape strides = Shape(), int offset = 0);
     void broadcast_to_inplace(const Shape& shape);
-    void index_inplace(nb::args args);
+    void index_inplace(nb::object index_arg);
 
 private:
     ref<Buffer> m_storage;

--- a/src/slangpy_ext/utils/slangpytensor.cpp
+++ b/src/slangpy_ext/utils/slangpytensor.cpp
@@ -41,10 +41,10 @@ ref<NativeTensor> NativeTensor::broadcast_to(const Shape& shape) const
     result->broadcast_to_inplace(shape);
     return result;
 }
-ref<NativeTensor> NativeTensor::index(nb::args args) const
+ref<NativeTensor> NativeTensor::index(nb::object index_arg) const
 {
     auto result = make_ref<NativeTensor>(desc(), storage(), m_grad_in, m_grad_out);
-    result->index_inplace(args);
+    result->index_inplace(index_arg);
     return result;
 }
 

--- a/src/slangpy_ext/utils/slangpytensor.h
+++ b/src/slangpy_ext/utils/slangpytensor.h
@@ -39,7 +39,7 @@ public:
 
     ref<NativeTensor> view(Shape shape, Shape strides = Shape(), int offset = 0) const;
     ref<NativeTensor> broadcast_to(const Shape& shape) const;
-    ref<NativeTensor> index(nb::args args) const;
+    ref<NativeTensor> index(nb::object index_arg) const;
 
     const ref<NativeTensor>& grad_in() const { return m_grad_in; }
     void set_grad_in(const ref<NativeTensor>& grad_in) { m_grad_in = grad_in; }


### PR DESCRIPTION
Buffer indexing fails when indexing with multiple indices (e.g. `buffer[3, 4]`), because `stridedbufferview` expects these to be passed as `*args`. However, python groups them into a tuple instead, and nanobind passes it through as `nb::args(nb::tuple(3, 4))` causing an exception during indexing.

This adds a fix, modifies the tests to catch this and adds a better error message.
