### PR TITLE
Option to print generated shaders to TTY

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,10 @@ Testing:
     - The Python testing system uses PYTEST
     - The C++ testing system uses doctest
     - Always build before running tests.
-    - To run all Python tests, run "pytest slangpy/tests"
+    - To run all Python tests, run "pytest slangpy/tests -v"
+    - An example of running a specific set of tests in a file is: "pytest slangpy/tests/slangpy_tests/test_shader_printing.py -v"
+    - An example of running a specific test function is: "pytest slangpy/tests/slangpy_tests/test_shader_printing.py::test_printing -v"
+    - To log any generated shaders in a test, set the SLANGPY_PRINT_SHADERS environment variable to "true". For example: "$env:SLANGPY_PRINT_SHADERS=1"true"; pytest slangpy/tests/slangpy_tests/test_shader_printing.py -v" (powershell syntax)
 
 C++ Code style:
     - Class names should start with a capital letter.
@@ -45,6 +48,10 @@ Python code style:
     - Local variable names are in snake_case.
     - Member variables start with "m_" and are in snake_case.
     - All arguments should have type annotations.
+
+Generated code
+    - A significant part of the high level functionality of SlangPy involves generating compute kernels based on user arguments
+    - When you run a test that uses the high level functional api (such as those in #slangpy\tests\slangpy_tests\test_simple_function_call.py), you can request the generated code to be printed to the console by setting the SLANGPY_PRINT_SHADERS environment variable to "true".
 
 CI
     - Our CI system uses github, and the main ci job is in #.github/workflows/ci.yml

--- a/slangpy/__init__.py
+++ b/slangpy/__init__.py
@@ -48,7 +48,11 @@ from . import bindings
 from . import builtin as internal_marshalls
 
 # Debug options for call data gen
-from .core.calldata import set_dump_generated_shaders, set_dump_slang_intermediates
+from .core.calldata import (
+    set_dump_generated_shaders,
+    set_dump_slang_intermediates,
+    set_print_generated_shaders,
+)
 
 # Core slangpy interface
 from .core.function import Function

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -33,6 +33,11 @@ SLANG_PATH = Path(__file__).parent.parent / "slang"
 
 _DUMP_GENERATED_SHADERS = False
 _DUMP_SLANG_INTERMEDIATES = False
+_PRINT_GENERATED_SHADERS = os.environ.get("SLANGPY_PRINT_SHADERS", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 
 def set_dump_generated_shaders(value: bool):
@@ -49,6 +54,15 @@ def set_dump_slang_intermediates(value: bool):
     """
     global _DUMP_SLANG_INTERMEDIATES
     _DUMP_SLANG_INTERMEDIATES = value
+
+
+def set_print_generated_shaders(value: bool):
+    """
+    Specify whether to print generated shaders to the terminal for analysis.
+    Can also be controlled via the SLANGPY_PRINT_SHADERS environment variable.
+    """
+    global _PRINT_GENERATED_SHADERS
+    _PRINT_GENERATED_SHADERS = value
 
 
 def unpack_arg(arg: Any) -> Any:
@@ -251,6 +265,24 @@ class CallData(NativeCallData):
                     f.write(bound_call_table(bindings))
                     f.write("\n*/\n")
                     f.write(code)
+
+            # Optionally print the shader to the terminal for AI analysis.
+            if _PRINT_GENERATED_SHADERS:
+                print("=" * 80)
+                print(f"GENERATED SHADER: {build_info.module.name}::{build_info.name}")
+                if self.call_mode == CallMode.bwds:
+                    print("MODE: Backwards")
+                else:
+                    print("MODE: Forward")
+                print("=" * 80)
+                print("/* BINDINGS:")
+                print(bound_call_table(bindings))
+                print("*/")
+                print(code)
+                print("=" * 80)
+                print(f"END SHADER: {build_info.module.name}::{build_info.name}")
+                print("=" * 80)
+                print()
 
             # Hash the code to get a unique identifier for the module.
             # We add type conformances to the start of the code to ensure that the hash is unique

--- a/slangpy/tests/slangpy_tests/test_shader_printing.py
+++ b/slangpy/tests/slangpy_tests/test_shader_printing.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import io
+import pytest
+from contextlib import redirect_stdout
+from slangpy.testing import helpers
+from slangpy import DeviceType
+from slangpy.core.calldata import set_print_generated_shaders
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_print_generated_shaders_programmatic(device_type: DeviceType):
+    """Test that set_print_generated_shaders() works correctly."""
+    device = helpers.get_device(device_type)
+
+    # Create a simple function that will generate a shader (like test_call_function)
+    function = helpers.create_function_from_module(
+        device,
+        "add_numbers",
+        r"""
+void add_numbers(int a, int b) {
+}
+""",
+    )
+
+    # Enable shader printing
+    set_print_generated_shaders(True)
+
+    # Capture stdout to verify the shader is printed
+    captured_output = io.StringIO()
+    with redirect_stdout(captured_output):
+        # Just verify it can be called with no exceptions (like test_call_function)
+        function(5, 10)
+
+    output = captured_output.getvalue()
+
+    # Verify that shader output is present
+    assert "GENERATED SHADER:" in output
+    assert "add_numbers" in output
+    assert "=" * 80 in output
+    assert "END SHADER:" in output
+
+    # Disable shader printing
+    set_print_generated_shaders(False)
+
+    # Verify no output when disabled
+    captured_output = io.StringIO()
+    with redirect_stdout(captured_output):
+        # Just verify it can be called with no exceptions
+        function(5, 10)
+
+    output = captured_output.getvalue()
+    assert "GENERATED SHADER:" not in output
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_print_generated_shaders_environment_variable(device_type: DeviceType):
+    """Test that SLANGPY_PRINT_SHADERS environment variable works correctly."""
+    device = helpers.get_device(device_type)
+
+    # Create a simple function that will generate a shader (like test_call_function)
+    function = helpers.create_function_from_module(
+        device,
+        "add_numbers",
+        r"""
+void add_numbers(int a, int b) {
+}
+""",
+    )
+
+    # Test with environment variable set
+    original_env = os.environ.get("SLANGPY_PRINT_SHADERS")
+
+    try:
+        # Set environment variable
+        os.environ["SLANGPY_PRINT_SHADERS"] = "true"
+
+        # We need to use the programmatic API since the environment variable
+        # is only checked at import time
+        set_print_generated_shaders(True)
+
+        # Capture stdout to verify the shader is printed
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            # Just verify it can be called with no exceptions (like test_call_function)
+            function(5, 10)
+
+        output = captured_output.getvalue()
+
+        # Verify that shader output is present
+        assert "GENERATED SHADER:" in output
+        assert "add_numbers" in output
+
+    finally:
+        # Restore original environment
+        if original_env is None:
+            os.environ.pop("SLANGPY_PRINT_SHADERS", None)
+        else:
+            os.environ["SLANGPY_PRINT_SHADERS"] = original_env
+        set_print_generated_shaders(False)
+
+
+def test_environment_variable_parsing():
+    """Test that various environment variable values are parsed correctly."""
+
+    # Test various true values
+    true_values = ["true", "1", "yes", "TRUE", "True", "YES"]
+    false_values = ["false", "0", "no", "FALSE", "False", "NO", "", "invalid"]
+
+    original_env = os.environ.get("SLANGPY_PRINT_SHADERS")
+
+    try:
+        for value in true_values:
+            os.environ["SLANGPY_PRINT_SHADERS"] = value
+            # We can't easily test the import-time behavior, so we'll just verify
+            # the logic by testing the string parsing directly
+            result = value.lower() in ("true", "1", "yes")
+            assert result is True, f"Value '{value}' should be parsed as True"
+
+        for value in false_values:
+            os.environ["SLANGPY_PRINT_SHADERS"] = value
+            result = value.lower() in ("true", "1", "yes")
+            assert result is False, f"Value '{value}' should be parsed as False"
+
+    finally:
+        # Restore original environment
+        if original_env is None:
+            os.environ.pop("SLANGPY_PRINT_SHADERS", None)
+        else:
+            os.environ["SLANGPY_PRINT_SHADERS"] = original_env
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
Mainly for AI development, adds env variable based option to slangpy to have generated shaders dumped to the TTY, so the agent can see what the code gen is producing.