### PR TITLE
fix: include mouse position in button events

### DIFF
--- a/src/sgl/core/window.cpp
+++ b/src/sgl/core/window.cpp
@@ -300,6 +300,7 @@ struct EventHandlers {
 
         MouseEvent event{
             .type = (action == GLFW_PRESS) ? MouseEventType::button_down : MouseEventType::button_up,
+            .pos = window->m_mouse_pos,
             .button = mouse_button,
             .mods = window->m_mods,
         };


### PR DESCRIPTION
Today I was working on an interactive 2D PINN and found that the position reported on mouse button down is (0,0). I figured I had the time to check the source code to see if this was some ugly bug, or a quick fix, and was pleasantly surprised to find that the bug only required a 1 line addition to fix!

MouseEvent was missing the pos field in handle_mouse_button, which was causing all GLFW mouse button down/up events to report (0, 0) as the position.

This PR adds .pos = window->m_mouse_pos to match the behaviour of handle_cursor_pos and handle_scroll event handlers.