### PR TITLE
Add `link` modules of a Module are now linked for layout. Added option to relink.

### DIFF
--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -62,8 +62,8 @@ class Module:
         self.slangpy_device_module = device_module.session.load_module("slangpy")
 
         # Extract linked modules
-        self.link = [x.module if isinstance(x, Module) else x for x in link]
-        self.link.sort(key=id)
+        self.link_set = set([x.module if isinstance(x, Module) else x for x in link])
+        self.link = list(self.link_set)
 
         #: Reflection / layout information for the module.
         # Link the user- and device module together so we can reflect combined types
@@ -205,12 +205,12 @@ class Module:
         """
 
         # Create a new list of modules to link and compare with the current one
-        new_link = [x.module if isinstance(x, Module) else x for x in link]
-        new_link.sort(key=id)
-        if self.link == new_link:
+        new_link_set = set([x.module if isinstance(x, Module) else x for x in link])
+        if self.link_set == new_link_set:
             return
 
-        self.link = new_link
+        self.link_set = new_link_set
+        self.link = list(self.link_set)
 
         # If different, we relink and clear the caches:
         # Relink combined program

--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -199,7 +199,7 @@ class Module:
             return None
         return child.as_func()
 
-    def relink_if_missing(self, link: list[Union["Module", SlangModule]]):
+    def relink_if_different(self, link: list[Union["Module", SlangModule]]):
         """
         Relink the program if the new link is different from the existing link.
         """


### PR DESCRIPTION
The `link` modules are added to the `combined_program` of `Module` on creation, so the contained data types can be found in the Module's layout.

This is needed when the Module depends on other code-generated modules it itself cannot `import`.

Added `relink_if_different` function that relinks the program and clears the caches, if the newly provided link list is different from the one already in the module.

The compilation of a program to get a layout should be replaced by using `createCompositeComponentType` instead of compiling all the way down to a program.