### PR TITLE
Improve report live objects

### DIFF
--- a/src/sgl/core/object.cpp
+++ b/src/sgl/core/object.cpp
@@ -13,6 +13,7 @@ namespace sgl {
 
 static void (*object_inc_ref_py)(PyObject*) noexcept = nullptr;
 static void (*object_dec_ref_py)(PyObject*) noexcept = nullptr;
+static Py_ssize_t_ (*object_ref_cnt_py)(PyObject*) noexcept = nullptr;
 
 #if SGL_ENABLE_OBJECT_TRACKING
 static std::mutex s_tracked_objects_mutex;
@@ -180,10 +181,15 @@ void Object::set_enable_ref_tracking(bool enable)
 
 #endif // SGL_ENABLE_REF_TRACKING
 
-void object_init_py(void (*object_inc_ref_py_)(PyObject*) noexcept, void (*object_dec_ref_py_)(PyObject*) noexcept)
+void object_init_py(
+    void (*object_inc_ref_py_)(PyObject*) noexcept,
+    void (*object_dec_ref_py_)(PyObject*) noexcept,
+    Py_ssize_t_ (*object_ref_cnt_py_)(PyObject*) noexcept
+)
 {
     object_inc_ref_py = object_inc_ref_py_;
     object_dec_ref_py = object_dec_ref_py_;
+    object_ref_cnt_py = object_ref_cnt_py_;
 }
 
 } // namespace sgl

--- a/src/sgl/core/object.cpp
+++ b/src/sgl/core/object.cpp
@@ -117,7 +117,7 @@ PyObject* Object::self_py() const noexcept
 
 #if SGL_ENABLE_OBJECT_TRACKING
 
-void Object::report_alive_objects()
+void Object::report_live_objects()
 {
     std::lock_guard<std::mutex> lock(s_tracked_objects_mutex);
     fmt::println("Alive objects:");

--- a/src/sgl/core/object.cpp
+++ b/src/sgl/core/object.cpp
@@ -125,9 +125,8 @@ void Object::report_live_objects()
         for (const Object* object : s_tracked_objects) {
             uint64_t ref_count = object->ref_count();
             PyObject* self_py = object->self_py();
-            if (self_py) {
+            if (self_py)
                 ref_count = object_ref_cnt_py(self_py);
-            }
             fmt::println(
                 "Live object: {} self_py={} ref_count={} class_name=\"{}\"",
                 fmt::ptr(object),

--- a/src/sgl/core/object.h
+++ b/src/sgl/core/object.h
@@ -138,8 +138,8 @@ public:
     virtual std::string to_string() const;
 
 #if SGL_ENABLE_OBJECT_TRACKING
-    /// Report all objects that are currently alive.
-    static void report_alive_objects();
+    /// Reports current set of live objects.
+    static void report_live_objects();
 
     /// Report references of this object.
     void report_refs() const;

--- a/src/sgl/core/object.h
+++ b/src/sgl/core/object.h
@@ -14,6 +14,8 @@
 extern "C" {
 struct _object;
 typedef _object PyObject;
+typedef int64_t Py_ssize_t_;
+static_assert(sizeof(Py_ssize_t_) == sizeof(size_t));
 };
 
 /// Enable/disable object lifetime tracking.
@@ -186,11 +188,14 @@ public:                                                                         
  * Python reference counting functionality will simply not be used.
  *
  * Python binding code must invoke `object_init_py` and provide functions that
- * can be used to increase/decrease the Python reference count of an instance
- * (i.e., `Py_INCREF` / `Py_DECREF`).
+ * can be used to increase/decrease/get the Python reference count of an instance
+ * (i.e., `Py_INCREF` / `Py_DECREF` / `Py_REFCNT`).
  */
-SGL_API void
-object_init_py(void (*object_inc_ref_py)(PyObject*) noexcept, void (*object_dec_ref_py)(PyObject*) noexcept);
+SGL_API void object_init_py(
+    void (*object_inc_ref_py)(PyObject*) noexcept,
+    void (*object_dec_ref_py)(PyObject*) noexcept,
+    Py_ssize_t_ (*object_ref_cnt_py)(PyObject*) noexcept
+);
 
 
 #if SGL_ENABLE_REF_TRACKING

--- a/src/sgl/sgl.cpp
+++ b/src/sgl/sgl.cpp
@@ -10,6 +10,8 @@
 
 #include "git_version.h"
 
+#include <slang-rhi.h>
+
 #include <atomic>
 
 static inline const char* git_version()
@@ -48,6 +50,11 @@ void static_shutdown()
     platform::static_shutdown();
     Logger::static_shutdown();
     thread::static_shutdown();
+
+#if SGL_ENABLE_OBJECT_TRACKING
+    Object::report_live_objects();
+    rhi::getRHI()->reportLiveObjects();
+#endif
 }
 
 } // namespace sgl

--- a/src/slangpy_ext/core/object.cpp
+++ b/src/slangpy_ext/core/object.cpp
@@ -17,6 +17,11 @@ SGL_PY_EXPORT(core_object)
         {
             nb::gil_scoped_acquire guard;
             Py_DECREF(o);
+        },
+        [](PyObject* o) noexcept -> Py_ssize_t_
+        {
+            nb::gil_scoped_acquire guard;
+            return Py_REFCNT(o);
         }
     );
 

--- a/src/slangpy_ext/core/object.cpp
+++ b/src/slangpy_ext/core/object.cpp
@@ -32,7 +32,7 @@ SGL_PY_EXPORT(core_object)
         "Base class for all reference counted objects."
     )
 #if SGL_ENABLE_OBJECT_TRACKING
-        .def_static("report_alive_objects", &Object::report_alive_objects)
+        .def_static("report_live_objects", &Object::report_live_objects)
 #endif
         .def("__repr__", &Object::to_string);
 }

--- a/tests/sgl/sgl_tests.cpp
+++ b/tests/sgl/sgl_tests.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
 
 #if SGL_ENABLE_OBJECT_TRACKING
     sgl::Logger::get().add_console_output();
-    sgl::Object::report_alive_objects();
+    sgl::Object::report_live_objects();
 #endif
 
     sgl::static_shutdown();

--- a/tests/sgl/sgl_tests.cpp
+++ b/tests/sgl/sgl_tests.cpp
@@ -59,11 +59,6 @@ int main(int argc, char** argv)
 
     sgl::Device::close_all_devices();
 
-#if SGL_ENABLE_OBJECT_TRACKING
-    sgl::Logger::get().add_console_output();
-    sgl::Object::report_live_objects();
-#endif
-
     sgl::static_shutdown();
 
     return result;


### PR DESCRIPTION
- Rename `Object::report_alive_objects` to `Object::report_live_objects` to match naming of slang-rhi / D3D12
- Reporting reference count (either internal or from the Python object)
- Automatically report live objects on shutdown if enabled