### PR TITLE
Re-enable tests, disable torch and add trimmed mean

### DIFF
--- a/slangpy/benchmarks/test_benchmark_interop.py
+++ b/slangpy/benchmarks/test_benchmark_interop.py
@@ -106,6 +106,7 @@ void compute_main(uint3 tid: SV_DispatchThreadID, StructuredBuffer<float> a, Str
 """
 
 
+@pytest.mark.skip(reason="See if pytorch causes perf issues")
 def test_pytorch_tensor_addition_cpu(benchmark_python_function: BenchmarkPythonFunction):
     device = helpers.get_device(spy.DeviceType.cuda)
 
@@ -196,6 +197,7 @@ def test_slangpy_tensor_addition_appendonly_cpu(
     benchmark_python_function(device, tensor_addition, a=buffer0, b=buffer1, res=resbuffer)
 
 
+@pytest.mark.skip(reason="See if pytorch causes perf issues")
 def test_pytorch_tensor_addition_gpu_est(report: ReportFixture):
     device = helpers.get_device(spy.DeviceType.cuda)
 

--- a/slangpy/benchmarks/test_benchmark_interop.py
+++ b/slangpy/benchmarks/test_benchmark_interop.py
@@ -106,7 +106,7 @@ void compute_main(uint3 tid: SV_DispatchThreadID, StructuredBuffer<float> a, Str
 """
 
 
-@pytest.mark.skip(reason="See if pytorch causes perf issues")
+@pytest.mark.skip(reason="Pytorch integration is affecting benchmarks")
 def test_pytorch_tensor_addition_cpu(benchmark_python_function: BenchmarkPythonFunction):
     device = helpers.get_device(spy.DeviceType.cuda)
 
@@ -197,7 +197,7 @@ def test_slangpy_tensor_addition_appendonly_cpu(
     benchmark_python_function(device, tensor_addition, a=buffer0, b=buffer1, res=resbuffer)
 
 
-@pytest.mark.skip(reason="See if pytorch causes perf issues")
+@pytest.mark.skip(reason="Pytorch integration is affecting benchmarks")
 def test_pytorch_tensor_addition_gpu_est(report: ReportFixture):
     device = helpers.get_device(spy.DeviceType.cuda)
 

--- a/slangpy/benchmarks/test_benchmark_interop.py
+++ b/slangpy/benchmarks/test_benchmark_interop.py
@@ -12,8 +12,6 @@ from slangpy.testing.benchmark import (
     ReportFixture,
 )
 
-pytest.skip("Temp disable interop benchmarks", allow_module_level=True)
-
 ADD_FLOATS = """
 float add_floats(float a, float b) {
     return a + b;
@@ -109,7 +107,7 @@ void compute_main(uint3 tid: SV_DispatchThreadID, StructuredBuffer<float> a, Str
 
 
 def test_pytorch_tensor_addition_cpu(benchmark_python_function: BenchmarkPythonFunction):
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_device(spy.DeviceType.cuda)
 
     BUFFER_SIZE = 10
     import torch
@@ -127,7 +125,7 @@ def test_pytorch_tensor_addition_cpu(benchmark_python_function: BenchmarkPythonF
 def test_compute_addition_noalloc_cpu(
     device_type: spy.DeviceType, benchmark_python_function: BenchmarkPythonFunction
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
 
     BUFFER_SIZE = 10
     buffer0 = spy.NDBuffer.empty(device, shape=(BUFFER_SIZE,), dtype=float)
@@ -148,7 +146,7 @@ def test_compute_addition_noalloc_cpu(
 def test_slangpy_tensor_addition_noalloc_cpu(
     device_type: spy.DeviceType, benchmark_python_function: BenchmarkPythonFunction
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(device, "add_floats", ADD_FLOATS)
 
     BUFFER_SIZE = 10
@@ -166,7 +164,7 @@ def test_slangpy_tensor_addition_noalloc_cpu(
 def test_slangpy_tensor_addition_alloc_cpu(
     device_type: spy.DeviceType, benchmark_python_function: BenchmarkPythonFunction
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(device, "add_floats", ADD_FLOATS)
 
     BUFFER_SIZE = 10
@@ -183,7 +181,7 @@ def test_slangpy_tensor_addition_alloc_cpu(
 def test_slangpy_tensor_addition_appendonly_cpu(
     device_type: spy.DeviceType, benchmark_python_function: BenchmarkPythonFunction
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(device, "add_floats", ADD_FLOATS)
 
     BUFFER_SIZE = 10
@@ -199,7 +197,7 @@ def test_slangpy_tensor_addition_appendonly_cpu(
 
 
 def test_pytorch_tensor_addition_gpu_est(report: ReportFixture):
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_device(spy.DeviceType.cuda)
 
     BUFFER_SIZE = 65535 * 32
     import torch
@@ -231,7 +229,7 @@ def test_pytorch_tensor_addition_gpu_est(report: ReportFixture):
 def test_compute_addition_noalloc_gpu(
     device_type: spy.DeviceType, benchmark_compute_kernel: BenchmarkComputeKernel
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
 
     BUFFER_SIZE = 65535 * 32
     buffer0 = spy.NDBuffer.empty(device, shape=(BUFFER_SIZE,), dtype=float)
@@ -256,7 +254,7 @@ def test_compute_addition_noalloc_gpu(
 def test_compute_addition_4x_noalloc_gpu(
     device_type: spy.DeviceType, benchmark_compute_kernel: BenchmarkComputeKernel
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
 
     BUFFER_SIZE = 65535 * 32
     buffer0 = spy.NDBuffer.empty(device, shape=(BUFFER_SIZE,), dtype=float)
@@ -281,7 +279,7 @@ def test_compute_addition_4x_noalloc_gpu(
 def test_compute_addition_16x_noalloc_gpu(
     device_type: spy.DeviceType, benchmark_compute_kernel: BenchmarkComputeKernel
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
 
     BUFFER_SIZE = 65535 * 32
     buffer0 = spy.NDBuffer.empty(device, shape=(BUFFER_SIZE,), dtype=float)
@@ -308,7 +306,7 @@ def test_compute_addition_16x_noalloc_gpu(
 def test_compute_addition_16xloop_noalloc_gpu(
     device_type: spy.DeviceType, benchmark_compute_kernel: BenchmarkComputeKernel
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
 
     BUFFER_SIZE = 65535 * 32
     buffer0 = spy.NDBuffer.empty(device, shape=(BUFFER_SIZE,), dtype=float)
@@ -335,7 +333,7 @@ def test_compute_addition_16xloop_noalloc_gpu(
 def test_compute_addition_16xunroll_noalloc_gpu(
     device_type: spy.DeviceType, benchmark_compute_kernel: BenchmarkComputeKernel
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
 
     BUFFER_SIZE = 65535 * 32
     buffer0 = spy.NDBuffer.empty(device, shape=(BUFFER_SIZE,), dtype=float)
@@ -362,7 +360,7 @@ def test_compute_addition_16xunroll_noalloc_gpu(
 def test_slangpy_tensor_addition_noalloc_gpu(
     device_type: spy.DeviceType, benchmark_slang_function: BenchmarkSlangFunction
 ):
-    device = helpers.get_torch_device(device_type)
+    device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(device, "add_floats", ADD_FLOATS)
 
     BUFFER_SIZE = 65535 * 32

--- a/slangpy/testing/benchmark/fixtures.py
+++ b/slangpy/testing/benchmark/fixtures.py
@@ -10,6 +10,9 @@ from datetime import datetime
 
 from .report import BenchmarkReport
 
+DEFAULT_ITERATIONS = 2000
+INITIAL_WARMUP_ITERATIONS = 100
+
 
 class ReportFixture:
 
@@ -76,8 +79,8 @@ class BenchmarkSlangFunction:
         self,
         device: spy.Device,
         function: Union[spy.Function, FunctionNodeBwds],
-        iterations: int = 2000,
-        warmup_iterations: int = 100,
+        iterations: int = DEFAULT_ITERATIONS,
+        warmup_iterations: int = INITIAL_WARMUP_ITERATIONS,
         **kwargs: Any,
     ) -> None:
         """Run the benchmark with the given parameters."""
@@ -117,8 +120,8 @@ class BenchmarkComputeKernel:
         device: spy.Device,
         kernel: spy.ComputeKernel,
         thread_count: spy.uint3,
-        iterations: int = 2000,
-        warmup_iterations: int = 100,
+        iterations: int = DEFAULT_ITERATIONS,
+        warmup_iterations: int = INITIAL_WARMUP_ITERATIONS,
         **kwargs: Any,
     ) -> None:
         """Run the benchmark with the given parameters."""
@@ -158,8 +161,8 @@ class BenchmarkPythonFunction:
         device: Optional[spy.Device],
         function: Callable[..., None],
         iterations: int = 10,
-        sub_iterations: int = 2000,
-        warmup_iterations: int = 100,
+        sub_iterations: int = DEFAULT_ITERATIONS // 10,
+        warmup_iterations: int = INITIAL_WARMUP_ITERATIONS,
         **kwargs: Any,
     ) -> None:
         """Run the benchmark with the given parameters."""

--- a/slangpy/testing/benchmark/fixtures.py
+++ b/slangpy/testing/benchmark/fixtures.py
@@ -38,6 +38,15 @@ class ReportFixture:
         if device:
             meta["adapter_name"] = device.info.adapter_name
 
+        # Calculate trimmed mean (remove 10% outliers - 5% from each end)
+        sorted_data = np.sort(data)
+        trim_count = int(len(sorted_data) * 0.05)  # 5% from each end
+        if trim_count > 0:
+            trimmed_data = sorted_data[trim_count:-trim_count]
+        else:
+            trimmed_data = sorted_data
+        trimmed_mean = float(np.mean(trimmed_data))
+
         report: BenchmarkReport = {
             "name": self.node.name,
             "filename": str(self.node.location[0]).replace("\\", "/"),
@@ -49,7 +58,7 @@ class ReportFixture:
             "data": [float(d) for d in data],
             "min": float(np.min(data)),
             "max": float(np.max(data)),
-            "mean": float(np.mean(data)),
+            "mean": trimmed_mean,
             "median": float(np.median(data)),
             "stddev": float(np.std(data)),
         }

--- a/slangpy/testing/benchmark/fixtures.py
+++ b/slangpy/testing/benchmark/fixtures.py
@@ -67,7 +67,7 @@ class BenchmarkSlangFunction:
         self,
         device: spy.Device,
         function: Union[spy.Function, FunctionNodeBwds],
-        iterations: int = 200,
+        iterations: int = 2000,
         warmup_iterations: int = 10,
         **kwargs: Any,
     ) -> None:
@@ -108,7 +108,7 @@ class BenchmarkComputeKernel:
         device: spy.Device,
         kernel: spy.ComputeKernel,
         thread_count: spy.uint3,
-        iterations: int = 200,
+        iterations: int = 2000,
         warmup_iterations: int = 10,
         **kwargs: Any,
     ) -> None:

--- a/slangpy/testing/benchmark/fixtures.py
+++ b/slangpy/testing/benchmark/fixtures.py
@@ -68,7 +68,7 @@ class BenchmarkSlangFunction:
         device: spy.Device,
         function: Union[spy.Function, FunctionNodeBwds],
         iterations: int = 2000,
-        warmup_iterations: int = 10,
+        warmup_iterations: int = 100,
         **kwargs: Any,
     ) -> None:
         """Run the benchmark with the given parameters."""
@@ -109,7 +109,7 @@ class BenchmarkComputeKernel:
         kernel: spy.ComputeKernel,
         thread_count: spy.uint3,
         iterations: int = 2000,
-        warmup_iterations: int = 10,
+        warmup_iterations: int = 100,
         **kwargs: Any,
     ) -> None:
         """Run the benchmark with the given parameters."""
@@ -149,8 +149,8 @@ class BenchmarkPythonFunction:
         device: Optional[spy.Device],
         function: Callable[..., None],
         iterations: int = 10,
-        sub_iterations: int = 200,
-        warmup_iterations: int = 10,
+        sub_iterations: int = 2000,
+        warmup_iterations: int = 100,
         **kwargs: Any,
     ) -> None:
         """Run the benchmark with the given parameters."""


### PR DESCRIPTION
Tweaks for benchmarking
- Re-enabled a load of the tests in interop
- Not using get_torch_device when not needed, and disabled tests that do need it
- Use trimmed mean 
- Much larger test set