### PR TITLE
Added faster options for write_from_numpy

### DIFF
--- a/src/slangpy_ext/device/buffer_cursor.cpp
+++ b/src/slangpy_ext/device/buffer_cursor.cpp
@@ -121,8 +121,10 @@ SGL_PY_EXPORT(device_buffer_cursor)
         .def("__len__", [](BufferCursor& self) { return self.element_count(); })
         .def(
             "write_from_numpy",
-            [](BufferCursor& self, nb::object nbval) { detail::_writeconv.write_from_numpy(self, nbval); },
-            "data"_a
+            [](BufferCursor& self, nb::object data, bool bitexact_write)
+            { detail::_writeconv.write_from_numpy(self, data, bitexact_write); },
+            "data"_a,
+            "bitexact_write"_a = true
         )
         .def(
             "to_numpy",

--- a/src/slangpy_ext/device/buffer_cursor.cpp
+++ b/src/slangpy_ext/device/buffer_cursor.cpp
@@ -121,10 +121,10 @@ SGL_PY_EXPORT(device_buffer_cursor)
         .def("__len__", [](BufferCursor& self) { return self.element_count(); })
         .def(
             "write_from_numpy",
-            [](BufferCursor& self, nb::object data, bool bitexact_write)
-            { detail::_writeconv.write_from_numpy(self, data, bitexact_write); },
+            [](BufferCursor& self, nb::object data, bool unchecked_copy)
+            { detail::_writeconv.write_from_numpy(self, data, unchecked_copy); },
             "data"_a,
-            "bitexact_write"_a = true
+            "unchecked_copy"_a = true
         )
         .def(
             "to_numpy",

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -266,19 +266,31 @@ private:
 
 #define scalar_case(c_type, scalar_type)                                                                               \
     m_write_scalar[(int)TypeReflection::ScalarType::scalar_type]                                                       \
-        = [](CursorType& self, nb::object nbval) { _write_scalar<c_type>(self, nbval); };
+        = [](CursorType& self, nb::object nbval) { _write_scalar<c_type>(self, nbval); };                              \
+    m_write_scalar_from_numpy[(int)TypeReflection::ScalarType::scalar_type]                                            \
+        = [](CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)                                          \
+    { _write_scalar_from_numpy<c_type>(self, nbarray); };
 
 #define vector_case(c_type, scalar_type)                                                                               \
     m_write_vector[(int)TypeReflection::ScalarType::scalar_type][c_type::dimension]                                    \
-        = [](CursorType& self, nb::object nbval) { _write_vector<c_type>(self, nbval); };
+        = [](CursorType& self, nb::object nbval) { _write_vector<c_type>(self, nbval); };                              \
+    m_write_vector_from_numpy[(int)TypeReflection::ScalarType::scalar_type][c_type::dimension]                         \
+        = [](CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)                                          \
+    { _write_vector_from_numpy<c_type>(self, nbarray); };
 
 #define bool_vector_case(c_type, scalar_type)                                                                          \
     m_write_vector[(int)TypeReflection::ScalarType::scalar_type][c_type::dimension]                                    \
-        = [](CursorType& self, nb::object nbval) { _write_bool_vector<c_type>(self, nbval); };
+        = [](CursorType& self, nb::object nbval) { _write_bool_vector<c_type>(self, nbval); };                         \
+    m_write_vector_from_numpy[(int)TypeReflection::ScalarType::scalar_type][c_type::dimension]                         \
+        = [](CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)                                          \
+    { _write_bool_vector_from_numpy<c_type>(self, nbarray); };
 
 #define matrix_case(c_type, scalar_type)                                                                               \
     m_write_matrix[(int)TypeReflection::ScalarType::scalar_type][c_type::rows][c_type::cols]                           \
-        = [](CursorType& self, nb::object nbval) { _write_matrix<c_type>(self, nbval); };
+        = [](CursorType& self, nb::object nbval) { _write_matrix<c_type>(self, nbval); };                              \
+    m_write_matrix_from_numpy[(int)TypeReflection::ScalarType::scalar_type][c_type::rows][c_type::cols]                \
+        = [](CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)                                          \
+    { _write_matrix_from_numpy<c_type>(self, nbarray); };
 
 /// Table of converters based on slang scalar type and shape.
 template<typename CursorType>
@@ -375,12 +387,17 @@ public:
     /// First dimension of the ndarray is treated as an index into the buffer,
     /// and all the other dimensions are then written to the corresponding
     /// BufferElementCursors.
-    void write_from_numpy(BufferCursor& dst, nb::object nbval)
+    /// If bitexact_write is true, the numpy values are written directly to the backend storage,
+    /// with only the basic check that the data fits into the backend store. Writing less is permitted,
+    /// (e.g., float3 is 16B on Metal, with the last 4 bytes unused).
+    /// Otherwise, the standard _set_type calls are invoked. This is especially dangerous if writing
+    /// into bool type which has different size based on the storage.
+    void write_from_numpy(BufferCursor& dst, nb::object nbval, bool bitexact_write = false)
         requires std::same_as<CursorType, BufferElementCursor>
     {
         m_stack.clear();
         try {
-            write_from_numpy_internal(dst, dst[0], nbval);
+            write_from_numpy_internal(dst, dst[0], nbval, bitexact_write);
         } catch (const std::exception& err) {
             SGL_THROW("{}: {}", build_error(), err.what());
         }
@@ -390,11 +407,17 @@ private:
     std::function<void(CursorType&, nb::object)> m_write_scalar[(int)TypeReflection::ScalarType::COUNT];
     std::function<void(CursorType&, nb::object)> m_write_vector[(int)TypeReflection::ScalarType::COUNT][5];
     std::function<void(CursorType&, nb::object)> m_write_matrix[(int)TypeReflection::ScalarType::COUNT][5][5];
+    std::function<void(CursorType&, const nb::ndarray<nb::numpy, nb::ro>&)>
+        m_write_scalar_from_numpy[(int)TypeReflection::ScalarType::COUNT];
+    std::function<void(CursorType&, const nb::ndarray<nb::numpy, nb::ro>&)>
+        m_write_vector_from_numpy[(int)TypeReflection::ScalarType::COUNT][5];
+    std::function<void(CursorType&, const nb::ndarray<nb::numpy, nb::ro>&)>
+        m_write_matrix_from_numpy[(int)TypeReflection::ScalarType::COUNT][5][5];
     std::vector<const char*> m_stack;
 
     std::string build_error() { return fmt::format("{}", fmt::join(m_stack, ".")); }
 
-    void write_from_numpy_internal(BufferCursor& dst, BufferElementCursor self, nb::object nbval)
+    void write_from_numpy_internal(BufferCursor& dst, BufferElementCursor self, nb::object nbval, bool bitexact_write)
         requires std::same_as<CursorType, BufferElementCursor>
     {
         if (!self.is_valid())
@@ -420,7 +443,7 @@ private:
                     auto child = self[name];
                     if (dict.contains(name)) {
                         m_stack.push_back(name);
-                        write_from_numpy_internal(dst, child, dict[name]);
+                        write_from_numpy_internal(dst, child, dict[name], bitexact_write);
                         m_stack.pop_back();
                     }
                 }
@@ -433,7 +456,13 @@ private:
         }
         }
 
-        auto nbarray = nb::cast<nb::ndarray<nb::numpy>>(nbval);
+        using AcceptedNDArrayType = nb::ndarray<nb::ro, nb::numpy>;
+        SGL_CHECK(
+            nb::isinstance<AcceptedNDArrayType>(nbval),
+            "nbval is not ndarray but {}",
+            nb::str(nbval.type()).c_str()
+        );
+        auto nbarray = nb::cast<AcceptedNDArrayType>(nbval);
         SGL_CHECK(
             nbarray.shape(0) == dst.element_count(),
             "First dimension of ndarray ({}) does not match the size of destination buffer ({})",
@@ -441,37 +470,102 @@ private:
             dst.element_count()
         );
 
-        const size_t itemsize = nbarray.itemsize();
-        auto data = reinterpret_cast<uint8_t*>(nbarray.data());
-        size_t element_byte_size = itemsize;
 
-        for (size_t index = 0; index < dst.element_count(); ++index) {
-            nb::ndarray<nb::numpy> subarray;
-            if (nbarray.ndim() == 1) {
-                subarray = nb::ndarray<nb::numpy>(
-                    data + index * nbarray.stride(0) * itemsize,
-                    {1},
-                    {},
-                    {},
-                    nbarray.dtype(),
-                    nbarray.device_type(),
-                    nbarray.device_id()
-                );
-            } else {
-                subarray = nb::ndarray<nb::numpy>(
-                    data + index * nbarray.stride(0) * itemsize,
-                    nbarray.ndim() - 1,
-                    reinterpret_cast<const size_t*>(nbarray.shape_ptr()) + 1,
-                    {},
-                    nbarray.stride_ptr() + 1,
-                    nbarray.dtype(),
-                    nbarray.device_type(),
-                    nbarray.device_id()
-                );
+        const size_t element_byte_size = nbarray.itemsize();
+        auto data = reinterpret_cast<const uint8_t*>(nbarray.data());
+        const size_t element_byte_stride = nbarray.stride(0) * element_byte_size;
+
+        if (bitexact_write) {
+            const size_t layout_compatible_size = element_byte_size * (nbarray.ndim() == 2 ? nbarray.shape(1) : 1);
+            SGL_CHECK(
+                layout_compatible_size <= self.type_layout()->size(),
+                "Attempting to write element of size {} into a backing storage of size {} (per element).",
+                layout_compatible_size,
+                self.type_layout()->size()
+            );
+            for (size_t index = 0; index < dst.element_count(); ++index, data += element_byte_stride) {
+                self.set_data(data, layout_compatible_size);
+                self._set_offset(self.offset() + dst.element_type_layout()->stride());
             }
+            return;
+        }
 
-            write_internal(self, subarray.cast());
-            self._set_offset(self.offset() + dst.element_type_layout()->stride());
+        /// data for the child ndrrays
+        const size_t shape1 = 1;
+        size_t subarray_ndim = nbarray.ndim() == 1 ? 1 : nbarray.ndim() - 1;
+        const size_t* subarray_shape
+            = nbarray.ndim() == 1 ? &shape1 : (reinterpret_cast<const size_t*>(nbarray.shape_ptr()) + 1);
+
+        // Gets the subarray of the current `data` pointer, caller needs to stride the data pointer.
+        auto get_subarray = [&]()
+        {
+            return nb::ndarray<nb::numpy, nb::ro>(
+                data,
+                subarray_ndim,
+                subarray_shape,
+                {},
+                nbarray.stride_ptr() + 1,
+                nbarray.dtype(),
+                nbarray.device_type(),
+                nbarray.device_id()
+            );
+        };
+
+        switch (kind) {
+        case TypeReflection::Kind::scalar: {
+            auto type = type_layout->getType();
+            SGL_ASSERT(type);
+            for (size_t index = 0; index < dst.element_count(); ++index, data += element_byte_stride) {
+                m_write_scalar_from_numpy[(int)type->getScalarType()](self, get_subarray());
+                self._set_offset(self.offset() + dst.element_type_layout()->stride());
+            }
+            break;
+        }
+        case TypeReflection::Kind::vector: {
+            auto type = type_layout->getType();
+            SGL_ASSERT(type);
+            for (size_t index = 0; index < dst.element_count(); ++index, data += element_byte_stride) {
+                m_write_vector_from_numpy[(int)type->getScalarType()][type->getColumnCount()](self, get_subarray());
+                self._set_offset(self.offset() + dst.element_type_layout()->stride());
+            }
+            break;
+        }
+        case TypeReflection::Kind::matrix: {
+            auto type = type_layout->getType();
+            SGL_ASSERT(type);
+            for (size_t index = 0; index < dst.element_count(); ++index, data += element_byte_stride) {
+                m_write_matrix_from_numpy[(int)type->getScalarType()][type->getRowCount()][type->getColumnCount()](
+                    self,
+                    get_subarray()
+                );
+                self._set_offset(self.offset() + dst.element_type_layout()->stride());
+            }
+            break;
+        }
+        case TypeReflection::Kind::array: {
+            for (size_t index = 0; index < dst.element_count(); ++index, data += element_byte_stride) {
+                auto subarray = get_subarray();
+                SGL_CHECK(subarray.ndim() == 1, "numpy array must have 1 dimension.");
+                SGL_CHECK(subarray.shape(0) == type_layout->getElementCount(), "numpy array is the wrong length.");
+                auto src_scalar_type = dtype_to_scalar_type(subarray.dtype());
+                SGL_CHECK(is_ndarray_contiguous(subarray), "data is not contiguous");
+                SGL_CHECK(src_scalar_type.has_value(), "unknown CPU type in numpy.");
+                self._set_array(
+                    subarray.data(),
+                    subarray.nbytes(),
+                    *src_scalar_type,
+                    narrow_cast<int>(subarray.shape(0))
+                );
+                self._set_offset(self.offset() + dst.element_type_layout()->stride());
+            }
+            break;
+        }
+        default:
+            for (size_t index = 0; index < dst.element_count(); ++index, data += element_byte_stride) {
+                write_internal(self, get_subarray().cast());
+                self._set_offset(self.offset() + dst.element_type_layout()->stride());
+            }
+            break;
         }
     }
 
@@ -636,6 +730,12 @@ private:
         SGL_THROW("Unsupported element type: {}", kind);
     }
 
+    template<typename ValType>
+    inline static void _write_scalar_from_numpy(CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)
+    {
+        auto val = *reinterpret_cast<const ValType*>(nbarray.data());
+        self.set(val);
+    }
 
     /// Write scalar value to buffer element cursor from Python object.
     template<typename ValType>
@@ -655,7 +755,7 @@ private:
     /// Default implementation of write vector from numpy array.
     template<typename ValType>
         requires IsSpecializationOfVector<ValType>
-    inline static void _write_vector_from_numpy(CursorType& self, nb::ndarray<nb::numpy> nbarray)
+    inline static void _write_vector_from_numpy(CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)
     {
         SGL_CHECK(nbarray.nbytes() == sizeof(ValType), "numpy array has wrong size.");
         auto val = *reinterpret_cast<const ValType*>(nbarray.data());
@@ -667,7 +767,7 @@ private:
     /// but that already duplicates work of the checks in cursor_utils
     template<typename ValType>
         requires IsSpecializationOfVector<ValType>
-    inline static void _write_bool_vector_from_numpy(CursorType& self, nb::ndarray<nb::numpy> nbarray)
+    inline static void _write_bool_vector_from_numpy(CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)
     {
         self._set_vector(nbarray.data(), nbarray.nbytes(), TypeReflection::ScalarType::bool_, ValType::dimension);
     }
@@ -683,7 +783,7 @@ private:
             self.set(val);
         } else if (nb::isinstance<nb::ndarray<nb::numpy>>(nbval)) {
             // A numpy array. Reinterpret numpy memory as vector type.
-            nb::ndarray<nb::numpy> nbarray = nb::cast<nb::ndarray<nb::numpy>>(nbval);
+            nb::ndarray<nb::numpy, nb::ro> nbarray = nb::cast<nb::ndarray<nb::numpy, nb::ro>>(nbval);
             SGL_CHECK(is_ndarray_contiguous(nbarray), "data is not contiguous");
             SGL_CHECK(nbarray.ndim() == 1 || nbarray.ndim() == 2, "numpy array must have 1 or 2 dimensions.");
             size_t dimension = 1;
@@ -716,7 +816,7 @@ private:
             self.set(val);
         } else if (nb::isinstance<nb::ndarray<nb::numpy>>(nbval)) {
             // A numpy array. Reinterpret numpy memory as vector type.
-            nb::ndarray<nb::numpy> nbarray = nb::cast<nb::ndarray<nb::numpy>>(nbval);
+            nb::ndarray<nb::numpy, nb::ro> nbarray = nb::cast<nb::ndarray<nb::numpy, nb::ro>>(nbval);
             SGL_CHECK(is_ndarray_contiguous(nbarray), "data is not contiguous");
             SGL_CHECK(nbarray.ndim() == 1 || nbarray.ndim() == 2, "numpy array must have 1 or 2 dimensions.");
             size_t dimension = 1;
@@ -736,6 +836,16 @@ private:
         } else {
             SGL_THROW("Expected numpy array or vector");
         }
+    }
+
+    /// Write matrix value to buffer element cursor from Python object.
+    template<typename ValType>
+        requires IsSpecializationOfMatrix<ValType>
+    inline static void _write_matrix_from_numpy(CursorType& self, const nb::ndarray<nb::numpy, nb::ro>& nbarray)
+    {
+        SGL_CHECK(nbarray.nbytes() == sizeof(ValType), "numpy array has wrong size.");
+        auto val = *reinterpret_cast<const ValType*>(nbarray.data());
+        self.set(val);
     }
 
     /// Write matrix value to buffer element cursor from Python object.


### PR DESCRIPTION
- Added `_from_numpy` to `scalar`, `matrix`, and `vector` writes to allow writing from numpy directly, rather than going through python objects.
- `write_from_numpy_internal` now invokes the `_from_numpy` versions of the call, to avoid the conversion of the per-element numpy array to a python object and back.
- `write_from_numpy` now has `bitexact_write` argument, that will skip most checks and conversions, and just write the data from numpy into the backend, only checking if there is enough space for it (will not truncate the data if too large, but won't require exact match to deal with `float3` on `Metal` being 16B but only using first 12)