### PR TITLE
Clang 20 fixes

### DIFF
--- a/src/sgl/CMakeLists.txt
+++ b/src/sgl/CMakeLists.txt
@@ -220,13 +220,19 @@ target_compile_options(sgl
         >
         # Clang flags.
         $<$<CXX_COMPILER_ID:Clang>:
+            -Wno-unknown-warning-option
             -Wno-unused-private-field
             -Wno-braced-scalar-init
             -Wno-self-assign-overloaded
             -Wno-deprecated-copy
+            -Wno-microsoft-cast
+
+            # this is for ImGUI only
+            -Wno-nontrivial-memcall
         >
         # GCC flags.
         $<$<CXX_COMPILER_ID:GNU>:
+            -Wno-unknown-warning
             -Wno-literal-suffix
             -Wno-class-memaccess
             -Wno-strict-aliasing

--- a/src/sgl/core/macros.h
+++ b/src/sgl/core/macros.h
@@ -15,7 +15,7 @@
  * http://sourceforge.net/p/predef/wiki/Compilers/
  */
 #ifndef SGL_COMPILER
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 #define SGL_COMPILER SGL_COMPILER_MSVC
 #elif defined(__clang__)
 #define SGL_COMPILER SGL_COMPILER_CLANG

--- a/src/sgl/math/constants.h
+++ b/src/sgl/math/constants.h
@@ -5,3 +5,8 @@
 #include <cmath>
 #include <cstdint>
 #include <cfloat>
+
+// We should move away from M_ constants, but for now fix issues when compiling with latest clang
+#ifndef M_PI
+#define M_PI (3.14159265358979323846)
+#endif

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -886,6 +886,8 @@ namespace {
         case slang::TypeReflection::Kind::Vector:
             return Py_ssize_t(slang_type_layout->getColumnCount());
             break;
+        default:
+            break;
         }
 
         return 0;


### PR DESCRIPTION
Fixes to allow slangpy to compiled on latest clang (on Windows).