### PR TITLE
Benchmark comparison

### DIFF
--- a/slangpy/testing/benchmark/plugin.py
+++ b/slangpy/testing/benchmark/plugin.py
@@ -42,10 +42,10 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         write_report(report, path)
 
     # Upload report to MongoDB
-    if session.config.getoption("--upload-benchmark-report"):
+    if session.config.getoption("--benchmark-upload"):
         print("Uploading benchmark report to MongoDB")
-        connection_string = session.config.getoption("--mongodb-connection-string")
-        database_name = session.config.getoption("--mongodb-database-name")
+        connection_string = session.config.getoption("--benchmark-mongodb-connection-string")
+        database_name = session.config.getoption("--benchmark-mongodb-database-name")
         upload_report(report, connection_string, database_name)
 
 
@@ -63,19 +63,19 @@ def pytest_addoption(parser: pytest.Parser):
         help="Path to the benchmark report JSON file",
     )
     parser.addoption(
-        "--upload-benchmark-report",
+        "--benchmark-upload",
         action="store_true",
         default=False,
         help="Upload benchmark report to a MongoDB",
     )
     parser.addoption(
-        "--mongodb-connection-string",
+        "--benchmark-mongodb-connection-string",
         action="store",
         default="mongodb://localhost:27017",
         help="MongoDB connection string",
     )
     parser.addoption(
-        "--mongodb-database-name",
+        "--benchmark-mongodb-database-name",
         action="store",
         default="nvr-ci",
         help="MongoDB database name",

--- a/slangpy/testing/benchmark/plugin.py
+++ b/slangpy/testing/benchmark/plugin.py
@@ -112,9 +112,12 @@ def pytest_cmdline_main(config: pytest.Config):
     compare = config.getoption("--benchmark-compare")
     if compare != "_unspecified_":
         ids = list_report_ids(BENCHMARK_DIR)
+        if len(ids) == 0:
+            print("No benchmark runs found!")
+            return 1
         id = compare if compare else ids[0]
         if not id in ids:
-            print(f'Benchmark run "{id}" not found')
+            print(f'Benchmark run "{id}" not found!')
             return 1
         print(f"Comparing against benchmark run: {id}")
 

--- a/slangpy/testing/benchmark/table.py
+++ b/slangpy/testing/benchmark/table.py
@@ -1,33 +1,101 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from _pytest._io import TerminalWriter
+
 from .report import BenchmarkReport
 
+from typing import Optional, Tuple
 
-def display(benchmark_reports: list[BenchmarkReport]):
+Part = Tuple[str, dict[str, bool]]
+Cell = list[Part]
 
-    column_titles = ["Name", "Min (ms)", "Max (ms)", "Mean (ms)", "Median (ms)", "Stddev (ms)"]
+
+def display(
+    writer: TerminalWriter,
+    benchmarks: list[BenchmarkReport],
+    baseline_benchmarks: Optional[list[BenchmarkReport]] = None,
+):
+    baseline_benchmarks_by_name = {
+        benchmark["name"]: benchmark for benchmark in (baseline_benchmarks or [])
+    }
+
+    # For table printing we use the following conventions:
+    # - a row is a list of cells
+    # - a cell is a list of parts
+    # - a part is a tuple of (text, markup)
+    # - no spaces are used to separate parts
+    # - 3 spaces are used to separate cells
+    # When printing the table, we align the text within each cell.
+    # Parts can have individual markup (color, bold etc.) passed to pytest's TerminalWriter.
+
+    def make_part(text: str, **markup: bool) -> Part:
+        return (text, markup)
+
+    def make_cell(text: str) -> Cell:
+        return [make_part(text)]
+
+    def cell_length(cell: Cell) -> int:
+        return sum(len(part) for part, _ in cell) + len(cell)
+
+    column_titles = [
+        make_cell("Name"),
+        make_cell("Min (ms)"),
+        make_cell("Max (ms)"),
+        make_cell("Mean (ms)"),
+        make_cell("Median (ms)"),
+        make_cell("Stddev (ms)"),
+    ]
     rows = []
 
-    for report in benchmark_reports:
+    for benchmark in benchmarks:
         row = [
-            report["name"],
-            f"{report['min']:.3f}",
-            f"{report['max']:.3f}",
-            f"{report['mean']:.3f}",
-            f"{report['median']:.3f}",
-            f"{report['stddev']:.3f}",
+            make_cell(benchmark["name"]),
+            make_cell(f"{benchmark['min']:.3f}"),
+            make_cell(f"{benchmark['max']:.3f}"),
+            make_cell(f"{benchmark['mean']:.3f}"),
+            make_cell(f"{benchmark['median']:.3f}"),
+            make_cell(f"{benchmark['stddev']:.3f}"),
         ]
+        if benchmark["name"] in baseline_benchmarks_by_name:
+            baseline_benchmark = baseline_benchmarks_by_name[benchmark["name"]]
+
+            def delta_info(current: float, baseline: float) -> Part:
+                if baseline == 0:
+                    return make_part(" (inf%)")
+                delta = ((current - baseline) / baseline) * 100
+                markup = {}
+                if delta < -5:
+                    markup = {"green": True}
+                elif delta > 5:
+                    markup = {"red": True}
+                else:
+                    markup = {"light": True}
+                return make_part(f" ({delta:+.1f}%)", **markup)
+
+            row[1].append(delta_info(benchmark["min"], baseline_benchmark["min"]))
+            row[2].append(delta_info(benchmark["max"], baseline_benchmark["max"]))
+            row[3].append(delta_info(benchmark["mean"], baseline_benchmark["mean"]))
+            row[4].append(delta_info(benchmark["median"], baseline_benchmark["median"]))
+            row[5].append(delta_info(benchmark["stddev"], baseline_benchmark["stddev"]))
+
         rows.append(row)
 
     column_widths = [
-        max(len(str(item)) for item in col) + 3 for col in zip(*([column_titles] + rows))
+        max(cell_length(item) for item in col) + 3 for col in zip(*([column_titles] + rows))
     ]
-    total_width = sum(column_widths)
-    line = "-" * total_width
 
-    print(line)
-    print("".join(f"{title:{width}}" for title, width in zip(column_titles, column_widths)))
-    print(line)
+    def write_row(row: list[Cell]):
+        for column_index, cell in enumerate(row):
+            length = 0
+            for part in cell:
+                writer.write(f"{part[0]}", **part[1])
+                length += len(part[0])
+            writer.write(" " * (column_widths[column_index] - length))
+        writer.line()
+
+    writer.sep("-")
+    write_row(column_titles)
+    writer.sep("-")
     for row in rows:
-        print("".join(f"{value:{width}}" for value, width in zip(row, column_widths)))
-    print(line)
+        write_row(row)
+    writer.sep("-")

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -166,10 +166,10 @@ def benchmark_python(args: Any):
     env = get_python_env()
     cmd = ["pytest", "slangpy/benchmarks", "-ra"]
     if args.mongodb_connection_string:
-        cmd += ["--upload-benchmark-report"]
-        cmd += ["--mongodb-connection-string", args.mongodb_connection_string]
+        cmd += ["--benchmark-upload"]
+        cmd += ["--benchmark-mongodb-connection-string", args.mongodb_connection_string]
         if args.mongodb_database_name:
-            cmd += ["--mongodb-database-name", args.mongodb_database_name]
+            cmd += ["--benchmark-mongodb-database-name", args.mongodb_database_name]
     run_command(cmd, env=env)
 
 

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -148,7 +148,7 @@ def typing_check_python(args: Any):
 def unit_test_python(args: Any):
     env = get_python_env()
     os.makedirs("reports", exist_ok=True)
-    cmd = ["pytest", "slangpy/tests", "-ra", "--junit-xml=reports/pytest-junit.xml", "--color=yes"]
+    cmd = ["pytest", "slangpy/tests", "-ra", "--junit-xml=reports/pytest-junit.xml"]
     if args.parallel:
         cmd += ["-n", "auto", "--maxprocesses=4"]
     run_command(cmd, env=env)
@@ -156,7 +156,7 @@ def unit_test_python(args: Any):
 
 def test_examples(args: Any):
     env = get_python_env()
-    cmd = ["pytest", "samples/tests", "-vra", "--color=yes"]
+    cmd = ["pytest", "samples/tests", "-vra"]
     if args.parallel:
         cmd += ["-n", "auto", "--maxprocesses=4"]
     run_command(cmd, env=env)
@@ -164,7 +164,7 @@ def test_examples(args: Any):
 
 def benchmark_python(args: Any):
     env = get_python_env()
-    cmd = ["pytest", "slangpy/benchmarks", "-ra", "--color=yes"]
+    cmd = ["pytest", "slangpy/benchmarks", "-ra"]
     if args.mongodb_connection_string:
         cmd += ["--benchmark-upload"]
         cmd += ["--benchmark-mongodb-connection-string", args.mongodb_connection_string]

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -148,7 +148,7 @@ def typing_check_python(args: Any):
 def unit_test_python(args: Any):
     env = get_python_env()
     os.makedirs("reports", exist_ok=True)
-    cmd = ["pytest", "slangpy/tests", "-ra", "--junit-xml=reports/pytest-junit.xml"]
+    cmd = ["pytest", "slangpy/tests", "-ra", "--junit-xml=reports/pytest-junit.xml", "--color=yes"]
     if args.parallel:
         cmd += ["-n", "auto", "--maxprocesses=4"]
     run_command(cmd, env=env)
@@ -156,7 +156,7 @@ def unit_test_python(args: Any):
 
 def test_examples(args: Any):
     env = get_python_env()
-    cmd = ["pytest", "samples/tests", "-vra"]
+    cmd = ["pytest", "samples/tests", "-vra", "--color=yes"]
     if args.parallel:
         cmd += ["-n", "auto", "--maxprocesses=4"]
     run_command(cmd, env=env)
@@ -164,7 +164,7 @@ def test_examples(args: Any):
 
 def benchmark_python(args: Any):
     env = get_python_env()
-    cmd = ["pytest", "slangpy/benchmarks", "-ra"]
+    cmd = ["pytest", "slangpy/benchmarks", "-ra", "--color=yes"]
     if args.mongodb_connection_string:
         cmd += ["--benchmark-upload"]
         cmd += ["--benchmark-mongodb-connection-string", args.mongodb_connection_string]


### PR DESCRIPTION
Add support for comparing benchmarks:
- `--benchmark-save=[ID]` to save a report for the current run (optional ID)
- `--benchmark-compare=[ID]` to compare to a previous run (optional ID, use latest by default)
- `--benchmark-list-runs` list all stored benchmark runs
- Print deltas in the benchmark table

Rename other benchmark CLI options:
- `--benchmark-upload` uploads the run to a MongoDB
- `--benchmark-mongodb-connection-string` specifies the MongoDB connection string
- `--benchmark-mongodb-database-name` specifies the DB name