### PR TITLE
Force release all slang-rhi resources during shutdown

### DIFF
--- a/src/sgl/device/command.h
+++ b/src/sgl/device/command.h
@@ -143,6 +143,8 @@ class SGL_API CommandEncoder : public DeviceChild {
 public:
     CommandEncoder(ref<Device> device, Slang::ComPtr<rhi::ICommandEncoder> rhi_command_encoder);
 
+    virtual void _release_rhi_resources() override { m_rhi_command_encoder.setNull(); }
+
     ref<RenderPassEncoder> begin_render_pass(const RenderPassDesc& desc);
     ref<ComputePassEncoder> begin_compute_pass();
     ref<RayTracingPassEncoder> begin_ray_tracing_pass();
@@ -420,6 +422,8 @@ class SGL_API CommandBuffer : public DeviceChild {
 public:
     CommandBuffer(ref<Device> device, Slang::ComPtr<rhi::ICommandBuffer> rhi_command_buffer);
     ~CommandBuffer();
+
+    virtual void _release_rhi_resources() override { m_rhi_command_buffer.setNull(); }
 
     rhi::ICommandBuffer* rhi_command_buffer() const { return m_rhi_command_buffer; }
 

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -343,6 +343,15 @@ Device::~Device()
     m_rhi_device.setNull();
 }
 
+void Device::_release_rhi_resources()
+{
+    for (DeviceChild* resource : m_device_children)
+        resource->_release_rhi_resources();
+    m_device_children.clear();
+    m_rhi_graphics_queue.setNull();
+    m_rhi_device.setNull();
+}
+
 ShaderCacheStats Device::shader_cache_stats() const
 {
     // TODO: revisit when we add a shader cache.
@@ -413,6 +422,17 @@ void Device::close_all_devices()
     }
     for (Device* device : devices)
         device->close();
+}
+
+void Device::_release_all_rhi_resources()
+{
+    std::vector<Device*> devices;
+    {
+        std::lock_guard lock(s_devices_mutex);
+        devices = s_devices;
+    }
+    for (Device* device : devices)
+        device->_release_rhi_resources();
 }
 
 ref<Surface> Device::create_surface(Window* window)
@@ -1053,6 +1073,18 @@ Blitter* Device::_blitter()
     if (!m_blitter)
         m_blitter = ref(new Blitter(this));
     return m_blitter;
+}
+
+void Device::_register_device_child(DeviceChild* device_child)
+{
+    std::lock_guard lock(m_device_children_mutex);
+    m_device_children.insert(device_child);
+}
+
+void Device::_unregister_device_child(DeviceChild* device_child)
+{
+    std::lock_guard lock(m_device_children_mutex);
+    m_device_children.erase(device_child);
 }
 
 std::array<NativeHandle, 3> get_cuda_current_context_native_handles()

--- a/src/sgl/device/device_child.cpp
+++ b/src/sgl/device/device_child.cpp
@@ -1,8 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "device_child.h"
+#include "device.h"
 
 namespace sgl {
+
+DeviceChild::DeviceChild(ref<Device> device)
+    : m_device(std::move(device))
+{
+    m_device->_register_device_child(this);
+}
+
+DeviceChild::~DeviceChild()
+{
+    m_device->_unregister_device_child(this);
+}
 
 DeviceChild::MemoryUsage DeviceChild::memory_usage() const
 {

--- a/src/sgl/device/device_child.h
+++ b/src/sgl/device/device_child.h
@@ -11,14 +11,15 @@ namespace sgl {
 class SGL_API DeviceChild : public Object {
     SGL_OBJECT(DeviceChild)
 public:
-    DeviceChild(ref<Device> device)
-        : m_device(std::move(device))
-    {
-    }
-
-    virtual ~DeviceChild() = default;
+    DeviceChild(ref<Device> device);
+    virtual ~DeviceChild();
 
     Device* device() const { return m_device; }
+
+    /// Release all underlying slang-rhi resources.
+    /// This is used as a workaround during shutdown, to ensure all resources are released
+    /// when slangpy fails to clean up properly due to reference cycles introduced in Python.
+    virtual void _release_rhi_resources() = 0;
 
     struct MemoryUsage {
         /// The amount of memory in bytes used on the device.

--- a/src/sgl/device/fence.h
+++ b/src/sgl/device/fence.h
@@ -32,6 +32,8 @@ public:
     /// Do not use directly, instead use \c Device::create_fence.
     Fence(ref<Device> device, FenceDesc desc);
 
+    virtual void _release_rhi_resources() override { m_rhi_fence.setNull(); }
+
     const FenceDesc& desc() const { return m_desc; }
 
     /**

--- a/src/sgl/device/input_layout.h
+++ b/src/sgl/device/input_layout.h
@@ -60,6 +60,8 @@ class SGL_API InputLayout : public DeviceChild {
 public:
     InputLayout(ref<Device> device, InputLayoutDesc desc);
 
+    virtual void _release_rhi_resources() override { m_rhi_input_layout.setNull(); }
+
     const InputLayoutDesc& desc() const { return m_desc; }
 
     rhi::IInputLayout* rhi_input_layout() const { return m_rhi_input_layout.get(); }

--- a/src/sgl/device/kernel.h
+++ b/src/sgl/device/kernel.h
@@ -21,6 +21,8 @@ public:
 
     virtual ~Kernel() = default;
 
+    virtual void _release_rhi_resources() override { }
+
     ShaderProgram* program() const { return m_program; }
     ReflectionCursor reflection() const { return ReflectionCursor(program()); }
 

--- a/src/sgl/device/pipeline.h
+++ b/src/sgl/device/pipeline.h
@@ -51,6 +51,8 @@ class SGL_API ComputePipeline : public Pipeline {
 public:
     ComputePipeline(ref<Device> device, ComputePipelineDesc desc);
 
+    virtual void _release_rhi_resources() override { m_rhi_pipeline.setNull(); }
+
     const ComputePipelineDesc& desc() const { return m_desc; }
 
     /// Thread group size.
@@ -88,6 +90,8 @@ struct RenderPipelineDesc {
 class SGL_API RenderPipeline : public Pipeline {
 public:
     RenderPipeline(ref<Device> device, RenderPipelineDesc desc);
+
+    virtual void _release_rhi_resources() override { m_rhi_pipeline.setNull(); }
 
     const RenderPipelineDesc& desc() const { return m_desc; }
 
@@ -132,6 +136,8 @@ struct RayTracingPipelineDesc {
 class SGL_API RayTracingPipeline : public Pipeline {
 public:
     RayTracingPipeline(ref<Device> device, RayTracingPipelineDesc desc);
+
+    virtual void _release_rhi_resources() override { m_rhi_pipeline.setNull(); }
 
     const RayTracingPipelineDesc& desc() const { return m_desc; }
 

--- a/src/sgl/device/query.h
+++ b/src/sgl/device/query.h
@@ -28,6 +28,8 @@ class SGL_API QueryPool : public DeviceChild {
 public:
     QueryPool(ref<Device> device, QueryPoolDesc desc);
 
+    virtual void _release_rhi_resources() override { m_rhi_query_pool.setNull(); }
+
     const QueryPoolDesc& desc() const { return m_desc; }
 
     void reset();

--- a/src/sgl/device/raytracing.h
+++ b/src/sgl/device/raytracing.h
@@ -211,6 +211,8 @@ public:
     AccelerationStructure(ref<Device> device, AccelerationStructureDesc desc);
     ~AccelerationStructure();
 
+    virtual void _release_rhi_resources() override { m_rhi_acceleration_structure.setNull(); }
+
     const AccelerationStructureDesc& desc() const { return m_desc; }
 
     AccelerationStructureHandle handle() const;
@@ -229,6 +231,8 @@ class SGL_API AccelerationStructureInstanceList : public DeviceChild {
 public:
     AccelerationStructureInstanceList(ref<Device> device, size_t size = 0);
     ~AccelerationStructureInstanceList();
+
+    virtual void _release_rhi_resources() override { }
 
     size_t size() const { return m_instances.size(); }
 
@@ -266,6 +270,8 @@ class SGL_API ShaderTable : public DeviceChild {
 public:
     ShaderTable(ref<Device> device, ShaderTableDesc desc);
     ~ShaderTable();
+
+    virtual void _release_rhi_resources() override { m_rhi_shader_table.setNull(); }
 
     rhi::IShaderTable* rhi_shader_table() const { return m_rhi_shader_table; }
 

--- a/src/sgl/device/resource.h
+++ b/src/sgl/device/resource.h
@@ -293,6 +293,8 @@ public:
 
     ~Buffer();
 
+    virtual void _release_rhi_resources() override { m_rhi_buffer.setNull(); }
+
     const BufferDesc& desc() const { return m_desc; }
 
     size_t size() const { return m_desc.size; }
@@ -407,6 +409,8 @@ class SGL_API BufferView : public DeviceChild {
     SGL_OBJECT(BufferView)
 public:
     BufferView(ref<Device> device, ref<Buffer> buffer, BufferViewDesc desc);
+
+    virtual void _release_rhi_resources() override { }
 
     Buffer* buffer() const { return m_buffer; }
 
@@ -532,6 +536,8 @@ public:
 
     ~Texture();
 
+    virtual void _release_rhi_resources() override { m_rhi_texture.setNull(); }
+
     const TextureDesc& desc() const { return m_desc; }
 
     TextureType type() const { return m_desc.type; }
@@ -616,6 +622,8 @@ class SGL_API TextureView : public DeviceChild {
     SGL_OBJECT(TextureView)
 public:
     TextureView(ref<Device> device, ref<Texture> texture, TextureViewDesc desc);
+
+    virtual void _release_rhi_resources() override { m_rhi_texture_view.setNull(); }
 
     Texture* texture() const { return m_texture.get(); }
 

--- a/src/sgl/device/sampler.h
+++ b/src/sgl/device/sampler.h
@@ -39,6 +39,8 @@ public:
     Sampler(ref<Device> device, SamplerDesc desc);
     ~Sampler();
 
+    virtual void _release_rhi_resources() override { m_rhi_sampler.setNull(); }
+
     const SamplerDesc& desc() const { return m_desc; }
 
     DescriptorHandle descriptor_handle() const;

--- a/src/sgl/device/shader.h
+++ b/src/sgl/device/shader.h
@@ -486,6 +486,12 @@ public:
     ShaderProgram(ref<Device> device, ref<SlangSession> session, const ShaderProgramDesc& desc);
     ~ShaderProgram();
 
+    virtual void _release_rhi_resources() override
+    {
+        if (m_data)
+            m_data->rhi_shader_program.setNull();
+    }
+
     /// Links program and outputs the resulting ShaderProgramData to current build info.
     void link(SlangSessionBuild& build) const;
 

--- a/src/sgl/sgl.cpp
+++ b/src/sgl/sgl.cpp
@@ -7,6 +7,7 @@
 #include "sgl/core/bitmap.h"
 #include "sgl/core/format.h"
 #include "sgl/core/thread.h"
+#include "sgl/device/device.h"
 
 #include "git_version.h"
 
@@ -45,6 +46,13 @@ void static_shutdown()
         return;
 
     thread::wait_for_tasks();
+
+    // For various reasons, we might end up with reference cycles in Python,
+    // including instances of slangpy objects. This can lead to slang-rhi
+    // resources not being released properly, which in turn can lead to a crash
+    // in Vulkan validation layers during process termination.
+    // We release all slang-rhi resources here to work around this issue.
+    Device::_release_all_rhi_resources();
 
     Bitmap::static_shutdown();
     platform::static_shutdown();


### PR DESCRIPTION
Due to reference cycles in Python, slangpy sometimes ends up not releasing all RHI resources. This is particularly problematic with Vulkan on Linux when validation layers are enabled which can crash the process on termination. We currently skip a few tests due to this issue. While solving the cyclic references is the better solution long-term, this is a workaround to allow us to enable more testing.