### PR TITLE
Initial support for ray tracing pipelines

### DIFF
--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -2,10 +2,11 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 from slangpy.core.native import AccessType, CallMode, CallDataMode, NativeMarshall
+from slangpy.core.function import PipelineType
 
 import slangpy.bindings.typeregistry as tr
 import slangpy.reflection as slr
-from slangpy import ModifierID, TypeReflection, DeviceType
+from slangpy import ModifierID, TypeReflection
 from slangpy.bindings.marshall import Marshall, BindContext, ReturnContext
 from slangpy.bindings.boundvariable import (
     BoundCall,
@@ -597,23 +598,35 @@ def generate_code(
     cg.trampoline.append_line("")
 
     # Generate the main function
-    cg.kernel.append_line('[shader("compute")]')
-    if call_group_size != 1:
-        cg.kernel.append_line(f"[numthreads({call_group_size}, 1, 1)]")
+    if build_info.pipeline_type == PipelineType.compute:
+        cg.kernel.append_line('[shader("compute")]')
+        if call_group_size != 1:
+            cg.kernel.append_line(f"[numthreads({call_group_size}, 1, 1)]")
+        else:
+            cg.kernel.append_line("[numthreads(32, 1, 1)]")
+        # Note: While flat_call_thread_id is 3-dimensional, we consider it "flat" and 1-dimensional because of the
+        #       true call group shape of [x, 1, 1] and only use the first dimension for the call thread id.
+        if is_entry_point:
+            cg.kernel.append_line(
+                "void compute_main(int3 flat_call_thread_id: SV_DispatchThreadID, int3 flat_call_group_id: SV_GroupID, int flat_call_group_thread_id: SV_GroupIndex, uniform CallData call_data)"
+            )
+        else:
+            cg.kernel.append_line(
+                "void compute_main(int3 flat_call_thread_id: SV_DispatchThreadID, int3 flat_call_group_id: SV_GroupID, int flat_call_group_thread_id: SV_GroupIndex)"
+            )
+    elif build_info.pipeline_type == PipelineType.ray_tracing:
+        cg.kernel.append_line('[shader("raygen")]')
+        if is_entry_point:
+            cg.kernel.append_line("void raygen_main(uniform CallData call_data)")
+        else:
+            cg.kernel.append_line("void raygen_main()")
     else:
-        cg.kernel.append_line("[numthreads(32, 1, 1)]")
+        raise RuntimeError(f"Unknown pipeline type: {build_info.pipeline_type}")
 
-    # Note: While flat_call_thread_id is 3-dimensional, we consider it "flat" and 1-dimensional because of the
-    #       true call group shape of [x, 1, 1] and only use the first dimension for the call thread id.
-    if is_entry_point:
-        cg.kernel.append_line(
-            "void compute_main(int3 flat_call_thread_id: SV_DispatchThreadID, int3 flat_call_group_id: SV_GroupID, int flat_call_group_thread_id: SV_GroupIndex, CallData call_data)"
-        )
-    else:
-        cg.kernel.append_line(
-            "void compute_main(int3 flat_call_thread_id: SV_DispatchThreadID, int3 flat_call_group_id: SV_GroupID, int flat_call_group_thread_id: SV_GroupIndex)"
-        )
     cg.kernel.begin_block()
+
+    if build_info.pipeline_type == PipelineType.ray_tracing:
+        cg.kernel.append_statement("int3 flat_call_thread_id = DispatchRaysIndex();")
 
     cg.kernel.append_statement("if (any(flat_call_thread_id >= call_data._thread_count)) return")
 
@@ -623,14 +636,22 @@ def generate_code(
     # Call init_thread_local_call_shape_info to initialize the call shape info. See
     # definition in callshape.slang.
     if call_data_len > 0:
-        cg.kernel.append_line(
-            f"""
-        if (!init_thread_local_call_shape_info(flat_call_group_thread_id,
-            flat_call_group_id, flat_call_thread_id, call_data._grid_stride,
-            call_data._grid_dim, call_data._call_dim))
-            return;"""
-        )
-
+        if build_info.pipeline_type == PipelineType.compute:
+            cg.kernel.append_line(
+                f"""
+    if (!init_thread_local_call_shape_info(flat_call_group_thread_id,
+        flat_call_group_id, flat_call_thread_id, call_data._grid_stride,
+        call_data._grid_dim, call_data._call_dim))
+        return;"""
+            )
+        elif build_info.pipeline_type == PipelineType.ray_tracing:
+            cg.kernel.append_line(
+                f"""
+    if (!init_thread_local_call_shape_info(0,
+        uint3(0), flat_call_thread_id, call_data._grid_stride,
+        call_data._grid_dim, call_data._call_dim))
+        return;"""
+            )
         context_args += ", CallShapeInfo::get_call_id().shape"
 
     cg.kernel.append_statement(f"Context __slangpy_context__ = {{{context_args}}}")

--- a/slangpy/core/dispatchdata.py
+++ b/slangpy/core/dispatchdata.py
@@ -9,7 +9,14 @@ from slangpy.core.enums import IOType
 from slangpy.core.native import CallMode, CallDataMode, pack_arg, unpack_arg
 from slangpy.core.calldata import _DUMP_SLANG_INTERMEDIATES, _DUMP_GENERATED_SHADERS
 
-from slangpy import CommandEncoder, ShaderCursor, SlangLinkOptions, uint3, DeviceType
+from slangpy import (
+    CommandEncoder,
+    ComputePipeline,
+    ShaderCursor,
+    SlangLinkOptions,
+    uint3,
+    DeviceType,
+)
 from slangpy.core.native import NativeCallRuntimeOptions
 from slangpy.bindings.marshall import BindContext
 from slangpy.bindings.boundvariable import BoundCall
@@ -174,9 +181,12 @@ void {reflection.name}_entrypoint({params}) {{
             hash = hashlib.sha256(code_minus_header.encode()).hexdigest()
 
             # Check if we've already built this module.
-            if hash in build_info.module.compute_pipeline_cache:
+            if hash in build_info.module.pipeline_cache:
                 # Get pipeline from cache if we have
-                self.compute_pipeline = build_info.module.compute_pipeline_cache[hash]
+                pipeline = build_info.module.pipeline_cache[hash]
+                if not isinstance(pipeline, ComputePipeline):
+                    raise RuntimeError("Pipeline cache entry is not a ComputePipeline")
+                self.compute_pipeline = pipeline
                 self.device = build_info.module.device
             else:
                 # Load the module

--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, Sequence
 from slangpy.core.function import Function
 from slangpy.core.struct import Struct
 
-from slangpy import ComputePipeline, SlangModule, Device, Logger
+from slangpy import Pipeline, ShaderTable, SlangModule, Device, Logger
 from slangpy.core.native import NativeCallDataCache
 from slangpy.reflection import SlangProgramLayout
 from slangpy.bindings.typeregistry import PYTHON_SIGNATURES
@@ -73,7 +73,8 @@ class Module:
 
         self.call_data_cache = CallDataCache()
         self.dispatch_data_cache: dict[str, "DispatchData"] = {}
-        self.compute_pipeline_cache: dict[str, ComputePipeline] = {}
+        self.pipeline_cache: dict[str, Pipeline] = {}
+        self.shader_table_cache: dict[str, ShaderTable] = {}
         self.logger: Optional[Logger] = None
 
         self._attr_cache: dict[str, Union[Function, Struct]] = {}
@@ -210,7 +211,8 @@ class Module:
         # Clear all caches
         self.call_data_cache = CallDataCache()
         self.dispatch_data_cache = {}
-        self.compute_pipeline_cache = {}
+        self.pipeline_cache = {}
+        self.shader_table_cache = {}
         self._attr_cache = {}
 
     def __getattr__(self, name: str):

--- a/slangpy/tests/slangpy_tests/test_caching.py
+++ b/slangpy/tests/slangpy_tests/test_caching.py
@@ -55,7 +55,7 @@ def test_share_compute_pipeline_with_same_mapping(device_type: DeviceType):
     float_float_cd = func.debug_build_call_data(b0, b1)
     mapped_float_float_cd = func.map((0,), (0,)).debug_build_call_data(b0, b1)
     assert float_float_cd != mapped_float_float_cd
-    assert float_float_cd.compute_pipeline == mapped_float_float_cd.compute_pipeline
+    assert float_float_cd.pipeline == mapped_float_float_cd.pipeline
 
 
 if __name__ == "__main__":

--- a/slangpy/tests/slangpy_tests/test_raytracing.py
+++ b/slangpy/tests/slangpy_tests/test_raytracing.py
@@ -100,6 +100,11 @@ def build_tlas(
 def test_raytracing(device_type: DeviceType):
     device = helpers.get_device(device_type)
 
+    if not device.has_feature(spy.Feature.acceleration_structure):
+        pytest.skip("Acceleration structures not supported on this device")
+    if not device.has_feature(spy.Feature.ray_tracing):
+        pytest.skip("Ray tracing not supported on this device")
+
     vertices = np.array([-1, -1, 0, 1, -1, 0, -1, 1, 0], dtype=np.float32)
     indices = np.array([0, 1, 2], dtype=np.uint32)
     blas = build_blas(device, vertices, indices)

--- a/slangpy/tests/slangpy_tests/test_raytracing.py
+++ b/slangpy/tests/slangpy_tests/test_raytracing.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import numpy as np
+
+import slangpy as spy
+from slangpy import DeviceType, Module
+from slangpy.types.tensor import Tensor
+from slangpy.testing import helpers
+
+
+def build_blas(
+    device: spy.Device, vertices: np.ndarray, indices: np.ndarray
+) -> spy.AccelerationStructure:
+    vertex_buffer = device.create_buffer(
+        usage=spy.BufferUsage.shader_resource,
+        label="vertex_buffer",
+        data=vertices,
+    )
+
+    index_buffer = device.create_buffer(
+        usage=spy.BufferUsage.shader_resource,
+        label="index_buffer",
+        data=indices,
+    )
+
+    blas_input_triangles = spy.AccelerationStructureBuildInputTriangles(
+        {
+            "vertex_buffers": [vertex_buffer],
+            "vertex_format": spy.Format.rgb32_float,
+            "vertex_count": vertices.size // 3,
+            "vertex_stride": vertices.itemsize * 3,
+            "index_buffer": index_buffer,
+            "index_format": spy.IndexFormat.uint32,
+            "index_count": indices.size,
+            "flags": spy.AccelerationStructureGeometryFlags.opaque,
+        }
+    )
+
+    blas_build_desc = spy.AccelerationStructureBuildDesc(
+        {
+            "inputs": [blas_input_triangles],
+        }
+    )
+
+    blas_sizes = device.get_acceleration_structure_sizes(blas_build_desc)
+
+    blas_scratch_buffer = device.create_buffer(
+        size=blas_sizes.scratch_size,
+        usage=spy.BufferUsage.unordered_access,
+        label="blas_scratch_buffer",
+    )
+
+    blas = device.create_acceleration_structure(
+        size=blas_sizes.acceleration_structure_size,
+        label="blas",
+    )
+
+    command_encoder = device.create_command_encoder()
+    command_encoder.build_acceleration_structure(
+        desc=blas_build_desc, dst=blas, src=None, scratch_buffer=blas_scratch_buffer
+    )
+    device.submit_command_buffer(command_encoder.finish())
+
+    return blas
+
+
+def build_tlas(
+    device: spy.Device, instance_list: spy.AccelerationStructureInstanceList
+) -> spy.AccelerationStructure:
+    tlas_build_desc = spy.AccelerationStructureBuildDesc(
+        {
+            "inputs": [instance_list.build_input_instances()],
+        }
+    )
+
+    tlas_sizes = device.get_acceleration_structure_sizes(tlas_build_desc)
+
+    tlas_scratch_buffer = device.create_buffer(
+        size=tlas_sizes.scratch_size,
+        usage=spy.BufferUsage.unordered_access,
+        label="tlas_scratch_buffer",
+    )
+
+    tlas = device.create_acceleration_structure(
+        size=tlas_sizes.acceleration_structure_size,
+        label="tlas",
+    )
+
+    command_encoder = device.create_command_encoder()
+    command_encoder.build_acceleration_structure(
+        desc=tlas_build_desc, dst=tlas, src=None, scratch_buffer=tlas_scratch_buffer
+    )
+    device.submit_command_buffer(command_encoder.finish())
+
+    return tlas
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_raytracing(device_type: DeviceType):
+    device = helpers.get_device(device_type)
+
+    vertices = np.array([-1, -1, 0, 1, -1, 0, -1, 1, 0], dtype=np.float32)
+    indices = np.array([0, 1, 2], dtype=np.uint32)
+    blas = build_blas(device, vertices, indices)
+
+    instance_list = device.create_acceleration_structure_instance_list(1)
+    instance_list.write(
+        0,
+        {
+            "transform": spy.float3x4.identity(),
+            "instance_id": 0,
+            "instance_mask": 0xFF,
+            "instance_contribution_to_hit_group_index": 0,
+            "flags": spy.AccelerationStructureInstanceFlags.none,
+            "acceleration_structure": blas.handle,
+        },
+    )
+    tlas = build_tlas(device, instance_list)
+
+    tensor = Tensor.zeros(device, (64, 64, 3), dtype=float)
+    module = Module(device.load_module("test_raytracing.slang"))
+
+    module.trace.ray_tracing(
+        hit_groups=[{"hit_group_name": "hit_group", "closest_hit_entry_point": "closest_hit"}],
+        miss_entry_points=["miss"],
+        max_recursion=1,
+        max_ray_payload_size=12,
+    )(tid=spy.call_id(), tlas=tlas, _result=tensor)
+
+    data = tensor.to_numpy()
+
+    spy.tev.show(spy.Bitmap(data))
+
+    assert np.allclose(data[0, 0, :], [0, 0, 0], atol=0.01)
+    assert np.allclose(data[0, 63, :], [1, 0, 0], atol=0.01)
+    assert np.allclose(data[63, 0, :], [0, 1, 0], atol=0.01)
+    assert np.allclose(data[63, 63, :], [1, 0, 1], atol=0.01)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/slangpy_tests/test_raytracing.py
+++ b/slangpy/tests/slangpy_tests/test_raytracing.py
@@ -135,7 +135,7 @@ def test_raytracing(device_type: DeviceType):
 
     data = tensor.to_numpy()
 
-    spy.tev.show(spy.Bitmap(data))
+    # spy.tev.show(spy.Bitmap(data))
 
     assert np.allclose(data[0, 0, :], [0, 0, 0], atol=0.01)
     assert np.allclose(data[0, 63, :], [1, 0, 0], atol=0.01)

--- a/slangpy/tests/slangpy_tests/test_raytracing.slang
+++ b/slangpy/tests/slangpy_tests/test_raytracing.slang
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import "slangpy";
+
+struct Payload { float3 color; };
+
+[shader("miss")]
+void miss(inout Payload payload)
+{
+    payload.color = float3(1, 0, 1);
+}
+
+[shader("closesthit")]
+void closest_hit(inout Payload payload, BuiltInTriangleIntersectionAttributes attribs)
+{
+    payload.color = float3(attribs.barycentrics, 0);
+}
+
+float3 trace(int2 tid, RaytracingAccelerationStructure tlas)
+{
+    float2 uv = (float2(tid) + 0.5) / 64.0;
+
+    RayDesc ray;
+    ray.Origin = float3(uv * 2 - 1, 1);
+    ray.Direction = float3(0, 0, -1);
+    ray.TMin = 0;
+    ray.TMax = 2;
+
+    Payload payload = {};
+
+    TraceRay(
+        tlas,
+        0,
+        0xff,
+        0 /* RayContributionToHitGroupIndex */,
+        0 /* MultiplierForGeometryContributionHitGroupIndex */,
+        0 /* MissShaderIndex */,
+        ray,
+        payload
+    );
+
+    return payload.color;
+}

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -599,17 +599,8 @@ nb::object NativeCallData::exec(
         );
     }
 
-    // Create temporary command encoder if none is provided.
-    ref<CommandEncoder> temp_command_encoder;
-    if (command_encoder == nullptr) {
-        temp_command_encoder = m_device->create_command_encoder();
-        command_encoder = temp_command_encoder.get();
-    }
-
-    ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
-    // Bind pipeline & call data
+    auto bind_call_data = [&](ShaderCursor cursor)
     {
-        ShaderCursor cursor(pass_encoder->bind_pipeline(m_compute_pipeline));
         // Get the call data cursor, either as an entry point parameter or global depending on call data mode
         ShaderCursor call_data_cursor;
         if (m_call_data_mode == CallDataMode::entry_point) {
@@ -663,9 +654,32 @@ nb::object NativeCallData::exec(
                 }
             }
         }
+    };
+
+    // Create temporary command encoder if none is provided.
+    ref<CommandEncoder> temp_command_encoder;
+    if (command_encoder == nullptr) {
+        temp_command_encoder = m_device->create_command_encoder();
+        command_encoder = temp_command_encoder.get();
     }
-    pass_encoder->dispatch(uint3(total_threads, 1, 1));
-    pass_encoder->end();
+
+    bool is_ray_tracing = opts->get_ray_tracing();
+
+    if (!is_ray_tracing) {
+        ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
+        ComputePipeline* pipeline = static_cast<ComputePipeline*>(m_pipeline.get());
+        ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline));
+        bind_call_data(cursor);
+        pass_encoder->dispatch(uint3(total_threads, 1, 1));
+        pass_encoder->end();
+    } else {
+        ref<RayTracingPassEncoder> pass_encoder = command_encoder->begin_ray_tracing_pass();
+        RayTracingPipeline* pipeline = static_cast<RayTracingPipeline*>(m_pipeline.get());
+        ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline, m_shader_table));
+        bind_call_data(cursor);
+        pass_encoder->dispatch_rays(0, uint3(total_threads, 1, 1));
+        pass_encoder->end();
+    }
 
     // If we created a temporary command encoder, we need to submit it.
     if (temp_command_encoder) {
@@ -1314,10 +1328,16 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def_prop_rw("device", &NativeCallData::get_device, &NativeCallData::set_device, D_NA(NativeCallData, device))
         .def_prop_rw(
-            "compute_pipeline",
-            &NativeCallData::get_compute_pipeline,
-            &NativeCallData::set_compute_pipeline,
-            D_NA(NativeCallData, compute_pipeline)
+            "pipeline",
+            &NativeCallData::get_pipeline,
+            &NativeCallData::set_pipeline,
+            D_NA(NativeCallData, pipeline)
+        )
+        .def_prop_rw(
+            "shader_table",
+            &NativeCallData::get_shader_table,
+            &NativeCallData::set_shader_table,
+            D_NA(NativeCallData, shader_table)
         )
         .def_prop_rw(
             "call_dimensionality",

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -663,18 +663,20 @@ nb::object NativeCallData::exec(
         command_encoder = temp_command_encoder.get();
     }
 
-    bool is_ray_tracing = opts->get_ray_tracing();
+    bool is_ray_tracing = opts->get_is_ray_tracing();
 
     if (!is_ray_tracing) {
         ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
-        ComputePipeline* pipeline = static_cast<ComputePipeline*>(m_pipeline.get());
+        ComputePipeline* pipeline = dynamic_cast<ComputePipeline*>(m_pipeline.get());
+        SGL_ASSERT(pipeline != nullptr);
         ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline));
         bind_call_data(cursor);
         pass_encoder->dispatch(uint3(total_threads, 1, 1));
         pass_encoder->end();
     } else {
         ref<RayTracingPassEncoder> pass_encoder = command_encoder->begin_ray_tracing_pass();
-        RayTracingPipeline* pipeline = static_cast<RayTracingPipeline*>(m_pipeline.get());
+        RayTracingPipeline* pipeline = dynamic_cast<RayTracingPipeline*>(m_pipeline.get());
+        SGL_ASSERT(pipeline != nullptr);
         ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline, m_shader_table));
         bind_call_data(cursor);
         pass_encoder->dispatch_rays(0, uint3(total_threads, 1, 1));

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -602,10 +602,10 @@ public:
     void set_cuda_stream(NativeHandle cuda_stream) { m_cuda_stream = cuda_stream; }
 
     /// Get ray tracing pipeline flag.
-    bool get_ray_tracing() const { return m_ray_tracing; }
+    bool get_is_ray_tracing() const { return m_is_ray_tracing; }
 
     /// Set ray tracing pipeline flag.
-    void set_ray_tracing(bool ray_tracing) { m_ray_tracing = ray_tracing; }
+    void set_is_ray_tracing(bool is_ray_tracing) { m_is_ray_tracing = is_ray_tracing; }
 
     /// Clear internal data for garbage collection
     void garbage_collect()
@@ -618,7 +618,7 @@ private:
     nb::list m_uniforms;
     nb::object m_this{nb::none()};
     NativeHandle m_cuda_stream;
-    bool m_ray_tracing{false};
+    bool m_is_ray_tracing{false};
 };
 
 /// Defines the common logging functions for a given log level.

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -601,6 +601,12 @@ public:
     /// Set the CUDA stream.
     void set_cuda_stream(NativeHandle cuda_stream) { m_cuda_stream = cuda_stream; }
 
+    /// Get ray tracing pipeline flag.
+    bool get_ray_tracing() const { return m_ray_tracing; }
+
+    /// Set ray tracing pipeline flag.
+    void set_ray_tracing(bool ray_tracing) { m_ray_tracing = ray_tracing; }
+
     /// Clear internal data for garbage collection
     void garbage_collect()
     {
@@ -612,6 +618,7 @@ private:
     nb::list m_uniforms;
     nb::object m_this{nb::none()};
     NativeHandle m_cuda_stream;
+    bool m_ray_tracing{false};
 };
 
 /// Defines the common logging functions for a given log level.
@@ -642,11 +649,17 @@ public:
     /// Set the device.
     void set_device(const ref<Device>& device) { m_device = device; }
 
-    /// Get the compute pipeline.
-    ref<ComputePipeline> get_compute_pipeline() const { return m_compute_pipeline; }
+    /// Get the pipeline.
+    ref<Pipeline> get_pipeline() const { return m_pipeline; }
 
-    /// Set the compute pipeline.
-    void set_compute_pipeline(const ref<ComputePipeline>& pipeline) { m_compute_pipeline = pipeline; }
+    /// Set the pipeline.
+    void set_pipeline(const ref<Pipeline>& pipeline) { m_pipeline = pipeline; }
+
+    /// Get the ray tracing shader table.
+    ref<ShaderTable> get_shader_table() const { return m_shader_table; }
+
+    /// Set the ray tracing shader table.
+    void set_shader_table(const ref<ShaderTable>& shader_table) { m_shader_table = shader_table; }
 
     /// Get the call dimensionality.
     int get_call_dimensionality() const { return m_call_dimensionality; }
@@ -759,7 +772,8 @@ public:
 
 private:
     ref<Device> m_device;
-    ref<ComputePipeline> m_compute_pipeline;
+    ref<Pipeline> m_pipeline;
+    ref<ShaderTable> m_shader_table;
     int m_call_dimensionality{0};
     ref<NativeBoundCallRuntime> m_runtime;
     CallMode m_call_mode{CallMode::prim};

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -84,7 +84,7 @@ public:
             options->set_cuda_stream(nb::cast<NativeHandle>(m_data));
             break;
         case sgl::slangpy::FunctionNodeType::ray_tracing:
-            options->set_ray_tracing(true);
+            options->set_is_ray_tracing(true);
             break;
         default:
             break;

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -19,14 +19,24 @@
 
 namespace sgl::slangpy {
 
-enum class FunctionNodeType { unknown, uniforms, kernelgen, this_, cuda_stream };
+enum class FunctionNodeType {
+    unknown,
+    uniforms,
+    kernelgen,
+    this_,
+    cuda_stream,
+    ray_tracing,
+};
 SGL_ENUM_INFO(
     FunctionNodeType,
-    {{FunctionNodeType::unknown, "unknown"},
-     {FunctionNodeType::uniforms, "uniforms"},
-     {FunctionNodeType::kernelgen, "kernelgen"},
-     {FunctionNodeType::this_, "this"},
-     {FunctionNodeType::cuda_stream, "cuda_stream"}}
+    {
+        {FunctionNodeType::unknown, "unknown"},
+        {FunctionNodeType::uniforms, "uniforms"},
+        {FunctionNodeType::kernelgen, "kernelgen"},
+        {FunctionNodeType::this_, "this"},
+        {FunctionNodeType::cuda_stream, "cuda_stream"},
+        {FunctionNodeType::ray_tracing, "ray_tracing"},
+    }
 );
 SGL_ENUM_REGISTER(FunctionNodeType);
 
@@ -72,6 +82,9 @@ public:
             break;
         case sgl::slangpy::FunctionNodeType::cuda_stream:
             options->set_cuda_stream(nb::cast<NativeHandle>(m_data));
+            break;
+        case sgl::slangpy::FunctionNodeType::ray_tracing:
+            options->set_ray_tracing(true);
             break;
         default:
             break;


### PR DESCRIPTION
Add initial support for raytracing pipelines in slangpy.
The currenty `ray_tracing` API on slangpy function objects is preliminary. We plan to add more convenience later.