### PR TITLE
Refactor UI API

### DIFF
--- a/examples/window/window.py
+++ b/examples/window/window.py
@@ -102,7 +102,6 @@ class App:
 
         while not self.window.should_close():
             self.window.process_events()
-            self.ui.process_events()
 
             elapsed = timer.elapsed_s()
             timer.reset()
@@ -118,6 +117,8 @@ class App:
             surface_texture = self.surface.acquire_next_image()
             if not surface_texture:
                 continue
+
+            self.ui.begin_frame(surface_texture.width, surface_texture.height)
 
             if (
                 self.output_texture == None
@@ -149,8 +150,7 @@ class App:
             )
             command_encoder.blit(surface_texture, self.output_texture)
 
-            self.ui.new_frame(surface_texture.width, surface_texture.height)
-            self.ui.render(surface_texture, command_encoder)
+            self.ui.end_frame(surface_texture, command_encoder)
 
             self.device.submit_command_buffer(command_encoder.finish())
             del surface_texture

--- a/src/sgl/app/app.cpp
+++ b/src/sgl/app/app.cpp
@@ -139,13 +139,14 @@ void AppWindow::on_keyboard_event(const KeyboardEvent& event)
 void AppWindow::_run_frame()
 {
     m_window->process_events();
-    m_ui_context->process_events();
 
     if (!m_surface->config())
         return;
     ref<Texture> texture = m_surface->acquire_next_image();
     if (!texture)
         return;
+
+    m_ui_context->begin_frame(texture->width(), texture->height());
 
     ref<CommandEncoder> command_encoder = m_device->create_command_encoder();
 
@@ -161,11 +162,9 @@ void AppWindow::_run_frame()
 
     render(render_context);
 
-    m_ui_context->new_frame(texture->width(), texture->height());
-
     render_ui();
 
-    m_ui_context->render(texture, command_encoder);
+    m_ui_context->end_frame(texture, command_encoder);
 
     m_device->submit_command_buffer(command_encoder->finish());
 

--- a/src/sgl/ui/ui.cpp
+++ b/src/sgl/ui/ui.cpp
@@ -354,7 +354,7 @@ ImFont* Context::get_font(const char* name)
     return it == m_fonts.end() ? nullptr : it->second;
 }
 
-void Context::new_frame(uint32_t width, uint32_t height)
+void Context::begin_frame(uint32_t width, uint32_t height)
 {
     ImGui::SetCurrentContext(m_imgui_context);
 
@@ -364,16 +364,16 @@ void Context::new_frame(uint32_t width, uint32_t height)
     m_frame_timer.reset();
 
     ImGui::NewFrame();
+
+    m_screen->render();
 }
 
-void Context::render(TextureView* texture_view, CommandEncoder* command_encoder)
+void Context::end_frame(TextureView* texture_view, CommandEncoder* command_encoder)
 {
     ImGui::SetCurrentContext(m_imgui_context);
     ImGuiIO& io = ImGui::GetIO();
 
     bool is_srgb_format = get_format_info(texture_view->format()).is_srgb_format();
-
-    m_screen->render();
 
     ImGui::Render();
 
@@ -484,10 +484,10 @@ void Context::render(TextureView* texture_view, CommandEncoder* command_encoder)
     }
 }
 
-void Context::render(Texture* texture, CommandEncoder* command_encoder)
+void Context::end_frame(Texture* texture, CommandEncoder* command_encoder)
 {
     // TODO(slang-rhi) use default_view once it is available
-    render(texture->create_view({}), command_encoder);
+    end_frame(texture->create_view({}), command_encoder);
 }
 
 bool Context::handle_keyboard_event(const KeyboardEvent& event)
@@ -537,11 +537,6 @@ bool Context::handle_mouse_event(const MouseEvent& event)
     }
 
     return io.WantCaptureMouse;
-}
-
-void Context::process_events()
-{
-    m_screen->dispatch_events();
 }
 
 RenderPipeline* Context::get_pipeline(Format format)

--- a/src/sgl/ui/ui.h
+++ b/src/sgl/ui/ui.h
@@ -24,18 +24,36 @@ public:
     Context(ref<Device> device);
     ~Context();
 
+    /// The main screen widget.
     ref<Screen> screen() const { return m_screen; }
 
     ImFont* get_font(const char* name);
 
-    void new_frame(uint32_t width, uint32_t height);
-    void render(TextureView* texture_view, CommandEncoder* command_encoder);
-    void render(Texture* texture, CommandEncoder* command_encoder);
+    /// Begin a new ImGui frame and renders the main screen widget.
+    /// ImGui widget calls are generally only valid between `begin_frame` and `end_frame`.
+    /// \param width Render texture width
+    /// \param height Render texture height
+    void begin_frame(uint32_t width, uint32_t height);
 
+    /// End the ImGui frame and renders the UI to the provided texture.
+    /// \param texture_view Texture view to render to
+    /// \param command_encoder Command encoder to encode commands to
+    void end_frame(TextureView* texture_view, CommandEncoder* command_encoder);
+
+    /// End the ImGui frame and renders the UI to the provided texture.
+    /// \param texture Texture to render to
+    /// \param command_encoder Command encoder to encode commands to
+    void end_frame(Texture* texture, CommandEncoder* command_encoder);
+
+    /// Pass a keyboard event to the UI context.
+    /// \param event Keyboard event
+    /// \return Returns true if event was consumed.
     bool handle_keyboard_event(const KeyboardEvent& event);
-    bool handle_mouse_event(const MouseEvent& event);
 
-    void process_events();
+    /// Pass a mouse event to the UI context.
+    /// \param event Mouse event
+    /// \return Returns true if event was consumed.
+    bool handle_mouse_event(const MouseEvent& event);
 
 private:
     RenderPipeline* get_pipeline(Format format);

--- a/src/slangpy_ext/ui/ui.cpp
+++ b/src/slangpy_ext/ui/ui.cpp
@@ -31,23 +31,22 @@ SGL_PY_EXPORT(ui)
 
     nb::class_<ui::Context, Object>(ui, "Context", gc_helper_type_slots<ui::Context>(), D(Context))
         .def(nb::init<ref<Device>>(), "device"_a)
-        .def("new_frame", &ui::Context::new_frame, "width"_a, "height"_a, D(Context, new_frame))
+        .def("begin_frame", &ui::Context::begin_frame, "width"_a, "height"_a, D_NA(Context, begin_frame))
         .def(
-            "render",
-            nb::overload_cast<TextureView*, CommandEncoder*>(&ui::Context::render),
+            "end_frame",
+            nb::overload_cast<TextureView*, CommandEncoder*>(&ui::Context::end_frame),
             "texture_view"_a,
             "command_encoder"_a,
-            D(Context, render)
+            D_NA(Context, end_frame)
         )
         .def(
-            "render",
-            nb::overload_cast<Texture*, CommandEncoder*>(&ui::Context::render),
+            "end_frame",
+            nb::overload_cast<Texture*, CommandEncoder*>(&ui::Context::end_frame),
             "texture"_a,
             "command_encoder"_a,
-            D(Context, render, 2)
+            D_NA(Context, end_frame, 2)
         )
         .def("handle_keyboard_event", &ui::Context::handle_keyboard_event, "event"_a, D(Context, handle_keyboard_event))
         .def("handle_mouse_event", &ui::Context::handle_mouse_event, "event"_a, D(Context, handle_mouse_event))
-        .def("process_events", &ui::Context::process_events, D(Context, process_events))
         .def_prop_ro("screen", &ui::Context::screen, D(Context, screen));
 }

--- a/src/slangpy_ext/ui/widgets.cpp
+++ b/src/slangpy_ext/ui/widgets.cpp
@@ -168,8 +168,7 @@ SGL_PY_EXPORT(ui_widgets)
         )
         .def("__delitem__", &Widget::remove_child_at, D(Widget, remove_child_at));
 
-    nb::class_<Screen, Widget>(ui, "Screen", D(Screen))
-        .def("dispatch_events", &Screen::dispatch_events, D(Screen, dispatch_events));
+    nb::class_<Screen, Widget>(ui, "Screen", D(Screen));
 
     nb::class_<Window, Widget>(ui, "Window", D(Window))
         .def(


### PR DESCRIPTION
- Rename new_frame() to begin_frame()
- Rename render() to end_frame()
- Dispatch ImGui events directly instead of deferring them to process_events(), which is just unneeded overhead/complexity
- Remove process_events()
- begin_frame() now immediately "renders" the contents of the main screen widget (and dispatches events immediately), rendering here means submitting ImGui commands, not actually drawing to the screen
- Added comments
- Update window.py example