### PR TITLE
Release 0.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you use SlangPy in a research project leading to a publication, please cite t
     title = {SlangPy},
     author = {Simon Kallweit and Chris Cummings and Benedikt Bitterli and Sai Bangaru and Yong He},
     note = {https://github.com/shader-slang/slangpy},
-    version = {0.35.0},
+    version = {0.36.0},
     year = 2025
 }
 ```

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,13 @@ Changelog
 
 SlangPy uses a `semantic versioning <http://semver.org>`__ policy for its API.
 
+Version 0.36.0 (September 30, 2025)
+-------
+
+- Update to Slang version 2025.18 with latest shader compilation improvements and bug fixes.
+- Update slang-rhi submodule to latest version with improved dependency handling.
+  (PR `#533 <https://github.com/shader-slang/slangpy/pull/533>`__)
+
 Version 0.35.0 (September 18, 2025)
 -------
 

--- a/docs/generated/api.rst
+++ b/docs/generated/api.rst
@@ -678,7 +678,7 @@ Constants
 
 .. py:data:: slangpy.SGL_VERSION_MINOR
     :type: int
-    :value: 35
+    :value: 36
 
 
 
@@ -694,7 +694,7 @@ Constants
 
 .. py:data:: slangpy.SGL_VERSION
     :type: str
-    :value: "0.35.0"
+    :value: "0.36.0"
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,7 +69,7 @@ If you use SlangPy in a research project leading to a publication, please cite t
         title = {SlangPy},
         author = {Simon Kallweit and Chris Cummings and Benedikt Bitterli and Sai Bangaru and Yong He},
         note = {https://github.com/shader-slang/slangpy},
-        version = {0.35.0},
+        version = {0.36.0},
         year = 2025
     }
 

--- a/src/sgl/sgl.h
+++ b/src/sgl/sgl.h
@@ -5,7 +5,7 @@
 #include "sgl/core/macros.h"
 
 #define SGL_VERSION_MAJOR 0
-#define SGL_VERSION_MINOR 35
+#define SGL_VERSION_MINOR 36
 #define SGL_VERSION_PATCH 0
 
 #define SGL_VERSION                                                                                                    \

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "sgl",
-    "version-string": "0.35.0",
+    "version-string": "0.36.0",
     "dependencies": [
         "libjpeg-turbo",
         "libpng",


### PR DESCRIPTION
  - Update to Slang version 2025.18                                                                                                                                                                    
  - Update slang-rhi submodule to latest version                                                                                                                                                        
 - Update version numbers across codebase to 0.36.0                                                                                                                                                    