### PR TITLE
prepare-release-0.33.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you use SlangPy in a research project leading to a publication, please cite t
     title = {SlangPy},
     author = {Simon Kallweit and Chris Cummings and Benedikt Bitterli and Sai Bangaru and Yong He},
     note = {https://github.com/shader-slang/slangpy},
-    version = {0.33.0},
+    version = {0.33.1},
     year = 2025
 }
 ```

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,30 @@ Changelog
 
 SlangPy uses a `semantic versioning <http://semver.org>`__ policy for its API.
 
+Version 0.33.1 (August 25, 2025)
+----------------------------
+
+- Include the missing Slang binary file into the package.
+  (PR `#445 <https://github.com/shader-slang/slangpy/pull/445>`__)
+- Introduce benchmark plugin and testing infrastructure with MongoDB integration for automated performance tracking.
+  (PR `#452 <https://github.com/shader-slang/slangpy/pull/452>`__)
+- Add support for bindless storage buffers in GPU abstraction layer.
+  (PR `#421 <https://github.com/shader-slang/slangpy/pull/421>`__).
+- Fix ``copy_from_torch()`` for CUDA devices and resolve PyTorch integration issues.
+  (PR `#391 <https://github.com/shader-slang/slangpy/pull/391>`__).
+- Introduce unified ``slangpy.testing`` module consolidating all testing utilities and pytest plugin system.
+  (PR `#448 <https://github.com/shader-slang/slangpy/pull/448>`__).
+- Force release all slang-rhi resources during shutdown to prevent memory leaks and segfaults on Linux.
+  (PR `#426 <https://github.com/shader-slang/slangpy/pull/426>`__).
+- Rename ``DeviceResource`` to ``DeviceChild`` for consistency with slang-rhi.
+  (PR `#425 <https://github.com/shader-slang/slangpy/pull/425>`__).
+- Enable more tests across platforms: Linux, CUDA, and Metal support improvements.
+  (PR `#429 <https://github.com/shader-slang/slangpy/pull/429>`__).
+- Fix race condition in hot reload test and improve shader change detection.
+  (PR `#433 <https://github.com/shader-slang/slangpy/pull/433>`__).
+- Force unroll small fixed size loops and globally disable warning 30856 for better compilation.
+  (PR `#437 <https://github.com/shader-slang/slangpy/pull/437>`__).
+
 Version 0.33.0 (August 12, 2025)
 ----------------------------
 

--- a/docs/generated/api.rst
+++ b/docs/generated/api.rst
@@ -686,7 +686,7 @@ Constants
 
 .. py:data:: slangpy.SGL_VERSION_PATCH
     :type: int
-    :value: 0
+    :value: 1
 
 
 
@@ -694,7 +694,7 @@ Constants
 
 .. py:data:: slangpy.SGL_VERSION
     :type: str
-    :value: "0.33.0"
+    :value: "0.33.1"
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,7 +69,7 @@ If you use SlangPy in a research project leading to a publication, please cite t
         title = {SlangPy},
         author = {Simon Kallweit and Chris Cummings and Benedikt Bitterli and Sai Bangaru and Yong He},
         note = {https://github.com/shader-slang/slangpy},
-        version = {0.33.0},
+        version = {0.33.1},
         year = 2025
     }
 

--- a/src/sgl/sgl.h
+++ b/src/sgl/sgl.h
@@ -6,7 +6,7 @@
 
 #define SGL_VERSION_MAJOR 0
 #define SGL_VERSION_MINOR 33
-#define SGL_VERSION_PATCH 0
+#define SGL_VERSION_PATCH 1
 
 #define SGL_VERSION                                                                                                    \
     SGL_TO_STRING(SGL_VERSION_MAJOR) "." SGL_TO_STRING(SGL_VERSION_MINOR) "." SGL_TO_STRING(SGL_VERSION_PATCH)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "sgl",
-    "version-string": "0.33.0",
+    "version-string": "0.33.1",
     "dependencies": [
         "libjpeg-turbo",
         "libpng",


### PR DESCRIPTION
This is mainly to include the missing Slang binary files, slang-glsl-module.XXX.