### PR TITLE
Fix build issue with VC ToolSets version 14.4X

### DIFF
--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -252,7 +252,7 @@ The following table lists the available configuration options:
       - Enable header validation
     * - ``SGL_MSVC_TOOLSET_VERSION``
       - ``Unset``
-      - Specify an exact MSVC toolset version to use (e.g., `14.38.33130`)
+      - Specify an exact MSVC toolset version to use (e.g., `14.44.35207`)
 
 
 

--- a/external/vcpkg-triplets/x64-windows-static-md-fix.cmake
+++ b/external/vcpkg-triplets/x64-windows-static-md-fix.cmake
@@ -13,9 +13,30 @@ if(DEFINED toolset_to_use)
     set(VCPKG_PLATFORM_TOOLSET_VERSION "${toolset_to_use}")
 
     # Also set the major toolset version, as vcpkg may require it to be present.
-    string(REGEX MATCH "^([0-9]+)\\.([0-9])" _match "${toolset_to_use}")
+    # For VS 2022, all versions (14.30-14.49) use v143 toolset
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _match "${toolset_to_use}")
     if(_match)
-        set(derived_toolset "v${CMAKE_MATCH_1}${CMAKE_MATCH_2}")
+        # Map version to correct Visual Studio toolset
+        # 14.0-14.9 -> v140 (VS 2015)
+        # 14.1X -> v141 (VS 2017)
+        # 14.2X -> v142 (VS 2019)
+        # 14.3X-14.4X -> v143 (VS 2022)
+        if(CMAKE_MATCH_1 EQUAL 14)
+            if(CMAKE_MATCH_2 GREATER_EQUAL 0 AND CMAKE_MATCH_2 LESS 10)
+                set(derived_toolset "v140")
+            elseif(CMAKE_MATCH_2 GREATER_EQUAL 10 AND CMAKE_MATCH_2 LESS 20)
+                set(derived_toolset "v141")
+            elseif(CMAKE_MATCH_2 GREATER_EQUAL 20 AND CMAKE_MATCH_2 LESS 30)
+                set(derived_toolset "v142")
+            else()
+                # v143 for 14.30+ (VS 2022 and future versions)
+                # Covers 14.3X, 14.4X, and beyond
+                set(derived_toolset "v143")
+            endif()
+        else()
+            # Fallback for unknown versions
+            set(derived_toolset "v${CMAKE_MATCH_1}${CMAKE_MATCH_2}")
+        endif()
         set(VCPKG_PLATFORM_TOOLSET "${derived_toolset}")
     endif()
 endif()


### PR DESCRIPTION
This is another attempt to get the PR #315 working.

Here is what is different from PR #315.
The MSVC Toolset version for VS2022 is v14.3.
However MS used up the minor version number from 14.31.XXX to 14.39.XXX and started using 14.40.XXX.

Although the first three digits of the version numbers are 144, 14.4X is still considered v14.3 toolset.
The current CMake setup needs to recognize this correctly.

You can find more official details and explanations from the following URL:
https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/
> The C++ Project System (MS Build) is being updated to support '14.4x' MSVC toolsets under the v143 Platform Toolset.