### PR TITLE
Update Slang to 2025.19

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -69,7 +69,7 @@ set(SGL_LOCAL_SLANG OFF CACHE BOOL "Use a local build of slang instead of downlo
 set(SGL_LOCAL_SLANG_DIR "${CMAKE_SOURCE_DIR}/../slang" CACHE PATH "Path to a local slang build")
 set(SGL_LOCAL_SLANG_BUILD_DIR "build/Debug" CACHE STRING "Build directory of the local slang build")
 
-set(SLANG_VERSION "2025.18.2")
+set(SLANG_VERSION "2025.19")
 set(SLANG_URL_BASE "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}")
 
 if(SGL_WINDOWS)


### PR DESCRIPTION
Updates `SLANG_VERSION` from `"2025.18.2"` to `"2025.19"` in `external/CMakeLists.txt`