### PR TITLE
Update clang-format to v20.1.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v16.0.6
+  rev: v20.1.7
   hooks:
   - id: clang-format
 - repo: https://github.com/psf/black

--- a/examples/pathtracer/pathtracer.cpp
+++ b/examples/pathtracer/pathtracer.cpp
@@ -420,12 +420,14 @@ struct Scene {
         uint32_t vertex_count = 0;
         uint32_t index_count = 0;
         for (const Mesh& mesh : stage.meshes) {
-            mesh_descs.push_back(MeshDesc{
-                .vertex_count = mesh.vertex_count(),
-                .index_count = mesh.index_count(),
-                .vertex_offset = vertex_count,
-                .index_offset = index_count,
-            });
+            mesh_descs.push_back(
+                MeshDesc{
+                    .vertex_count = mesh.vertex_count(),
+                    .index_count = mesh.index_count(),
+                    .vertex_offset = vertex_count,
+                    .index_offset = index_count,
+                }
+            );
             vertex_count += mesh.vertex_count();
             index_count += mesh.index_count();
         }

--- a/src/sgl/app/app.cpp
+++ b/src/sgl/app/app.cpp
@@ -129,8 +129,9 @@ void AppWindow::_run_frame()
     else
         command_encoder->clear_texture_uint(texture, {}, uint4{0, 0, 0, 255});
 
-    struct RenderContext render_context {
-        .surface_texture = texture, .command_encoder = command_encoder,
+    struct RenderContext render_context{
+        .surface_texture = texture,
+        .command_encoder = command_encoder,
     };
 
     render(render_context);

--- a/src/sgl/core/bitmap.cpp
+++ b/src/sgl/core/bitmap.cpp
@@ -191,11 +191,13 @@ std::vector<ref<Bitmap>> Bitmap::read_multiple(std::span<std::filesystem::path> 
     std::vector<std::future<ref<Bitmap>>> futures;
     futures.reserve(paths.size());
     for (const auto& path : paths)
-        futures.push_back(thread::do_async(
-            [](const std::filesystem::path& path, FileFormat format) { return make_ref<Bitmap>(path, format); },
-            path,
-            format
-        ));
+        futures.push_back(
+            thread::do_async(
+                [](const std::filesystem::path& path, FileFormat format) { return make_ref<Bitmap>(path, format); },
+                path,
+                format
+            )
+        );
     std::vector<ref<Bitmap>> bitmaps;
     bitmaps.reserve(paths.size());
     for (auto& future : futures) {

--- a/src/sgl/core/data_struct.cpp
+++ b/src/sgl/core/data_struct.cpp
@@ -947,13 +947,15 @@ private:
                 switch (op.type) {
                 case Op::Type::load_mem: {
                     Register& reg = get_register(op.reg);
-                    comment(fmt::format(
-                        "load_mem (reg={}, type={}, offset={}, swap={})",
-                        reg.index,
-                        op.load_mem.type,
-                        op.load_mem.offset,
-                        op.load_mem.swap
-                    ));
+                    comment(
+                        fmt::format(
+                            "load_mem (reg={}, type={}, offset={}, swap={})",
+                            reg.index,
+                            op.load_mem.type,
+                            op.load_mem.offset,
+                            op.load_mem.swap
+                        )
+                    );
                     load(reg, src, static_cast<int32_t>(op.load_mem.offset), op.load_mem.type, op.load_mem.swap);
                     break;
                 }
@@ -966,13 +968,15 @@ private:
                 }
                 case Op::Type::save_mem: {
                     const Register& reg = get_register(op.reg);
-                    comment(fmt::format(
-                        "save_mem (reg={}, type={}, offset={}, swap={})",
-                        reg.index,
-                        op.save_mem.type,
-                        op.save_mem.offset,
-                        op.save_mem.swap
-                    ));
+                    comment(
+                        fmt::format(
+                            "save_mem (reg={}, type={}, offset={}, swap={})",
+                            reg.index,
+                            op.save_mem.type,
+                            op.save_mem.offset,
+                            op.save_mem.swap
+                        )
+                    );
                     save(reg, dst, static_cast<int32_t>(op.save_mem.offset), op.save_mem.type, op.save_mem.swap);
                     break;
                 }
@@ -1003,12 +1007,14 @@ private:
                 case Op::Type::multiply_add: {
                     const Register& reg1 = get_register(op.reg);
                     const Register& reg2 = get_register(op.multiply_add.reg);
-                    comment(fmt::format(
-                        "multiply_add (reg1={}, reg2={}, factor={})",
-                        reg1.index,
-                        reg2.index,
-                        op.multiply_add.factor
-                    ));
+                    comment(
+                        fmt::format(
+                            "multiply_add (reg1={}, reg2={}, factor={})",
+                            reg1.index,
+                            reg2.index,
+                            op.multiply_add.factor
+                        )
+                    );
                     fmadd231sd(reg1.xmm, reg2.xmm, const_(op.multiply_add.factor));
                     break;
                 }
@@ -1534,13 +1540,15 @@ private:
                 switch (op.type) {
                 case Op::Type::load_mem: {
                     Register& reg = get_register(op.reg);
-                    comment(fmt::format(
-                        "load_mem (reg={}, type={}, offset={}, swap={})",
-                        reg.index,
-                        op.load_mem.type,
-                        op.load_mem.offset,
-                        op.load_mem.swap
-                    ));
+                    comment(
+                        fmt::format(
+                            "load_mem (reg={}, type={}, offset={}, swap={})",
+                            reg.index,
+                            op.load_mem.type,
+                            op.load_mem.offset,
+                            op.load_mem.swap
+                        )
+                    );
                     load(reg, src, static_cast<int32_t>(op.load_mem.offset), op.load_mem.type, op.load_mem.swap);
                     break;
                 }
@@ -1553,13 +1561,15 @@ private:
                 }
                 case Op::Type::save_mem: {
                     const Register& reg = get_register(op.reg);
-                    comment(fmt::format(
-                        "save_mem (reg={}, type={}, offset={}, swap={})",
-                        reg.index,
-                        op.save_mem.type,
-                        op.save_mem.offset,
-                        op.save_mem.swap
-                    ));
+                    comment(
+                        fmt::format(
+                            "save_mem (reg={}, type={}, offset={}, swap={})",
+                            reg.index,
+                            op.save_mem.type,
+                            op.save_mem.offset,
+                            op.save_mem.swap
+                        )
+                    );
                     save(reg, dst, static_cast<int32_t>(op.save_mem.offset), op.save_mem.type, op.save_mem.swap);
                     break;
                 }
@@ -1592,12 +1602,14 @@ private:
                 case Op::Type::multiply_add: {
                     const Register& reg1 = get_register(op.reg);
                     const Register& reg2 = get_register(op.multiply_add.reg);
-                    comment(fmt::format(
-                        "multiply_add (reg1={}, reg2={}, factor={})",
-                        reg1.index,
-                        reg2.index,
-                        op.multiply_add.factor
-                    ));
+                    comment(
+                        fmt::format(
+                            "multiply_add (reg1={}, reg2={}, factor={})",
+                            reg1.index,
+                            reg2.index,
+                            op.multiply_add.factor
+                        )
+                    );
                     auto tmp = c.newVecD();
                     c.ldr(tmp, const_(op.multiply_add.factor));
                     c.fmadd(reg1.vec, reg2.vec, tmp, reg1.vec);

--- a/src/sgl/core/enum.h
+++ b/src/sgl/core/enum.h
@@ -21,12 +21,8 @@ using EnumInfo = decltype(find_enum_info_adl(std::declval<T>()));
 
 template<typename T>
 concept is_enum_info = requires(T v) {
-    {
-        v.name
-    } -> std::same_as<const char* const&>;
-    {
-        v.items[0]
-    } -> std::same_as<const std::pair<typename T::enum_type, const char*>&>;
+    { v.name } -> std::same_as<const char* const&>;
+    { v.items[0] } -> std::same_as<const std::pair<typename T::enum_type, const char*>&>;
 };
 
 template<typename T>

--- a/src/sgl/core/error.cpp
+++ b/src/sgl/core/error.cpp
@@ -9,7 +9,8 @@
 namespace sgl {
 
 static ExceptionDiagnosticFlags s_exception_diagnostic_flags{
-    ExceptionDiagnosticFlags::break_debugger | ExceptionDiagnosticFlags::log};
+    ExceptionDiagnosticFlags::break_debugger | ExceptionDiagnosticFlags::log
+};
 
 void set_exception_diagnostics(ExceptionDiagnosticFlags flags)
 {

--- a/src/sgl/core/memory_mapped_file.cpp
+++ b/src/sgl/core/memory_mapped_file.cpp
@@ -204,7 +204,7 @@ bool MemoryMappedFile::remap(uint64_t offset, size_t mapped_size)
         m_mapped_size = 0;
     m_mapped_size = mapped_size;
 #elif SGL_LINUX || SGL_MACOS
-        // Create new mapping.
+    // Create new mapping.
 #if SGL_LINUX
     m_mapped_data = ::mmap64(NULL, mapped_size, PROT_READ, MAP_SHARED, m_file, offset);
 #elif SGL_MACOS

--- a/src/sgl/core/string.h
+++ b/src/sgl/core/string.h
@@ -94,9 +94,7 @@ SGL_API void copy_to_cstr(char* dst, size_t dst_len, std::string_view src);
 
 template<typename T>
 concept object_to_string = requires(typename std::remove_pointer<typename remove_ref<T>::type>::type t) {
-    {
-        t.to_string()
-    } -> std::convertible_to<std::string>;
+    { t.to_string() } -> std::convertible_to<std::string>;
 };
 
 /**
@@ -125,9 +123,7 @@ inline std::string list_to_string(std::span<T> list, std::string_view indentatio
 
 template<typename T>
 concept free_standing_to_string = requires(T t) {
-    {
-        to_string(t)
-    } -> std::convertible_to<std::string>;
+    { to_string(t) } -> std::convertible_to<std::string>;
 };
 
 /**
@@ -159,9 +155,7 @@ inline std::string list_to_string(const std::vector<T>& list, std::string_view i
 
 template<typename T>
 concept iterable_has_to_string = requires(typename T::iterator t) {
-    {
-        (*t)->to_string()
-    } -> std::convertible_to<std::string>;
+    { (*t)->to_string() } -> std::convertible_to<std::string>;
 };
 
 template<iterable_has_to_string T>

--- a/src/sgl/device/buffer_cursor.cpp
+++ b/src/sgl/device/buffer_cursor.cpp
@@ -121,13 +121,19 @@ DeviceType BufferElementCursor::_get_device_type() const
 }
 
 // Explicit instantiation of the methods
-template void
-CursorWriteWrappers<BufferElementCursor, size_t>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
-    const;
+template void CursorWriteWrappers<BufferElementCursor, size_t>::_set_array(
+    const void*,
+    size_t,
+    TypeReflection::ScalarType,
+    size_t
+) const;
 
-template void
-CursorWriteWrappers<BufferElementCursor, size_t>::_set_vector(const void*, size_t, TypeReflection::ScalarType, int)
-    const;
+template void CursorWriteWrappers<BufferElementCursor, size_t>::_set_vector(
+    const void*,
+    size_t,
+    TypeReflection::ScalarType,
+    int
+) const;
 
 //
 // Setter specializations

--- a/src/sgl/device/command.cpp
+++ b/src/sgl/device/command.cpp
@@ -209,7 +209,8 @@ void ComputePassEncoder::dispatch(uint3 thread_count)
     uint3 thread_group_count{
         div_round_up(thread_count.x, m_thread_group_size.x),
         div_round_up(thread_count.y, m_thread_group_size.y),
-        div_round_up(thread_count.z, m_thread_group_size.z)};
+        div_round_up(thread_count.z, m_thread_group_size.z)
+    };
     dispatch_compute(thread_group_count);
 }
 
@@ -513,7 +514,8 @@ void CommandEncoder::upload_buffer_data(Buffer* buffer, size_t offset, size_t si
 
     set_buffer_state(buffer, ResourceState::copy_destination);
 
-    SLANG_RHI_CALL(m_rhi_command_encoder->uploadBufferData(buffer->rhi_buffer(), offset, size, const_cast<void*>(data))
+    SLANG_RHI_CALL(
+        m_rhi_command_encoder->uploadBufferData(buffer->rhi_buffer(), offset, size, const_cast<void*>(data))
     );
 }
 

--- a/src/sgl/device/cursor_access_wrappers.h
+++ b/src/sgl/device/cursor_access_wrappers.h
@@ -222,8 +222,12 @@ template<typename BaseCursor, typename TOffset>
 class SGL_API CursorReadWrappers {
     using BaseCursorOffset = TOffset;
 
-    void _get_array_or_vector(void* data, size_t size, TypeReflection::ScalarType cpu_scalar_type, size_t element_count)
-        const
+    void _get_array_or_vector(
+        void* data,
+        size_t size,
+        TypeReflection::ScalarType cpu_scalar_type,
+        size_t element_count
+    ) const
     {
         // CPU is assumed tightly packed, i.e., stride and size are the same value.
         size_t cpu_element_size = cursor_utils::get_scalar_type_cpu_size(cpu_scalar_type);

--- a/src/sgl/device/cursor_utils.h
+++ b/src/sgl/device/cursor_utils.h
@@ -75,30 +75,14 @@ struct _AnyCursorValue { };
 /// cursor object that represents the field or element.
 template<typename T>
 concept TraversableCursor = requires(T obj, std::string_view name_idx, uint32_t el_index) {
-    {
-        obj[name_idx]
-    } -> std::same_as<T>;
-    {
-        obj[el_index]
-    } -> std::same_as<T>;
-    {
-        obj.find_field(name_idx)
-    } -> std::same_as<T>;
-    {
-        obj.find_element(el_index)
-    } -> std::same_as<T>;
-    {
-        obj.has_field(name_idx)
-    } -> std::convertible_to<bool>;
-    {
-        obj.has_element(el_index)
-    } -> std::convertible_to<bool>;
-    {
-        obj.slang_type_layout()
-    } -> std::convertible_to<slang::TypeLayoutReflection*>;
-    {
-        obj.is_valid()
-    } -> std::convertible_to<bool>;
+    { obj[name_idx] } -> std::same_as<T>;
+    { obj[el_index] } -> std::same_as<T>;
+    { obj.find_field(name_idx) } -> std::same_as<T>;
+    { obj.find_element(el_index) } -> std::same_as<T>;
+    { obj.has_field(name_idx) } -> std::convertible_to<bool>;
+    { obj.has_element(el_index) } -> std::convertible_to<bool>;
+    { obj.slang_type_layout() } -> std::convertible_to<slang::TypeLayoutReflection*>;
+    { obj.is_valid() } -> std::convertible_to<bool>;
 };
 
 /// Concept that defines the requirements for a cursor that can be read from.
@@ -111,48 +95,24 @@ concept ReadableCursor = requires(
     size_t element_count,
     _AnyCursorValue& val
 ) {
-    {
-        obj.template get<_AnyCursorValue>(val)
-    } -> std::same_as<void>; // Ensure set() method exists
-    {
-        obj.template as<_AnyCursorValue>()
-    } -> std::same_as<_AnyCursorValue>;
-    {
-        obj._get_array(data, size, scalar_type, element_count)
-    } -> std::same_as<void>;
-    {
-        obj._get_scalar(data, size, scalar_type)
-    } -> std::same_as<void>;
-    {
-        obj._get_vector(data, size, scalar_type, 0)
-    } -> std::same_as<void>;
-    {
-        obj._get_matrix(data, size, scalar_type, 0, 0)
-    } -> std::same_as<void>;
+    { obj.template get<_AnyCursorValue>(val) } -> std::same_as<void>; // Ensure set() method exists
+    { obj.template as<_AnyCursorValue>() } -> std::same_as<_AnyCursorValue>;
+    { obj._get_array(data, size, scalar_type, element_count) } -> std::same_as<void>;
+    { obj._get_scalar(data, size, scalar_type) } -> std::same_as<void>;
+    { obj._get_vector(data, size, scalar_type, 0) } -> std::same_as<void>;
+    { obj._get_matrix(data, size, scalar_type, 0, 0) } -> std::same_as<void>;
 };
 
 /// Concept that defines the requirements for a cursor that can be written to.
 template<typename T>
 concept WritableCursor
     = requires(T obj, void* data, size_t size, TypeReflection::ScalarType scalar_type, size_t element_count) {
-          {
-              obj.template set<_AnyCursorValue>({})
-          } -> std::same_as<void>;
-          {
-              obj.template operator=<_AnyCursorValue>({})
-          } -> std::same_as<void>;
-          {
-              obj._set_array(data, size, scalar_type, element_count)
-          } -> std::same_as<void>;
-          {
-              obj._set_scalar(data, size, scalar_type)
-          } -> std::same_as<void>;
-          {
-              obj._set_vector(data, size, scalar_type, 0)
-          } -> std::same_as<void>;
-          {
-              obj._set_matrix(data, size, scalar_type, 0, 0)
-          } -> std::same_as<void>;
+          { obj.template set<_AnyCursorValue>({}) } -> std::same_as<void>;
+          { obj.template operator= <_AnyCursorValue>({}) } -> std::same_as<void>;
+          { obj._set_array(data, size, scalar_type, element_count) } -> std::same_as<void>;
+          { obj._set_scalar(data, size, scalar_type) } -> std::same_as<void>;
+          { obj._set_vector(data, size, scalar_type, 0) } -> std::same_as<void>;
+          { obj._set_matrix(data, size, scalar_type, 0, 0) } -> std::same_as<void>;
       };
 
 } // namespace sgl

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -102,8 +102,10 @@ Device::Device(const DeviceDesc& desc)
         for (const auto& handle : m_desc.existing_device_handles) {
             if (handle.is_valid()) {
                 m_desc.adapter_luid.reset();
-                log_warn("Both adapter LUID and existing handles have been provided, which are both ways to "
-                         "specify the device. Adapter LUID will be ignored in favor of provided existing handles");
+                log_warn(
+                    "Both adapter LUID and existing handles have been provided, which are both ways to "
+                    "specify the device. Adapter LUID will be ignored in favor of provided existing handles"
+                );
                 break;
             }
         }
@@ -1037,8 +1039,10 @@ bool Device::enable_agility_sdk()
     D3D12GetInterfaceFn pD3D12GetInterface
         = handle ? (D3D12GetInterfaceFn)GetProcAddress(handle, "D3D12GetInterface") : nullptr;
     if (!pD3D12GetInterface) {
-        log_warn("Cannot enable D3D12 Agility SDK: "
-                 "Failed to get D3D12GetInterface.");
+        log_warn(
+            "Cannot enable D3D12 Agility SDK: "
+            "Failed to get D3D12GetInterface."
+        );
         return false;
     }
 
@@ -1049,15 +1053,19 @@ bool Device::enable_agility_sdk()
     _COM_SMARTPTR_TYPEDEF(ID3D12SDKConfiguration, __uuidof(ID3D12SDKConfiguration));
     ID3D12SDKConfigurationPtr pD3D12SDKConfiguration;
     if (!SUCCEEDED(pD3D12GetInterface(CLSID_D3D12SDKConfiguration__, IID_PPV_ARGS(&pD3D12SDKConfiguration)))) {
-        log_warn("Cannot enable D3D12 Agility SDK: "
-                 "Failed to get D3D12SDKConfiguration interface.");
+        log_warn(
+            "Cannot enable D3D12 Agility SDK: "
+            "Failed to get D3D12SDKConfiguration interface."
+        );
         return false;
     }
 
     // Set the SDK version and path.
     if (!SUCCEEDED(pD3D12SDKConfiguration->SetSDKVersion(SLANG_RHI_AGILITY_SDK_VERSION, rel_path.string().c_str()))) {
-        log_warn("Cannot enable D3D12 Agility SDK: "
-                 "Calling SetSDKVersion failed.");
+        log_warn(
+            "Cannot enable D3D12 Agility SDK: "
+            "Calling SetSDKVersion failed."
+        );
         return false;
     }
 

--- a/src/sgl/device/raytracing.cpp
+++ b/src/sgl/device/raytracing.cpp
@@ -51,7 +51,8 @@ AccelerationStructureBuildDescConverter::AccelerationStructureBuildDescConverter
             for (size_t i = 0; i < triangles->vertex_buffers.size(); ++i)
                 rhi_build_input.triangles.vertexBuffers[i] = detail::to_rhi(triangles->vertex_buffers[i]);
             rhi_build_inputs.push_back(rhi_build_input);
-        } else if (auto* proceduralPrimitives = std::get_if<AccelerationStructureBuildInputProceduralPrimitives>(&input)) {
+        } else if (auto* proceduralPrimitives
+                   = std::get_if<AccelerationStructureBuildInputProceduralPrimitives>(&input)) {
             rhi::AccelerationStructureBuildInput rhi_build_input{
                 .type = rhi::AccelerationStructureBuildInputType::ProceduralPrimitives,
                 .proceduralPrimitives{

--- a/src/sgl/device/shader.cpp
+++ b/src/sgl/device/shader.cpp
@@ -102,14 +102,16 @@ public:
     void insert_cache_include(const std::filesystem::path& path, size_t index)
     {
         SGL_ASSERT(index <= m_entries.size());
-        m_entries.insert(m_entries.begin() + index,
+        m_entries.insert(
+            m_entries.begin() + index,
             {
-            .name = slang::CompilerOptionName::Include,
-            .value = {
-                .kind = slang::CompilerOptionValueKind::String,
-                .string0 = path.string(),
-            },
-        });
+                .name = slang::CompilerOptionName::Include,
+                .value = {
+                    .kind = slang::CompilerOptionValueKind::String,
+                    .string0 = path.string(),
+                },
+            }
+        );
     }
 
     std::vector<slang::CompilerOptionEntry> slang_entries() const

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -316,9 +316,8 @@ inline bool is_buffer_resource_type(slang::TypeReflection* type)
     switch ((TypeReflection::Kind)type->getKind()) {
     case TypeReflection::Kind::constant_buffer:
     case TypeReflection::Kind::resource: {
-        auto shape = (TypeReflection::ResourceShape)(
-            type->getResourceShape() & SlangResourceShape::SLANG_RESOURCE_BASE_SHAPE_MASK
-        );
+        auto shape = (TypeReflection::ResourceShape)(type->getResourceShape()
+                                                     & SlangResourceShape::SLANG_RESOURCE_BASE_SHAPE_MASK);
         switch (shape) {
         case TypeReflection::ResourceShape::texture_buffer:
         case TypeReflection::ResourceShape::structured_buffer:
@@ -341,9 +340,8 @@ inline bool is_texture_resource_type(slang::TypeReflection* type)
 {
     switch ((TypeReflection::Kind)type->getKind()) {
     case TypeReflection::Kind::resource: {
-        auto shape = (TypeReflection::ResourceShape)(
-            type->getResourceShape() & SlangResourceShape::SLANG_RESOURCE_BASE_SHAPE_MASK
-        );
+        auto shape = (TypeReflection::ResourceShape)(type->getResourceShape()
+                                                     & SlangResourceShape::SLANG_RESOURCE_BASE_SHAPE_MASK);
         switch (shape) {
         case TypeReflection::ResourceShape::texture_1d:
         case TypeReflection::ResourceShape::texture_2d:
@@ -532,13 +530,19 @@ DeviceType ShaderCursor::_get_device_type() const
 }
 
 // Explicit instantiation of the methods
-template void
-CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_array(const void*, size_t, TypeReflection::ScalarType, size_t)
-    const;
+template void CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_array(
+    const void*,
+    size_t,
+    TypeReflection::ScalarType,
+    size_t
+) const;
 
-template void
-CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_vector(const void*, size_t, TypeReflection::ScalarType, int)
-    const;
+template void CursorWriteWrappers<ShaderCursor, ShaderOffset>::_set_vector(
+    const void*,
+    size_t,
+    TypeReflection::ScalarType,
+    int
+) const;
 
 //
 // Setter specializations

--- a/src/sgl/device/shader_cursor.h
+++ b/src/sgl/device/shader_cursor.h
@@ -86,9 +86,12 @@ public:
     template<typename T>
     void set(const T& value) const;
 
-    void
-    _set_array_unsafe(const void* data, size_t size, size_t element_count, TypeReflection::ScalarType cpu_scalar_type)
-        const;
+    void _set_array_unsafe(
+        const void* data,
+        size_t size,
+        size_t element_count,
+        TypeReflection::ScalarType cpu_scalar_type
+    ) const;
 
     /// CursorWriteWrappers, CursorReadWrappers
     void _set_data(ShaderOffset offset, const void* data, size_t size) const;

--- a/src/sgl/device/shader_object.cpp
+++ b/src/sgl/device/shader_object.cpp
@@ -84,7 +84,8 @@ ref<ShaderObject> ShaderObject::get_object(const ShaderOffset& offset)
 
 void ShaderObject::set_object(const ShaderOffset& offset, const ref<ShaderObject>& object)
 {
-    SLANG_RHI_CALL(m_shader_object->setObject(rhi_shader_offset(offset), object ? object->rhi_shader_object() : nullptr)
+    SLANG_RHI_CALL(
+        m_shader_object->setObject(rhi_shader_offset(offset), object ? object->rhi_shader_object() : nullptr)
     );
 }
 

--- a/src/sgl/sgl.cpp
+++ b/src/sgl/sgl.cpp
@@ -19,7 +19,8 @@ static inline const char* git_version()
 {
     static std::string str{
         fmt::format("commit: {} / branch: {}", GIT_VERSION_COMMIT, GIT_VERSION_BRANCH)
-        + (GIT_VERSION_DIRTY ? " (local changes)" : "")};
+        + (GIT_VERSION_DIRTY ? " (local changes)" : "")
+    };
     return str.c_str();
 }
 

--- a/src/sgl/utils/texture_loader.cpp
+++ b/src/sgl/utils/texture_loader.cpp
@@ -56,8 +56,9 @@ inline std::pair<Format, bool> determine_texture_format(const Bitmap* bitmap, co
         srgb = 2,
     };
 
-    auto make_key = [](PixelFormat pixel_format, ComponentType component_type, FormatFlags flags = FormatFlags::none
-                    ) constexpr -> uint32_t
+    auto make_key = [](PixelFormat pixel_format,
+                       ComponentType component_type,
+                       FormatFlags flags = FormatFlags::none) constexpr -> uint32_t
     {
         static_assert(Bitmap::PIXEL_FORMAT_COUNT <= 8);
         static_assert(DataStruct::TYPE_COUNT <= 16);

--- a/src/slangpy_ext/core/platform.cpp
+++ b/src/slangpy_ext/core/platform.cpp
@@ -18,9 +18,8 @@ SGL_PY_EXPORT(core_platform)
 #elif SGL_LINUX
         .def(
             "__init__",
-            [](sgl::WindowHandle* self, uintptr_t xdisplay, uint32_t xwindow) {
-                new (self) sgl::WindowHandle{reinterpret_cast<void*>(xdisplay), xwindow};
-            },
+            [](sgl::WindowHandle* self, uintptr_t xdisplay, uint32_t xwindow)
+            { new (self) sgl::WindowHandle{reinterpret_cast<void*>(xdisplay), xwindow}; },
             "xdisplay"_a,
             "xwindow"_a
         )

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -981,11 +981,7 @@ inline void bind_readable_cursor(ReadConverterTable<CursorType>& table, nanobind
     // __setitem__ and __setattr__ functions are overloaded to allow direct setting
     // of fields and elements.
     cursor //
-        .def(
-            "read",
-            [&table](CursorType& self) { return table.read(self); },
-            D_NA(CursorType, read)
-        );
+        .def("read", [&table](CursorType& self) { return table.read(self); }, D_NA(CursorType, read));
 }
 
 template<typename CursorType>

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -339,7 +339,7 @@ SGL_PY_EXPORT(device_device)
                 // cursor code below needs to ensure it maintains a reference to the type layout if
                 // returned, so we attempt to convert to the raw ptr here, and then immediately
                 // store it in a local ref counted ptr.
-                if (const TypeLayoutReflection * resolved_struct_type_ptr;
+                if (const TypeLayoutReflection* resolved_struct_type_ptr;
                     nb::try_cast(resource_type_layout, resolved_struct_type_ptr)) {
                     resolved_resource_type_layout = ref<const TypeLayoutReflection>(resolved_struct_type_ptr);
                 }
@@ -657,11 +657,13 @@ SGL_PY_EXPORT(device_device)
            bool add_default_include_paths,
            std::optional<std::filesystem::path> cache_path)
         {
-            return self->create_slang_session(SlangSessionDesc{
-                .compiler_options = compiler_options.value_or(SlangCompilerOptions{}),
-                .add_default_include_paths = add_default_include_paths,
-                .cache_path = cache_path,
-            });
+            return self->create_slang_session(
+                SlangSessionDesc{
+                    .compiler_options = compiler_options.value_or(SlangCompilerOptions{}),
+                    .add_default_include_paths = add_default_include_paths,
+                    .cache_path = cache_path,
+                }
+            );
         },
         "compiler_options"_a.none() = nb::none(),
         "add_default_include_paths"_a = SlangSessionDesc().add_default_include_paths,
@@ -908,11 +910,7 @@ SGL_PY_EXPORT(device_device)
         "timeout_ms"_a,
         D_NA(Device, set_hot_reload_delay)
     );
-    device.def(
-        "hot_reload_check",
-        [](Device* self) { self->_hot_reload()->update(); },
-        D_NA(Device, hot_reload_check)
-    );
+    device.def("hot_reload_check", [](Device* self) { self->_hot_reload()->update(); }, D_NA(Device, hot_reload_check));
 
     device.def_static(
         "enumerate_adapters",

--- a/src/slangpy_ext/device/raytracing.cpp
+++ b/src/slangpy_ext/device/raytracing.cpp
@@ -151,7 +151,8 @@ SGL_PY_EXPORT(device_raytracing)
         .def(nb::init<>())
         .def(
             "__init__",
-            [](AccelerationStructureBuildInputInstances* self, nb::dict dict) {
+            [](AccelerationStructureBuildInputInstances* self, nb::dict dict)
+            {
                 new (self)
                     AccelerationStructureBuildInputInstances(dict_to_AccelerationStructureBuildInputInstances(dict));
             }
@@ -169,7 +170,8 @@ SGL_PY_EXPORT(device_raytracing)
         .def(nb::init<>())
         .def(
             "__init__",
-            [](AccelerationStructureBuildInputTriangles* self, nb::dict dict) {
+            [](AccelerationStructureBuildInputTriangles* self, nb::dict dict)
+            {
                 new (self)
                     AccelerationStructureBuildInputTriangles(dict_to_AccelerationStructureBuildInputTriangles(dict));
             }
@@ -220,7 +222,8 @@ SGL_PY_EXPORT(device_raytracing)
         .def(nb::init<>())
         .def(
             "__init__",
-            [](AccelerationStructureBuildInputMotionOptions* self, nb::dict dict) {
+            [](AccelerationStructureBuildInputMotionOptions* self, nb::dict dict)
+            {
                 new (self) AccelerationStructureBuildInputMotionOptions(
                     dict_to_AccelerationStructureBuildInputMotionOptions(dict)
                 );

--- a/src/slangpy_ext/device/shader.cpp
+++ b/src/slangpy_ext/device/shader.cpp
@@ -63,7 +63,8 @@ SGL_PY_EXPORT(device_shader)
                 new (self) TypeConformance{
                     nb::cast<std::string>(tuple[0]),
                     nb::cast<std::string>(tuple[1]),
-                    tuple.size() > 2 ? nb::cast<int32_t>(tuple[2]) : -1};
+                    tuple.size() > 2 ? nb::cast<int32_t>(tuple[2]) : -1
+                };
             }
         )
         .def_rw("interface_name", &TypeConformance::interface_name, D(TypeConformance, interface_name))

--- a/src/slangpy_ext/math/matrix.cpp
+++ b/src/slangpy_ext/math/matrix.cpp
@@ -153,23 +153,11 @@ void bind_matrix_type(nb::module_& m, const char* name)
 
     // Intrinsics
 
-    m.def(
-        "transpose",
-        [](const T& x) { return transpose(x); },
-        "x"_a
-    );
+    m.def("transpose", [](const T& x) { return transpose(x); }, "x"_a);
 
     if constexpr (rows == cols) {
-        m.def(
-            "determinant",
-            [](const T& x) { return determinant(x); },
-            "x"_a
-        );
-        m.def(
-            "inverse",
-            [](const T& x) { return inverse(x); },
-            "x"_a
-        );
+        m.def("determinant", [](const T& x) { return determinant(x); }, "x"_a);
+        m.def("inverse", [](const T& x) { return inverse(x); }, "x"_a);
     }
 
     m.def(
@@ -178,18 +166,8 @@ void bind_matrix_type(nb::module_& m, const char* name)
         "x"_a,
         "y"_a
     );
-    m.def(
-        "mul",
-        [](const T& x, const row_type& y) { return mul(x, y); },
-        "x"_a,
-        "y"_a
-    );
-    m.def(
-        "mul",
-        [](const col_type& x, const T& y) { return mul(x, y); },
-        "x"_a,
-        "y"_a
-    );
+    m.def("mul", [](const T& x, const row_type& y) { return mul(x, y); }, "x"_a, "y"_a);
+    m.def("mul", [](const col_type& x, const T& y) { return mul(x, y); }, "x"_a, "y"_a);
 }
 
 inline void bind_matrix(nb::module_& m)
@@ -206,37 +184,12 @@ inline void bind_matrix(nb::module_& m)
     bind_matrix_type<float4x3>(m, "float4x3");
     bind_matrix_type<float4x4>(m, "float4x4");
 
-    m.def(
-        "transform_point",
-        [](const float4x4& m, const float3& v) { return transform_point(m, v); },
-        "m"_a,
-        "v"_a
-    );
-    m.def(
-        "transform_vector",
-        [](const float3x3& m, const float3& v) { return transform_vector(m, v); },
-        "m"_a,
-        "v"_a
-    );
-    m.def(
-        "transform_vector",
-        [](const float4x4& m, const float3& v) { return transform_vector(m, v); },
-        "m"_a,
-        "v"_a
-    );
+    m.def("transform_point", [](const float4x4& m, const float3& v) { return transform_point(m, v); }, "m"_a, "v"_a);
+    m.def("transform_vector", [](const float3x3& m, const float3& v) { return transform_vector(m, v); }, "m"_a, "v"_a);
+    m.def("transform_vector", [](const float4x4& m, const float3& v) { return transform_vector(m, v); }, "m"_a, "v"_a);
 
-    m.def(
-        "translate",
-        [](const float4x4& m, const float3& v) { return translate(m, v); },
-        "m"_a,
-        "v"_a
-    );
-    m.def(
-        "translate_2d",
-        [](const float3x3& m, const float2& v) { return translate_2d(m, v); },
-        "m"_a,
-        "v"_a
-    );
+    m.def("translate", [](const float4x4& m, const float3& v) { return translate(m, v); }, "m"_a, "v"_a);
+    m.def("translate_2d", [](const float3x3& m, const float2& v) { return translate_2d(m, v); }, "m"_a, "v"_a);
     m.def(
         "rotate",
         [](const float4x4& m, float angle, const float3& axis) { return rotate(m, angle, axis); },
@@ -244,24 +197,9 @@ inline void bind_matrix(nb::module_& m)
         "angle"_a,
         "axis"_a
     );
-    m.def(
-        "rotate_2d",
-        [](const float3x3& m, float angle) { return rotate_2d(m, angle); },
-        "m"_a,
-        "angle"_a
-    );
-    m.def(
-        "scale",
-        [](const float4x4& m, const float3& v) { return scale(m, v); },
-        "m"_a,
-        "v"_a
-    );
-    m.def(
-        "scale_2d",
-        [](const float3x3& m, const float2& v) { return scale_2d(m, v); },
-        "m"_a,
-        "v"_a
-    );
+    m.def("rotate_2d", [](const float3x3& m, float angle) { return rotate_2d(m, angle); }, "m"_a, "angle"_a);
+    m.def("scale", [](const float4x4& m, const float3& v) { return scale(m, v); }, "m"_a, "v"_a);
+    m.def("scale_2d", [](const float3x3& m, const float2& v) { return scale_2d(m, v); }, "m"_a, "v"_a);
 
     m.def(
         "perspective",
@@ -283,27 +221,11 @@ inline void bind_matrix(nb::module_& m)
         "z_far"_a
     );
 
-    m.def(
-        "matrix_from_translation",
-        [](const float3& v) { return matrix_from_translation(v); },
-        "v"_a
-    );
-    m.def(
-        "matrix_from_translation_2d",
-        [](const float2& v) { return matrix_from_translation_2d(v); },
-        "v"_a
-    );
+    m.def("matrix_from_translation", [](const float3& v) { return matrix_from_translation(v); }, "v"_a);
+    m.def("matrix_from_translation_2d", [](const float2& v) { return matrix_from_translation_2d(v); }, "v"_a);
 
-    m.def(
-        "matrix_from_scaling",
-        [](const float3& v) { return matrix_from_scaling(v); },
-        "v"_a
-    );
-    m.def(
-        "matrix_from_scaling_2d",
-        [](const float2& v) { return matrix_from_scaling_2d(v); },
-        "v"_a
-    );
+    m.def("matrix_from_scaling", [](const float3& v) { return matrix_from_scaling(v); }, "v"_a);
+    m.def("matrix_from_scaling_2d", [](const float2& v) { return matrix_from_scaling_2d(v); }, "v"_a);
 
     m.def(
         "matrix_from_rotation",
@@ -311,27 +233,11 @@ inline void bind_matrix(nb::module_& m)
         "angle"_a,
         "axis"_a
     );
-    m.def(
-        "matrix_from_rotation_2d",
-        [](float angle) { return matrix_from_rotation_2d(angle); },
-        "angle"_a
-    );
+    m.def("matrix_from_rotation_2d", [](float angle) { return matrix_from_rotation_2d(angle); }, "angle"_a);
 
-    m.def(
-        "matrix_from_rotation_x",
-        [](float angle) { return matrix_from_rotation_x(angle); },
-        "angle"_a
-    );
-    m.def(
-        "matrix_from_rotation_y",
-        [](float angle) { return matrix_from_rotation_y(angle); },
-        "angle"_a
-    );
-    m.def(
-        "matrix_from_rotation_z",
-        [](float angle) { return matrix_from_rotation_z(angle); },
-        "angle"_a
-    );
+    m.def("matrix_from_rotation_x", [](float angle) { return matrix_from_rotation_x(angle); }, "angle"_a);
+    m.def("matrix_from_rotation_y", [](float angle) { return matrix_from_rotation_y(angle); }, "angle"_a);
+    m.def("matrix_from_rotation_z", [](float angle) { return matrix_from_rotation_z(angle); }, "angle"_a);
     m.def(
         "matrix_from_rotation_xyz",
         [](float angle_x, float angle_y, float angle_z) { return matrix_from_rotation_xyz(angle_x, angle_y, angle_z); },
@@ -353,16 +259,8 @@ inline void bind_matrix(nb::module_& m)
         "up"_a,
         "handedness"_a = Handedness::right_handed
     );
-    m.def(
-        "matrix_from_quat",
-        [](const quatf& q) { return matrix_from_quat(q); },
-        "q"_a
-    );
-    m.def(
-        "matrix_4x4_from_3x4",
-        [](const float3x4& m) { return matrix_4x4_from_3x4(m); },
-        "m"_a
-    );
+    m.def("matrix_from_quat", [](const quatf& q) { return matrix_from_quat(q); }, "q"_a);
+    m.def("matrix_4x4_from_3x4", [](const float3x4& m) { return matrix_4x4_from_3x4(m); }, "m"_a);
     m.def(
         "decompose",
         [](const float4x4& model_matrix,

--- a/src/slangpy_ext/math/quaternion.cpp
+++ b/src/slangpy_ext/math/quaternion.cpp
@@ -92,18 +92,8 @@ void bind_quaternion_type(nb::module_& m, const char* name)
 
     // Multiplication
 
-    m.def(
-        "mul",
-        [](const T& x, const T& y) { return mul(x, y); },
-        "x"_a,
-        "y"_a
-    );
-    m.def(
-        "mul",
-        [](const T& x, const vector<value_type, 3>& y) { return mul(x, y); },
-        "x"_a,
-        "y"_a
-    );
+    m.def("mul", [](const T& x, const T& y) { return mul(x, y); }, "x"_a, "y"_a);
+    m.def("mul", [](const T& x, const vector<value_type, 3>& y) { return mul(x, y); }, "x"_a, "y"_a);
 
     m.def(
         "transform_vector",
@@ -164,11 +154,7 @@ void bind_quaternion_type(nb::module_& m, const char* name)
         "angles"_a
     );
 
-    m.def(
-        "quat_from_matrix",
-        [](const matrix<value_type, 3, 3>& m) { return quat_from_matrix(m); },
-        "m"_a
-    );
+    m.def("quat_from_matrix", [](const matrix<value_type, 3, 3>& m) { return quat_from_matrix(m); }, "m"_a);
 
     m.def(
         "quat_from_look_at",

--- a/src/slangpy_ext/math/vector.cpp
+++ b/src/slangpy_ext/math/vector.cpp
@@ -308,13 +308,7 @@ void bind_vector_type(nb::module_& m, const char* name)
         if constexpr (floating_point<value_type>) {
             m.def("fmod", WRAP_INTRINSIC_XY(fmod));
             m.def("frac", WRAP_INTRINSIC_X(frac));
-            m.def(
-                "lerp",
-                [](const T& x, const T& y, const T& s) { return lerp(x, y, s); },
-                "x"_a,
-                "y"_a,
-                "s"_a
-            );
+            m.def("lerp", [](const T& x, const T& y, const T& s) { return lerp(x, y, s); }, "x"_a, "y"_a, "s"_a);
             m.def(
                 "lerp",
                 [](const T& x, const T& y, const value_type& s) { return lerp(x, y, s); },
@@ -343,12 +337,7 @@ void bind_vector_type(nb::module_& m, const char* name)
         if constexpr (floating_point<value_type>) {
             m.def("length", WRAP_INTRINSIC_X(length));
             m.def("normalize", WRAP_INTRINSIC_X(normalize));
-            m.def(
-                "reflect",
-                [](const T& i, const T& n) { return reflect(i, n); },
-                "i"_a,
-                "n"_a
-            );
+            m.def("reflect", [](const T& i, const T& n) { return reflect(i, n); }, "i"_a, "n"_a);
         }
     }
 

--- a/src/slangpy_ext/ui/widgets.cpp
+++ b/src/slangpy_ext/ui/widgets.cpp
@@ -146,7 +146,8 @@ SGL_PY_EXPORT(ui_widgets)
         .def("__len__", &Widget::child_count, D(Widget, child_count))
         .def(
             "__iter__",
-            [](const Widget& self) {
+            [](const Widget& self)
+            {
                 return nb::make_iterator(
                     nb::type<Widget>(),
                     "iterator",

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -472,12 +472,14 @@ nb::object NativeCallData::exec(
         // Our check above should have already validated that
         // call_group_shape.size() > 0.
         if (call_group_shape.size() > cs.size()) {
-            throw std::runtime_error(fmt::format(
-                "call_group_shape dimensionality ({}) must be <= call_shape dimensionality ({}). "
-                "call_group_shape cannot have more dimensions than call_shape.",
-                call_group_shape.size(),
-                cs.size()
-            ));
+            throw std::runtime_error(
+                fmt::format(
+                    "call_group_shape dimensionality ({}) must be <= call_shape dimensionality ({}). "
+                    "call_group_shape cannot have more dimensions than call_shape.",
+                    call_group_shape.size(),
+                    cs.size()
+                )
+            );
         } else if (call_group_shape.size() < cs.size()) {
             // Call group shape size is less than the call shape size so we need to
             // pad the call group shape with 1's to account for the missing dimensions.
@@ -503,11 +505,13 @@ nb::object NativeCallData::exec(
         // Verify that all elements of call_group_shape are >= 1
         for (size_t i = 0; i < call_group_shape.size(); ++i) {
             if (call_group_shape[i] < 1) {
-                throw std::runtime_error(fmt::format(
-                    "call_group_shape[{}] = {} is invalid. All call_group_shape elements must be >= 1.",
-                    i,
-                    call_group_shape[i]
-                ));
+                throw std::runtime_error(
+                    fmt::format(
+                        "call_group_shape[{}] = {} is invalid. All call_group_shape elements must be >= 1.",
+                        i,
+                        call_group_shape[i]
+                    )
+                );
             }
         }
     } else {
@@ -1023,12 +1027,7 @@ SGL_PY_EXPORT(utils_slangpy)
     nb::sgl_enum<CallMode>(slangpy, "CallMode");
     nb::sgl_enum<CallDataMode>(slangpy, "CallDataMode");
 
-    slangpy.def(
-        "unpack_args",
-        [](nb::args args) { return unpack_args(args); },
-        "args"_a,
-        D_NA(slangpy, unpack_args)
-    );
+    slangpy.def("unpack_args", [](nb::args args) { return unpack_args(args); }, "args"_a, D_NA(slangpy, unpack_args));
     slangpy.def(
         "unpack_refs_and_args",
         [](nb::list refs, nb::args args) { return unpack_args(args, refs); },
@@ -1049,12 +1048,7 @@ SGL_PY_EXPORT(utils_slangpy)
         "kwargs"_a,
         D_NA(slangpy, unpack_kwargs)
     );
-    slangpy.def(
-        "unpack_arg",
-        [](nb::object arg) { return unpack_arg(arg); },
-        "arg"_a,
-        D_NA(slangpy, unpack_arg)
-    );
+    slangpy.def("unpack_arg", [](nb::object arg) { return unpack_arg(arg); }, "arg"_a, D_NA(slangpy, unpack_arg));
     slangpy.def(
         "pack_arg",
         [](nb::object arg, nb::object unpacked_arg) { pack_arg(arg, unpacked_arg); },

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -140,7 +140,7 @@ class NativeSlangType : public Object {
 public:
     NativeSlangType() = default;
 
-    virtual ~NativeSlangType(){
+    virtual ~NativeSlangType() {
 
     };
 
@@ -390,8 +390,12 @@ struct PyNativeMarshall : public NativeMarshall {
 
     nb::object create_dispatchdata(nb::object data) const override { NB_OVERRIDE(create_dispatchdata, data); }
 
-    void read_calldata(CallContext* context, NativeBoundVariableRuntime* binding, nb::object data, nb::object result)
-        const override
+    void read_calldata(
+        CallContext* context,
+        NativeBoundVariableRuntime* binding,
+        nb::object data,
+        nb::object result
+    ) const override
     {
         NB_OVERRIDE(read_calldata, context, binding, data, result);
     }
@@ -420,8 +424,11 @@ struct PyNativeMarshall : public NativeMarshall {
         NB_OVERRIDE(resolve_type, context, bound_type);
     }
 
-    int resolve_dimensionality(nb::object context, nb::object binding, ref<NativeSlangType> vector_target_type)
-        const override
+    int resolve_dimensionality(
+        nb::object context,
+        nb::object binding,
+        ref<NativeSlangType> vector_target_type
+    ) const override
     {
         NB_OVERRIDE(resolve_dimensionality, context, binding, vector_target_type);
     }
@@ -793,9 +800,12 @@ class PyNativeCallData : public NativeCallData {
 public:
     NB_TRAMPOLINE(NativeCallData, 1);
 
-    nb::object
-    _py_torch_call(NativeFunctionNode* func, ref<NativeCallRuntimeOptions> opts, nb::tuple args, nb::dict kwargs)
-        override;
+    nb::object _py_torch_call(
+        NativeFunctionNode* func,
+        ref<NativeCallRuntimeOptions> opts,
+        nb::tuple args,
+        nb::dict kwargs
+    ) override;
 };
 
 typedef std::function<bool(const ref<SignatureBuilder>& builder, nb::handle)> BuildSignatureFunc;
@@ -850,13 +860,15 @@ public:
         : m_id(id)
         , m_tensor(tensor)
     {
-        set_slangpy_signature(fmt::format(
-            "[torch,D{},C{},B{},L{}]",
-            tensor.ndim(),
-            tensor.dtype().code,
-            tensor.dtype().bits,
-            tensor.dtype().lanes
-        ));
+        set_slangpy_signature(
+            fmt::format(
+                "[torch,D{},C{},B{},L{}]",
+                tensor.ndim(),
+                tensor.dtype().code,
+                tensor.dtype().bits,
+                tensor.dtype().lanes
+            )
+        );
     }
 
     std::optional<nb::ndarray<nb::pytorch, nb::device::cuda>> tensor() const { return m_tensor; }

--- a/src/slangpy_ext/utils/slangpybuffer.h
+++ b/src/slangpy_ext/utils/slangpybuffer.h
@@ -75,8 +75,12 @@ public:
         nb::list read_back
     ) const override;
 
-    void read_calldata(CallContext* context, NativeBoundVariableRuntime* binding, nb::object data, nb::object result)
-        const override;
+    void read_calldata(
+        CallContext* context,
+        NativeBoundVariableRuntime* binding,
+        nb::object data,
+        nb::object result
+    ) const override;
 
     nb::object create_output(CallContext* context, NativeBoundVariableRuntime* binding) const override;
 
@@ -120,8 +124,12 @@ public:
         nb::list read_back
     ) const override;
 
-    void read_calldata(CallContext* context, NativeBoundVariableRuntime* binding, nb::object data, nb::object result)
-        const override;
+    void read_calldata(
+        CallContext* context,
+        NativeBoundVariableRuntime* binding,
+        nb::object data,
+        nb::object result
+    ) const override;
 
     nb::object create_output(CallContext* context, NativeBoundVariableRuntime* binding) const override;
 

--- a/src/slangpy_ext/utils/slangpytensor.cpp
+++ b/src/slangpy_ext/utils/slangpytensor.cpp
@@ -315,7 +315,8 @@ SGL_PY_EXPORT(utils_slangpy_tensor)
                ref<NativeSlangType> slang_element_type,
                ref<TypeLayoutReflection> element_layout,
                ref<NativeTensorMarshall> d_in,
-               ref<NativeTensorMarshall> d_out) {
+               ref<NativeTensorMarshall> d_out)
+            {
                 new (&self)
                     PyNativeTensorMarshall(dims, writable, slang_type, slang_element_type, element_layout, d_in, d_out);
             },

--- a/src/slangpy_ext/utils/slangpytensor.h
+++ b/src/slangpy_ext/utils/slangpytensor.h
@@ -113,8 +113,12 @@ public:
         nb::list read_back
     ) const override;
 
-    void read_calldata(CallContext* context, NativeBoundVariableRuntime* binding, nb::object data, nb::object result)
-        const override;
+    void read_calldata(
+        CallContext* context,
+        NativeBoundVariableRuntime* binding,
+        nb::object data,
+        nb::object result
+    ) const override;
 
     nb::object create_output(CallContext* context, NativeBoundVariableRuntime* binding) const override;
 
@@ -152,8 +156,12 @@ struct PyNativeTensorMarshall : public NativeTensorMarshall {
         NB_OVERRIDE(create_calldata, context, binding, data);
     }
 
-    void read_calldata(CallContext* context, NativeBoundVariableRuntime* binding, nb::object data, nb::object result)
-        const override
+    void read_calldata(
+        CallContext* context,
+        NativeBoundVariableRuntime* binding,
+        nb::object data,
+        nb::object result
+    ) const override
     {
         NB_OVERRIDE(read_calldata, context, binding, data, result);
     }

--- a/tests/sgl/math/test_matrix.cpp
+++ b/tests/sgl/math/test_matrix.cpp
@@ -908,21 +908,23 @@ TEST_CASE("rotate_2d_vs_matrix_multiplication")
     // mul(matrix, matrix_from_rotation_2d(angle))
 
     // Test with various starting matrices
-    float3x3 test_matrices[] = {// Identity matrix
-                                float3x3::identity(),
+    float3x3 test_matrices[]
+        = {// Identity matrix
+           float3x3::identity(),
 
-                                // Translation matrix
-                                math::matrix_from_translation_2d(float2(5.f, 3.f)),
+           // Translation matrix
+           math::matrix_from_translation_2d(float2(5.f, 3.f)),
 
-                                // Scaling matrix
-                                math::matrix_from_scaling_2d(float2(2.f, 0.5f)),
+           // Scaling matrix
+           math::matrix_from_scaling_2d(float2(2.f, 0.5f)),
 
-                                // Complex transformation matrix
-                                float3x3({
-                                    ROW(2, 1, 4),
-                                    ROW(-1, 3, 7),
-                                    ROW(0, 0, 1),
-                                })};
+           // Complex transformation matrix
+           float3x3({
+               ROW(2, 1, 4),
+               ROW(-1, 3, 7),
+               ROW(0, 0, 1),
+           })
+        };
 
     float angles[] = {0.f, math::radians(30.f), math::radians(90.f), math::radians(-45.f), math::radians(180.f)};
 


### PR DESCRIPTION
This updates clang-format to a more recent version which fixes a few formatting issues. This is the same version slang-rhi is using.