### PR TITLE
Fix race condition in hot reload test

### DIFF
--- a/tests/sgl/device/test_hot_reload.cpp
+++ b/tests/sgl/device/test_hot_reload.cpp
@@ -443,12 +443,9 @@ TEST_CASE_GPU("change program and auto detect changes")
     ref<ComputeKernel> kernel = ctx.device->create_compute_kernel({.program = program});
     CHECK(run_and_verify(ctx, kernel, 1));
 
-    // Re-write the shader, and verify it still returns 1, as hasn't reloaded yet.
-    write_shader({.path = path, .set_to = "2"});
-    CHECK(run_and_verify(ctx, kernel, 1));
-
-    // Tell the hot reload system to auto detect changes for 500ms.
+    // Re-write the shader so it returns 2 and wait for it to reload.
     ctx.device->_hot_reload()->_reset_reloaded();
+    write_shader({.path = path, .set_to = "2"});
     for (int i = 0; i < 400 && !ctx.device->_hot_reload()->_has_reloaded(); i++) {
         std::this_thread::sleep_for(std::chrono::milliseconds(25));
         ctx.device->_hot_reload()->update();


### PR DESCRIPTION
Sometimes after re-writing the shader, it did return "2" instead of "1" in the run_and_verify call right after it, so the shader was already reloaded. This is because on command buffer submission, we check for changed shaders and recreate sessions if a shader has changed (enabled because m_auto_detect_changes is true). This is a race condition, because under normal (slow) circumstances, FileSystemWatcher's thread doesn't execute between write_shader and run_and_verify calls, but in rare cases it does and thus triggers the reload.

The race condition can be reproduced by adding a sleep after the write_shader call.

The fix is to not check that the shader hasn't reloaded yet as that would only work with m_auto_detect_changes == false, instead we just check that it is actually reloaded.