### PR TITLE
Re-enable skipped tests

### DIFF
--- a/slangpy/tests/slangpy_tests/test_torchbuffers.py
+++ b/slangpy/tests/slangpy_tests/test_torchbuffers.py
@@ -165,11 +165,6 @@ void copy_buffers(int call_id, float* in_buffer, float* out_buffer) {
 # Pytest for our most common default cuda-interop case, in which we've configured pytorch
 # and slangpy to share the same context and stream.
 def test_shared_context_and_stream():
-    if sys.platform == "win32":
-        pytest.skip(
-            "Test fails sporadically with 'RuntimeError: cannot write to file: bad file descriptor'"
-        )
-
     assert (
         run_tensor_race_condition_tests(share_context=True, custom_stream=False, share_stream=True)
         == False
@@ -180,11 +175,6 @@ def test_shared_context_and_stream():
 # of synchronization in the default streams of separate contexts. For now this has shown not
 # to cause race conditions, so testing for that behaviour.
 def test_non_shared_context():
-    if sys.platform == "win32":
-        pytest.skip(
-            "Test fails sporadically with 'RuntimeError: cannot write to file: bad file descriptor'"
-        )
-
     assert run_tensor_race_condition_tests(share_context=False) == False
 
 
@@ -199,11 +189,6 @@ def test_custom_stream_no_share():
 
 # Pytest that removes the race condition by sharing the custom stream
 def test_custom_stream_share():
-    if sys.platform == "win32":
-        pytest.skip(
-            "Test fails sporadically with 'RuntimeError: cannot write to file: bad file descriptor'"
-        )
-
     assert (
         run_tensor_race_condition_tests(share_context=True, custom_stream=True, share_stream=True)
         == False


### PR DESCRIPTION
The "bad file descriptor" issues has been fixed in #394

Fixes #376