### PR TITLE
Various fixes for mem leaks

### DIFF
--- a/slangpy/core/utils.py
+++ b/slangpy/core/utils.py
@@ -127,8 +127,10 @@ def find_type_layout_for_buffer(
 ):
     if isinstance(slang_type, str):
         slang_type_name = slang_type
-    elif isinstance(slang_type, (TypeReflection, TypeLayoutReflection)):
-        slang_type_name = slang_type.name
+    elif isinstance(slang_type, TypeReflection):
+        slang_type_name = slang_type.full_name
+    elif isinstance(slang_type, TypeLayoutReflection):
+        slang_type_name = slang_type.type.full_name
     buffer_type = program_layout.find_type_by_name(f"StructuredBuffer<{slang_type_name}>")
     buffer_layout = program_layout.get_type_layout(buffer_type)
     return buffer_layout.element_type_layout

--- a/slangpy/types/buffer.py
+++ b/slangpy/types/buffer.py
@@ -134,11 +134,11 @@ def resolve_element_type(program_layout: SlangProgramLayout, element_type: Any) 
         if element_type.module.layout == program_layout:
             element_type = element_type.struct
         else:
-            element_type = program_layout.find_type_by_name(element_type.name)
+            element_type = program_layout.find_type_by_name(element_type.full_name)
     elif isinstance(element_type, TypeReflection):
-        element_type = program_layout.find_type(element_type)
+        element_type = program_layout.find_type_by_name(element_type.full_name)
     elif isinstance(element_type, TypeLayoutReflection):
-        element_type = program_layout.find_type(element_type.type)
+        element_type = program_layout.find_type_by_name(element_type.type.full_name)
     elif isinstance(element_type, Marshall):
         if element_type.slang_type.program == program_layout:
             element_type = element_type.slang_type

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -229,6 +229,7 @@ private:
 };
 
 class SGL_API DeclReflection : public BaseReflectionObjectImpl<slang::DeclReflection> {
+    SGL_OBJECT(DeclReflection)
 
 public:
     DeclReflection(ref<const Object> owner, slang::DeclReflection* target)
@@ -346,6 +347,7 @@ protected:
 };
 
 class SGL_API TypeReflection : public BaseReflectionObjectImpl<slang::TypeReflection> {
+    SGL_OBJECT(TypeReflection)
 public:
     enum class Kind {
         none = SLANG_TYPE_KIND_NONE,
@@ -676,6 +678,7 @@ protected:
 
 
 class SGL_API TypeLayoutReflection : public BaseReflectionObjectImpl<slang::TypeLayoutReflection> {
+    SGL_OBJECT(TypeLayoutReflection)
 public:
     static ref<const TypeLayoutReflection>
     from_slang(ref<const Object> owner, slang::TypeLayoutReflection* type_layout_reflection)
@@ -798,6 +801,7 @@ protected:
 };
 
 class SGL_API FunctionReflection : public BaseReflectionObjectImpl<slang::FunctionReflection> {
+    SGL_OBJECT(FunctionReflection)
 public:
     FunctionReflection(ref<const Object> owner, slang::FunctionReflection* target)
         : BaseReflectionObjectImpl(std::move(owner), target)
@@ -911,6 +915,7 @@ protected:
 };
 
 class SGL_API VariableReflection : public BaseReflectionObjectImpl<slang::VariableReflection> {
+    SGL_OBJECT(VariableReflection)
 public:
     static ref<const VariableReflection>
     from_slang(ref<const Object> owner, slang::VariableReflection* variable_reflection)
@@ -964,6 +969,7 @@ public:
 };
 
 class SGL_API EntryPointLayout : public BaseReflectionObjectImpl<slang::EntryPointLayout> {
+    SGL_OBJECT(EntryPointLayout)
 public:
     static ref<const EntryPointLayout>
     from_slang(ref<const Object> owner, slang::EntryPointLayout* entry_point_reflection)
@@ -1027,6 +1033,7 @@ protected:
 
 
 class SGL_API ProgramLayout : public BaseReflectionObjectImpl<slang::ProgramLayout> {
+    SGL_OBJECT(ProgramLayout)
 public:
     static ref<const ProgramLayout> from_slang(ref<const Object> owner, slang::ProgramLayout* program_layout)
     {

--- a/src/sgl/device/shader.h
+++ b/src/sgl/device/shader.h
@@ -236,6 +236,8 @@ struct SlangSessionDesc {
 
 /// Internal data stored once the slang session has been created.
 struct SlangSessionData : Object {
+    SGL_OBJECT(SlangSessionData)
+
     /// Pointer to internal slang session.
     Slang::ComPtr<slang::ISession> slang_session;
 
@@ -353,6 +355,8 @@ struct SlangModuleDesc {
 };
 
 struct SlangModuleData : Object {
+    SGL_OBJECT(SlangModuleData)
+
     slang::IModule* slang_module = nullptr;
     std::string name;
     std::filesystem::path path;
@@ -429,6 +433,8 @@ struct SlangEntryPointDesc {
     std::vector<TypeConformance> type_conformances;
 };
 struct SlangEntryPointData : Object {
+    SGL_OBJECT(SlangEntryPointData)
+
     Slang::ComPtr<slang::IComponentType> slang_entry_point;
     std::string name;
     ShaderStage stage;
@@ -477,6 +483,7 @@ struct ShaderProgramDesc {
     std::string label;
 };
 struct ShaderProgramData : Object {
+    SGL_OBJECT(ShaderProgramData)
     Slang::ComPtr<slang::IComponentType> linked_program;
     Slang::ComPtr<rhi::IShaderProgram> rhi_shader_program;
 };

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -800,13 +800,13 @@ struct HeapReport {
     {
         return fmt::format(
             "HeapReport(\n"
-            "  name = \"{}\",\n"
+            "  label = \"{}\",\n"
             "  num_pages = {},\n"
             "  total_allocated = {},\n"
             "  total_mem_usage = {},\n"
             "  num_allocations = {}\n"
             ")",
-            name,
+            label,
             num_pages,
             total_allocated,
             total_mem_usage,

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -795,6 +795,24 @@ struct HeapReport {
     uint64_t total_mem_usage{0};
     /// Number of allocations.
     uint64_t num_allocations{0};
+
+    std::string to_string() const
+    {
+        return fmt::format(
+            "HeapReport(\n"
+            "  name = \"{}\",\n"
+            "  num_pages = {},\n"
+            "  total_allocated = {},\n"
+            "  total_mem_usage = {},\n"
+            "  num_allocations = {}\n"
+            ")",
+            name,
+            num_pages,
+            total_allocated,
+            total_mem_usage,
+            num_allocations
+        );
+    }
 };
 
 } // namespace sgl

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -244,7 +244,8 @@ SGL_PY_EXPORT(device_device)
         .def_rw("num_pages", &HeapReport::num_pages, D_NA(HeapReport, num_pages))
         .def_rw("total_allocated", &HeapReport::total_allocated, D_NA(HeapReport, total_allocated))
         .def_rw("total_mem_usage", &HeapReport::total_mem_usage, D_NA(HeapReport, total_mem_usage))
-        .def_rw("num_allocations", &HeapReport::num_allocations, D_NA(HeapReport, num_allocations));
+        .def_rw("num_allocations", &HeapReport::num_allocations, D_NA(HeapReport, num_allocations))
+        .def("__repr__", &HeapReport::to_string);
 
     nb::class_<Device, Object> device(m, "Device", nb::is_weak_referenceable(), D(Device));
     device.def(

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -33,9 +33,9 @@ struct GcHelper<slangpy::NativeCallRuntimeOptions> {
     void traverse(slangpy::NativeCallRuntimeOptions*, GcVisitor& visitor)
     {
         visitor("uniforms");
-        visitor("this_ref");
+        visitor("_native_this");
     }
-    void clear(slangpy::NativeCallRuntimeOptions* opts) { opts->clear(); }
+    void clear(slangpy::NativeCallRuntimeOptions* opts) { opts->garbage_collect(); }
 };
 
 } // namespace sgl
@@ -1282,10 +1282,10 @@ SGL_PY_EXPORT(utils_slangpy)
             D_NA(NativeCallRuntimeOptions, uniforms)
         )
         .def_prop_rw(
-            "this_ref",
+            "_native_this",
             &NativeCallRuntimeOptions::get_this,
             &NativeCallRuntimeOptions::set_this,
-            D_NA(NativeCallRuntimeOptions, this_ref)
+            D_NA(NativeCallRuntimeOptions, _native_this)
         )
         .def_prop_rw(
             "cuda_stream",

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -28,6 +28,16 @@ extern void buffer_copy_from_numpy(Buffer* self, nb::ndarray<nb::numpy> data);
 extern nb::ndarray<nb::pytorch, nb::device::cuda>
 buffer_to_torch(Buffer* self, DataType type, std::vector<size_t> shape, std::vector<int64_t> strides, size_t offset);
 
+template<>
+struct GcHelper<slangpy::NativeCallRuntimeOptions> {
+    void traverse(slangpy::NativeCallRuntimeOptions*, GcVisitor& visitor)
+    {
+        visitor("uniforms");
+        visitor("this_ref");
+    }
+    void clear(slangpy::NativeCallRuntimeOptions* opts) { opts->clear(); }
+};
+
 } // namespace sgl
 
 namespace sgl::slangpy {
@@ -1270,6 +1280,12 @@ SGL_PY_EXPORT(utils_slangpy)
             &NativeCallRuntimeOptions::get_uniforms,
             &NativeCallRuntimeOptions::set_uniforms,
             D_NA(NativeCallRuntimeOptions, uniforms)
+        )
+        .def_prop_rw(
+            "this_ref",
+            &NativeCallRuntimeOptions::get_this,
+            &NativeCallRuntimeOptions::set_this,
+            D_NA(NativeCallRuntimeOptions, this_ref)
         )
         .def_prop_rw(
             "cuda_stream",

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -127,6 +127,7 @@ private:
 
 /// Nanobind trampoline class for NativeObject
 class PyNativeObject : public NativeObject {
+    SGL_OBJECT(PyNativeObject)
 public:
     NB_TRAMPOLINE(NativeObject, 1);
 
@@ -529,6 +530,7 @@ private:
 /// Binding information for a call to a compute kernel. Includes a set of positional
 /// and keyword arguments as bound variables.
 class NativeBoundCallRuntime : Object {
+    SGL_OBJECT(NativeBoundCallRuntime)
 public:
     NativeBoundCallRuntime() = default;
 
@@ -579,6 +581,7 @@ private:
 };
 
 class NativeCallRuntimeOptions : Object {
+    SGL_OBJECT(NativeCallRuntimeOptions)
 public:
     /// Get the uniforms.
     nb::list get_uniforms() const { return m_uniforms; }
@@ -597,6 +600,13 @@ public:
 
     /// Set the CUDA stream.
     void set_cuda_stream(NativeHandle cuda_stream) { m_cuda_stream = cuda_stream; }
+
+    /// Clear internal data for garbage collection
+    void clear()
+    {
+        m_uniforms.clear();
+        m_this = nb::none();
+    }
 
 private:
     nb::list m_uniforms;
@@ -622,6 +632,7 @@ private:
 /// Contains the compute kernel for a call, the corresponding bindings and any additional
 /// options provided by the user.
 class NativeCallData : Object {
+    SGL_OBJECT(NativeCallData)
 public:
     NativeCallData() = default;
 
@@ -778,6 +789,8 @@ typedef std::function<bool(const ref<SignatureBuilder>& builder, nb::handle)> Bu
 
 /// Native side of system for caching call data info for given function signatures.
 class NativeCallDataCache : Object {
+    SGL_OBJECT(NativeCallDataCache)
+
 public:
     NativeCallDataCache();
 

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -602,7 +602,7 @@ public:
     void set_cuda_stream(NativeHandle cuda_stream) { m_cuda_stream = cuda_stream; }
 
     /// Clear internal data for garbage collection
-    void clear()
+    void garbage_collect()
     {
         m_uniforms.clear();
         m_this = nb::none();

--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -7,9 +7,20 @@
 
 namespace sgl {
 
+template<>
+struct GcHelper<slangpy::NativeFunctionNode> {
+    void traverse(slangpy::NativeFunctionNode*, GcVisitor& visitor)
+    {
+        visitor("_native_data");
+        visitor("_native_parent");
+    }
+    void clear(slangpy::NativeFunctionNode* node) { node->garbage_collect(); }
+};
+
 } // namespace sgl
 
 namespace sgl::slangpy {
+
 
 ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
 {
@@ -128,7 +139,11 @@ SGL_PY_EXPORT(utils_slangpy_function)
 
     nb::sgl_enum<FunctionNodeType>(slangpy, "FunctionNodeType");
 
-    nb::class_<NativeFunctionNode, PyNativeFunctionNode, NativeObject>(slangpy, "NativeFunctionNode")
+    nb::class_<NativeFunctionNode, PyNativeFunctionNode, NativeObject>(
+        slangpy,
+        "NativeFunctionNode",
+        gc_helper_type_slots<NativeFunctionNode>()
+    )
         .def(
             "__init__",
             [](NativeFunctionNode& self,

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -31,6 +31,7 @@ SGL_ENUM_INFO(
 SGL_ENUM_REGISTER(FunctionNodeType);
 
 class NativeFunctionNode : NativeObject {
+    SGL_OBJECT(NativeFunctionNode)
 public:
     NativeFunctionNode(NativeFunctionNode* parent, FunctionNodeType type, nb::object data)
         : m_parent(parent)
@@ -106,6 +107,12 @@ public:
         SGL_UNUSED(args);
         SGL_UNUSED(kwargs);
         return nullptr;
+    }
+
+    void garbage_collect()
+    {
+        m_parent = nullptr;
+        m_data = nb::none();
     }
 
 private:

--- a/src/slangpy_ext/utils/slangpypackedarg.h
+++ b/src/slangpy_ext/utils/slangpypackedarg.h
@@ -16,6 +16,7 @@ namespace sgl::slangpy {
 class NativeMarshall;
 
 class NativePackedArg : public NativeObject {
+    SGL_OBJECT(NativePackedArg)
 public:
     NativePackedArg(ref<NativeMarshall> python, ref<ShaderObject> shader_object, nb::object python_object)
         : m_python(std::move(python))

--- a/src/slangpy_ext/utils/slangpystridedbufferview.h
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.h
@@ -29,6 +29,7 @@ struct StridedBufferViewDesc {
 };
 
 class StridedBufferView : public NativeObject {
+    SGL_OBJECT(StridedBufferView)
 public:
     StridedBufferView(Device* device, const StridedBufferViewDesc& desc, ref<Buffer> storage);
     virtual ~StridedBufferView() { }


### PR DESCRIPTION
- Fixed use of 'type.name' in type lookups
- Fixed ability for buffer to cause internal lookups to be associated with the wrong cache
- Properly labelled a load of native objects
- Code to log heap status to text
- Add python GC visitors to some slangpy types