### PR TITLE
ci-latest-slang branch option

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -65,7 +65,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
+          # Cache not needed on self-hosted runners
+          # cache: 'pip'
 
       # Setup Python environment.
       - name: Setup Python environment

--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 1 * * *' # run at 1 AM UTC
   workflow_dispatch:
+    inputs:
+      slang_branch:
+        description: 'Slang branch'
+        required: true
+        default: 'master'
 
 permissions:
   contents: read
@@ -83,11 +88,13 @@ jobs:
       - name: Setup CMake/Ninja
         uses: lukka/get-cmake@latest
 
-      # Build latest Slang.
-      - name: Build latest Slang
+      # Build Slang.
+      - name: Build Slang
         run: |
           git clone --recursive https://github.com/shader-slang/slang.git
           cd slang
+          git checkout ${{ github.event.inputs.slang_branch }}
+          git submodule update --init --recursive
           mkdir build
           cmake -B build --preset default
           cmake --build build --config ${{ matrix.config }} --parallel

--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -65,8 +65,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          # Cache not needed on self-hosted runners
-          # cache: 'pip'
 
       # Setup Python environment.
       - name: Setup Python environment

--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -89,13 +89,18 @@ jobs:
       - name: Setup CMake/Ninja
         uses: lukka/get-cmake@latest
 
-      # Build Slang.
-      - name: Build Slang
+      # Checkout Slang.
+      - name: Checkout Slang
         run: |
           git clone --recursive https://github.com/shader-slang/slang.git
           cd slang
           git checkout ${{ github.event.inputs.slang_branch }}
           git submodule update --init --recursive
+
+      # Build Slang.
+      - name: Build Slang
+        run: |
+          cd slang
           mkdir build
           cmake -B build --preset default
           cmake --build build --config ${{ matrix.config }} --parallel


### PR DESCRIPTION
- Add a `slang_branch` option to `ci-latest-slang` workflow to allow testing against arbitrary version of slang.
- Remove pip cache which harms self-hosted runners (they have a persistent pip cache) as well as macos hosted runners, where the install from scratch is slightly faster
- Split "Build Slang" step into separate "Checkout Slang" and "Build Slang" steps