### PR TITLE
Skip UI rendering if rasterization is not available

### DIFF
--- a/src/sgl/ui/ui.cpp
+++ b/src/sgl/ui/ui.cpp
@@ -282,6 +282,11 @@ Context::Context(ref<Device> device)
     setup_style();
     ImGui::GetStyle().ScaleAllSizes(scale_factor);
 
+    // Skip initializing rasterizer if device does not support rasterization.
+    // TODO: This will be fixed later when adding sw rasterizer (wip).    
+    if (!m_device->has_feature(Feature::rasterization))
+        return;
+
     // Setup sampler.
     m_sampler = m_device->create_sampler({
         .min_filter = TextureFilteringMode::linear,
@@ -369,6 +374,11 @@ void Context::render(TextureView* texture_view, CommandEncoder* command_encoder)
     m_screen->render();
 
     ImGui::Render();
+
+    // Skip actual rendering device does not support it.
+    if (!m_device->has_feature(Feature::rasterization))
+        return;
+
     ImDrawData* draw_data = ImGui::GetDrawData();
 
     if (draw_data->CmdListsCount > 0) {


### PR DESCRIPTION
This is a temporary workaround until we have the compute based rasterizer for CUDA.