### PR TITLE
Fix for load from mem stream + add load from file / numpy functions

### DIFF
--- a/src/sgl/core/file_stream.h
+++ b/src/sgl/core/file_stream.h
@@ -12,19 +12,6 @@
 
 namespace sgl {
 
-class SGL_API EOFException : public std::runtime_error {
-public:
-    EOFException(const std::string& what, size_t gcount)
-        : std::runtime_error(what)
-        , m_gcount(gcount)
-    {
-    }
-
-    size_t gcount() const { return m_gcount; }
-
-private:
-    size_t m_gcount;
-};
 
 class SGL_API FileStream : public Stream {
     SGL_OBJECT(FileStream)

--- a/src/sgl/core/memory_stream.cpp
+++ b/src/sgl/core/memory_stream.cpp
@@ -55,11 +55,16 @@ void MemoryStream::read(void* p, size_t size)
     if (!is_open())
         SGL_THROW("Attempted to read from a closed memory stream");
 
-    if (m_pos + size > m_size)
-        SGL_THROW("Attempted to read past the end of a memory stream");
+    size_t gcount = size;
+    if (m_pos + size > m_size) {
+        gcount = m_size - m_pos;
+    }
 
-    std::memcpy(p, m_data + m_pos, size);
-    m_pos += size;
+    std::memcpy(p, m_data + m_pos, gcount);
+    m_pos += gcount;
+
+    if (gcount < size)
+        throw EOFException(fmt::format("Memory stream: read {} out of {} bytes", gcount, size), gcount);
 }
 
 void MemoryStream::write(const void* p, size_t size)

--- a/src/sgl/core/stream.h
+++ b/src/sgl/core/stream.h
@@ -7,6 +7,20 @@
 
 namespace sgl {
 
+class SGL_API EOFException : public std::runtime_error {
+public:
+    EOFException(const std::string& what, size_t gcount)
+        : std::runtime_error(what)
+        , m_gcount(gcount)
+    {
+    }
+
+    size_t gcount() const { return m_gcount; }
+
+private:
+    size_t m_gcount;
+};
+
 /**
  * \brief Base class for all stream objects.
  */

--- a/src/slangpy_ext/core/bitmap.cpp
+++ b/src/slangpy_ext/core/bitmap.cpp
@@ -148,6 +148,8 @@ SGL_PY_EXPORT(core_bitmap)
             "load_from_numpy",
             [](nb::ndarray<nb::device::cpu> data)
             {
+                if(!is_ndarray_contiguous(data))
+                    SGL_THROW("To load from a numpy array, ensure it is contiguous.");
                 MemoryStream stream(data.data(), data.nbytes());
                 return make_ref<Bitmap>(&stream);
             },

--- a/src/slangpy_ext/core/bitmap.cpp
+++ b/src/slangpy_ext/core/bitmap.cpp
@@ -138,6 +138,20 @@ SGL_PY_EXPORT(core_bitmap)
             "path"_a,
             D(Bitmap, Bitmap, 3)
         )
+        .def_static("load_from_file", [](const std::filesystem::path& path) { return make_ref<Bitmap>(path); },
+            "path"_a,
+            D_NA(Bitmap, load_from_file)
+        )
+        .def_static(
+            "load_from_numpy",
+            [](nb::ndarray<nb::device::cpu> data)
+            {
+                MemoryStream stream(data.data(), data.nbytes());
+                return make_ref<Bitmap>(&stream);
+            },
+            "data"_a,
+            D_NA(Bitmap, load_from_numpy)
+        )        
         .def_prop_ro("pixel_format", &Bitmap::pixel_format, D(Bitmap, pixel_format))
         .def_prop_ro("component_type", &Bitmap::component_type, D(Bitmap, component_type))
         .def_prop_ro("pixel_struct", &Bitmap::pixel_struct, D(Bitmap, pixel_struct))

--- a/src/slangpy_ext/core/bitmap.cpp
+++ b/src/slangpy_ext/core/bitmap.cpp
@@ -138,7 +138,9 @@ SGL_PY_EXPORT(core_bitmap)
             "path"_a,
             D(Bitmap, Bitmap, 3)
         )
-        .def_static("load_from_file", [](const std::filesystem::path& path) { return make_ref<Bitmap>(path); },
+        .def_static(
+            "load_from_file",
+            [](const std::filesystem::path& path) { return make_ref<Bitmap>(path); },
             "path"_a,
             D_NA(Bitmap, load_from_file)
         )
@@ -151,7 +153,7 @@ SGL_PY_EXPORT(core_bitmap)
             },
             "data"_a,
             D_NA(Bitmap, load_from_numpy)
-        )        
+        )
         .def_prop_ro("pixel_format", &Bitmap::pixel_format, D(Bitmap, pixel_format))
         .def_prop_ro("component_type", &Bitmap::component_type, D(Bitmap, component_type))
         .def_prop_ro("pixel_struct", &Bitmap::pixel_struct, D(Bitmap, pixel_struct))

--- a/src/slangpy_ext/core/bitmap.cpp
+++ b/src/slangpy_ext/core/bitmap.cpp
@@ -148,7 +148,7 @@ SGL_PY_EXPORT(core_bitmap)
             "load_from_numpy",
             [](nb::ndarray<nb::device::cpu> data)
             {
-                if(!is_ndarray_contiguous(data))
+                if (!is_ndarray_contiguous(data))
                     SGL_THROW("To load from a numpy array, ensure it is contiguous.");
                 MemoryStream stream(data.data(), data.nbytes());
                 return make_ref<Bitmap>(&stream);


### PR DESCRIPTION
- Added a fix to mem stream so it correctly handles read-beyond-end-of-file
- Added python functionality to load from a memory buffer
- Added clear load_from_file and load_from_numpy functions, to distringuish from Bitmap constructors that take a numpy array of actual pixels.