### PR TITLE
Use compute pipeline

### DIFF
--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -329,7 +329,9 @@ class CallData(NativeCallData):
                     [ep],
                     opts,
                 )
-                self.compute_pipeline = device.create_compute_pipeline(program)
+                self.compute_pipeline = device.create_compute_pipeline(
+                    program, defer_target_compilation=True
+                )
                 build_info.module.compute_pipeline_cache[hash] = self.compute_pipeline
                 self.device = device
                 self.log_debug(f"  Build succesful")

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -308,15 +308,15 @@ class CallData(NativeCallData):
             hash = hashlib.sha256(code_minus_header.encode()).hexdigest()
 
             # Check if we've already built this module.
-            if hash in build_info.module.kernel_cache:
-                # Get kernel from cache if we have
-                self.kernel = build_info.module.kernel_cache[hash]
+            if hash in build_info.module.compute_pipeline_cache:
+                # Get pipeline from cache if we have
+                self.compute_pipeline = build_info.module.compute_pipeline_cache[hash]
                 self.device = build_info.module.device
-                self.log_debug(f"  Found cached kernel with hash {hash}")
+                self.log_debug(f"  Found cached pipeline with hash {hash}")
 
             else:
                 # Build new module and link it with the one that contains the function being called.
-                self.log_debug(f"  Building new kernel with hash {hash}")
+                self.log_debug(f"  Building new pipeline with hash {hash}")
                 session = build_info.module.session
                 device = session.device
                 module = session.load_module_from_source(hash, code)
@@ -329,8 +329,8 @@ class CallData(NativeCallData):
                     [ep],
                     opts,
                 )
-                self.kernel = device.create_compute_kernel(program)
-                build_info.module.kernel_cache[hash] = self.kernel
+                self.compute_pipeline = device.create_compute_pipeline(program)
+                build_info.module.compute_pipeline_cache[hash] = self.compute_pipeline
                 self.device = device
                 self.log_debug(f"  Build succesful")
 

--- a/slangpy/core/dispatchdata.py
+++ b/slangpy/core/dispatchdata.py
@@ -197,8 +197,9 @@ void {reflection.name}_entrypoint({params}) {{
                     [ep],
                     opts,
                 )
-
-                self.compute_pipeline = device.create_compute_pipeline(program)
+                self.compute_pipeline = device.create_compute_pipeline(
+                    program, defer_target_compilation=True
+                )
                 self.device = device
 
         except Exception as e:

--- a/slangpy/core/dispatchdata.py
+++ b/slangpy/core/dispatchdata.py
@@ -9,7 +9,7 @@ from slangpy.core.enums import IOType
 from slangpy.core.native import CallMode, CallDataMode, pack_arg, unpack_arg
 from slangpy.core.calldata import _DUMP_SLANG_INTERMEDIATES, _DUMP_GENERATED_SHADERS
 
-from slangpy import CommandEncoder, SlangLinkOptions, uint3, DeviceType
+from slangpy import CommandEncoder, ShaderCursor, SlangLinkOptions, uint3, DeviceType
 from slangpy.core.native import NativeCallRuntimeOptions
 from slangpy.bindings.marshall import BindContext
 from slangpy.bindings.boundvariable import BoundCall
@@ -174,9 +174,9 @@ void {reflection.name}_entrypoint({params}) {{
             hash = hashlib.sha256(code_minus_header.encode()).hexdigest()
 
             # Check if we've already built this module.
-            if hash in build_info.module.kernel_cache:
-                # Get kernel from cache if we have
-                self.kernel = build_info.module.kernel_cache[hash]
+            if hash in build_info.module.compute_pipeline_cache:
+                # Get pipeline from cache if we have
+                self.compute_pipeline = build_info.module.compute_pipeline_cache[hash]
                 self.device = build_info.module.device
             else:
                 # Load the module
@@ -198,7 +198,7 @@ void {reflection.name}_entrypoint({params}) {{
                     opts,
                 )
 
-                self.kernel = device.create_compute_kernel(program)
+                self.compute_pipeline = device.create_compute_pipeline(program)
                 self.device = device
 
         except Exception as e:
@@ -230,8 +230,24 @@ void {reflection.name}_entrypoint({params}) {{
         call_data = {}
         self.runtime.write_raw_dispatch_data(call_data, unpacked_kwargs)
 
-        # Call dispatch
-        self.kernel.dispatch(thread_count, uniforms, command_encoder, **call_data)
+        # Create temporary command encoder if none is provided
+        temp_command_encoder: Optional[CommandEncoder] = None
+        if command_encoder is None:
+            temp_command_encoder = self.device.create_command_encoder()
+            command_encoder = temp_command_encoder
+
+        # Dispatch kernel
+        compute_pass = command_encoder.begin_compute_pass()
+        cursor = ShaderCursor(compute_pass.bind_pipeline(self.compute_pipeline))
+        cursor.write(uniforms)
+        cursor.find_entry_point(0).write(call_data)
+        compute_pass.dispatch(thread_count)
+        compute_pass.end()
+
+        # Submit if we created a temporary command encoder
+        if temp_command_encoder is not None:
+            self.device.submit_command_buffer(temp_command_encoder.finish())
+            command_encoder = None
 
         # If just adding to command encoder, post dispatch is redundant
         if command_encoder is not None:

--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, Sequence
 from slangpy.core.function import Function
 from slangpy.core.struct import Struct
 
-from slangpy import ComputeKernel, SlangModule, Device, Logger
+from slangpy import ComputePipeline, SlangModule, Device, Logger
 from slangpy.core.native import NativeCallDataCache
 from slangpy.reflection import SlangProgramLayout
 from slangpy.bindings.typeregistry import PYTHON_SIGNATURES
@@ -73,7 +73,7 @@ class Module:
 
         self.call_data_cache = CallDataCache()
         self.dispatch_data_cache: dict[str, "DispatchData"] = {}
-        self.kernel_cache: dict[str, ComputeKernel] = {}
+        self.compute_pipeline_cache: dict[str, ComputePipeline] = {}
         self.logger: Optional[Logger] = None
 
         self._attr_cache: dict[str, Union[Function, Struct]] = {}
@@ -210,7 +210,7 @@ class Module:
         # Clear all caches
         self.call_data_cache = CallDataCache()
         self.dispatch_data_cache = {}
-        self.kernel_cache = {}
+        self.compute_pipeline_cache = {}
         self._attr_cache = {}
 
     def __getattr__(self, name: str):

--- a/slangpy/tests/slangpy_tests/test_caching.py
+++ b/slangpy/tests/slangpy_tests/test_caching.py
@@ -42,7 +42,7 @@ def test_scalar_types(device_type: DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_share_kernel_with_same_mapping(device_type: DeviceType):
+def test_share_compute_pipeline_with_same_mapping(device_type: DeviceType):
     device = helpers.get_device(device_type)
     m = load_test_module(device_type)
     assert m is not None
@@ -55,7 +55,7 @@ def test_share_kernel_with_same_mapping(device_type: DeviceType):
     float_float_cd = func.debug_build_call_data(b0, b1)
     mapped_float_float_cd = func.map((0,), (0,)).debug_build_call_data(b0, b1)
     assert float_float_cd != mapped_float_float_cd
-    assert float_float_cd.kernel == mapped_float_float_cd.kernel
+    assert float_float_cd.compute_pipeline == mapped_float_float_cd.compute_pipeline
 
 
 if __name__ == "__main__":

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -9,7 +9,7 @@
 #include "sgl/core/logger.h"
 #include "sgl/utils/slangpy.h"
 #include "sgl/device/device.h"
-#include "sgl/device/kernel.h"
+#include "sgl/device/pipeline.h"
 #include "sgl/device/command.h"
 #include "sgl/stl/bit.h" // Replace with <bit> when available on all platforms.
 
@@ -570,8 +570,45 @@ nb::object NativeCallData::exec(
 
     nb::list read_back;
 
-    // Dispatch the kernel.
-    auto bind_vars = [&](ShaderCursor cursor)
+    if (is_log_enabled(LogLevel::debug)) {
+        log_debug("Dispatching {}", m_debug_name);
+        log_debug("  Call type: {}", command_encoder ? "append" : "call");
+        log_debug("  Call shape: {}", call_shape.to_string());
+        log_debug("  Call mode: {}", m_call_mode);
+        log_debug("  Strides: [{}]", fmt::join(strides, ", "));
+        log_debug("  Call grid shape: [{}]", fmt::join(call_grid_shape, ", "));
+        log_debug("  Call grid strides: [{}]", fmt::join(call_grid_strides, ", "));
+        log_debug("  Call group shape: [{}]", fmt::join(call_group_shape, ", "));
+        log_debug("  Call group strides: [{}]", fmt::join(call_group_strides, ", "));
+        if (is_call_shape_unaligned) {
+            log_debug("  Call shape was not aligned to the given call group shape");
+            log_debug("  and has been padded up as a result. Note that this will");
+            log_debug("  result in wasted threads.");
+            log_debug("  Aligned call shape: [{}]", fmt::join(aligned_call_shape, ", "));
+        }
+        log_debug("  Threads: {}", total_threads);
+    }
+
+    // If CUDA stream is provided, check for valid use and sync device to the CUDA stream
+    NativeHandle cuda_stream = opts->get_cuda_stream();
+    if (cuda_stream.is_valid()) {
+        SGL_CHECK(command_encoder == nullptr, "Cannot specify a CUDA stream when appending to a command encoder.");
+        SGL_CHECK(
+            m_device->supports_cuda_interop() || m_device->type() == DeviceType::cuda,
+            "To specify a CUDA stream, device must be either using CUDA backend or have CUDA interop enabled."
+        );
+    }
+
+    // Create temporary command encoder if none is provided.
+    ref<CommandEncoder> temp_command_encoder;
+    if (command_encoder == nullptr) {
+        temp_command_encoder = m_device->create_command_encoder();
+        command_encoder = temp_command_encoder.get();
+    }
+
+    ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
+    ShaderCursor cursor(pass_encoder->bind_pipeline(m_compute_pipeline));
+    // Bind call data
     {
         // Get the call data cursor, either as an entry point parameter or global depending on call data mode
         ShaderCursor call_data_cursor;
@@ -626,46 +663,17 @@ nb::object NativeCallData::exec(
                 }
             }
         }
-    };
+    }
+    pass_encoder->dispatch(uint3(total_threads, 1, 1));
+    pass_encoder->end();
 
-    if (is_log_enabled(LogLevel::debug)) {
-        log_debug("Dispatching {}", m_debug_name);
-        log_debug("  Call type: {}", command_encoder ? "append" : "call");
-        log_debug("  Call shape: {}", call_shape.to_string());
-        log_debug("  Call mode: {}", m_call_mode);
-        log_debug("  Strides: [{}]", fmt::join(strides, ", "));
-        log_debug("  Call grid shape: [{}]", fmt::join(call_grid_shape, ", "));
-        log_debug("  Call grid strides: [{}]", fmt::join(call_grid_strides, ", "));
-        log_debug("  Call group shape: [{}]", fmt::join(call_group_shape, ", "));
-        log_debug("  Call group strides: [{}]", fmt::join(call_group_strides, ", "));
-        if (is_call_shape_unaligned) {
-            log_debug("  Call shape was not aligned to the given call group shape");
-            log_debug("  and has been padded up as a result. Note that this will");
-            log_debug("  result in wasted threads.");
-            log_debug("  Aligned call shape: [{}]", fmt::join(aligned_call_shape, ", "));
-        }
-        log_debug("  Threads: {}", total_threads);
+    // If we created a temporary command encoder, we need to submit it.
+    if (temp_command_encoder) {
+        m_device->submit_command_buffer(temp_command_encoder->finish(), CommandQueueType::graphics, cuda_stream);
+        command_encoder = nullptr;
     }
 
-    // If CUDA stream is provided, check for valid use and sync device to the CUDA stream
-    NativeHandle cuda_stream = opts->get_cuda_stream();
-    if (cuda_stream.is_valid()) {
-        SGL_CHECK(command_encoder == nullptr, "Cannot specify a CUDA stream when appending to a command encoder.");
-        SGL_CHECK(
-            m_device->supports_cuda_interop() || m_device->type() == DeviceType::cuda,
-            "To specify a CUDA stream, device must be either using CUDA backend or have CUDA interop enabled."
-        );
-    }
-
-    if (command_encoder == nullptr) {
-        // If we are not appending to a command encoder, we can dispatch directly.
-        m_kernel->dispatch(uint3(total_threads, 1, 1), bind_vars, CommandQueueType::graphics, cuda_stream);
-    } else {
-        // If we are appending to a command encoder, we need to use the command encoder.
-        m_kernel->dispatch(uint3(total_threads, 1, 1), bind_vars, command_encoder);
-    }
-
-    // If command_buffer is not null, return early.
+    // If command_encoder is not null, return early.
     if (command_encoder != nullptr) {
         return nanobind::none();
     }
@@ -1305,7 +1313,12 @@ SGL_PY_EXPORT(utils_slangpy)
             D_NA(NativeCallData, NativeCallData)
         )
         .def_prop_rw("device", &NativeCallData::get_device, &NativeCallData::set_device, D_NA(NativeCallData, device))
-        .def_prop_rw("kernel", &NativeCallData::get_kernel, &NativeCallData::set_kernel, D_NA(NativeCallData, kernel))
+        .def_prop_rw(
+            "compute_pipeline",
+            &NativeCallData::get_compute_pipeline,
+            &NativeCallData::set_compute_pipeline,
+            D_NA(NativeCallData, compute_pipeline)
+        )
         .def_prop_rw(
             "call_dimensionality",
             &NativeCallData::get_call_dimensionality,

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -607,9 +607,9 @@ nb::object NativeCallData::exec(
     }
 
     ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
-    ShaderCursor cursor(pass_encoder->bind_pipeline(m_compute_pipeline));
-    // Bind call data
+    // Bind pipeline & call data
     {
+        ShaderCursor cursor(pass_encoder->bind_pipeline(m_compute_pipeline));
         // Get the call data cursor, either as an entry point parameter or global depending on call data mode
         ShaderCursor call_data_cursor;
         if (m_call_data_mode == CallDataMode::entry_point) {

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -629,7 +629,7 @@ private:
         log(level, fmt::format(fmt, std::forward<Args>(args)...), LogFrequency::always);                               \
     }
 
-/// Contains the compute kernel for a call, the corresponding bindings and any additional
+/// Contains the compute pipeline for a call, the corresponding bindings and any additional
 /// options provided by the user.
 class NativeCallData : Object {
     SGL_OBJECT(NativeCallData)
@@ -642,11 +642,11 @@ public:
     /// Set the device.
     void set_device(const ref<Device>& device) { m_device = device; }
 
-    /// Get the compute kernel.
-    ref<ComputeKernel> get_kernel() const { return m_kernel; }
+    /// Get the compute pipeline.
+    ref<ComputePipeline> get_compute_pipeline() const { return m_compute_pipeline; }
 
-    /// Set the compute kernel.
-    void set_kernel(const ref<ComputeKernel>& kernel) { m_kernel = kernel; }
+    /// Set the compute pipeline.
+    void set_compute_pipeline(const ref<ComputePipeline>& pipeline) { m_compute_pipeline = pipeline; }
 
     /// Get the call dimensionality.
     int get_call_dimensionality() const { return m_call_dimensionality; }
@@ -759,7 +759,7 @@ public:
 
 private:
     ref<Device> m_device;
-    ref<ComputeKernel> m_kernel;
+    ref<ComputePipeline> m_compute_pipeline;
     int m_call_dimensionality{0};
     ref<NativeBoundCallRuntime> m_runtime;
     CallMode m_call_mode{CallMode::prim};


### PR DESCRIPTION
Replaces use of `ComputeKernel` with `ComputePipeline`. This is in preparation of supporting raytracing pipelines in slangpy.