### PR TITLE
Added option of having `None` in the mapping args to skip those we want to leave as default

### DIFF
--- a/slangpy/bindings/boundvariable.py
+++ b/slangpy/bindings/boundvariable.py
@@ -101,7 +101,8 @@ class BoundCall:
             raise ValueError("Too many keyword arguments supplied for explicit vectorization")
 
         for i, arg in enumerate(args):
-            self.args[i].apply_explicit_vectorization(context, arg)
+            if arg:
+                self.args[i].apply_explicit_vectorization(context, arg)
 
         for name, arg in kwargs.items():
             if not name in self.kwargs:


### PR DESCRIPTION
This allows doing `.map(None, int, None)` when we want to map only the 2nd positional argument.