### PR TITLE
Treat the array type of vector type as a proper tensor type

### DIFF
--- a/slangpy/builtin/tensor.py
+++ b/slangpy/builtin/tensor.py
@@ -45,9 +45,11 @@ def types_equal(a: SlangType, b: SlangType):
     return a.full_name == b.full_name
 
 
-def is_nested_array(a: SlangType):
+def castable_to_scalar(a: SlangType):
     while True:
         if isinstance(a, ScalarType):
+            return True
+        if isinstance(a, VectorType):
             return True
         if isinstance(a, MatrixType):
             return True
@@ -172,7 +174,7 @@ class TensorMarshall(NativeTensorMarshall):
         # or array type
         # Be lenient and allow e.g. passing float to float[N] or float[M][N]
         if types_equal(self.slang_element_type, innermost_type(bound_type)):
-            if is_nested_array(bound_type) and len(bound_type.shape) <= 2:
+            if castable_to_scalar(bound_type) and len(bound_type.shape) <= 2:
                 return bound_type
             if isinstance(bound_type, VectorType):
                 return bound_type

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -137,6 +137,25 @@ public extension<T : IDifferentiable, let D : int, TensorType : ITensor<T, D>> T
             }
         }
     }
+
+    [Differentiable]
+    public void load<let M : int, let N : int>(ContextND<D - 2> context, out vector<T, N>[M] value)
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 2; ++i)
+            idx[i] = context.call_id[i];
+        [ForceUnroll]
+        for (int i = 0; i < M; i++) {
+            [ForceUnroll]
+            for (int j = 0; j < N; j++) {
+                idx[D - 2] = i;
+                idx[D - 1] = j;
+
+                value[i][j] = get(idx);
+            }
+        }
+    }
 }
 
 public extension<T : IDifferentiable, let D : int, TensorType : IRWTensor<T, D>> TensorType
@@ -196,6 +215,25 @@ public extension<T : IDifferentiable, let D : int, TensorType : IRWTensor<T, D>>
 
     [Differentiable]
     public void store<let M : int, let N : int>(ContextND<D - 2> context, in matrix <T, M, N> value)
+    {
+        int idx[D];
+        [ForceUnroll]
+        for (int i = 0; i < D - 2; ++i)
+            idx[i] = context.call_id[i];
+        [ForceUnroll]
+        for (int i = 0; i < M; i++) {
+            [ForceUnroll]
+            for (int j = 0; j < N; j++) {
+                idx[D - 2] = i;
+                idx[D - 1] = j;
+
+                set(idx, value[i][j]);
+            }
+        }
+    }
+
+    [Differentiable]
+    public void store<let M : int, let N : int>(ContextND<D - 2> context, in vector<T, N>[M] value)
     {
         int idx[D];
         [ForceUnroll]

--- a/slangpy/tests/slangpy_tests/test_torchintegration.slang
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.slang
@@ -92,3 +92,21 @@ void copy_tensor(Tensor<float, 1> input, RWTensor<float, 1> output) {
     for (uint i = 0; i < input.shape[0]; i++)
         output.set({int(i)}, input[int(i)]);
 }
+
+[Differentiable]
+float2[6] return_vector_array(int coord) {
+    float2 outputs[6];
+    for (int i = 0; i < 6; ++i) {
+        outputs[i] = float2(coord, coord + i);
+    }
+    return outputs;
+}
+
+[Differentiable]
+float3[4] return_vector_array_float3(int coord) {
+    float3 outputs[4];
+    for (int i = 0; i < 4; ++i) {
+        outputs[i] = float3(coord, coord + i, coord + i * 2);
+    }
+    return outputs;
+}

--- a/slangpy/torchintegration/torchtensormarshall.py
+++ b/slangpy/torchintegration/torchtensormarshall.py
@@ -10,7 +10,7 @@ from slangpy.core.native import AccessType, CallContext, CallMode, Shape, Tensor
 from slangpy.bindings.boundvariableruntime import BoundVariableRuntime
 from slangpy.bindings.marshall import ReturnContext
 from slangpy.bindings.typeregistry import PYTHON_SIGNATURES, PYTHON_TYPES
-from slangpy.builtin.tensor import TensorMarshall, is_nested_array
+from slangpy.builtin.tensor import TensorMarshall, castable_to_scalar
 from slangpy import Buffer
 from slangpy.reflection.reflectiontypes import (
     SlangProgramLayout,
@@ -80,13 +80,7 @@ class TensorRefMarshall(TensorMarshall):
     ):
 
         dtype = innermost_type(slang_dtype)
-        can_convert = (
-            is_nested_array(slang_dtype)
-            or isinstance(slang_dtype, ScalarType)
-            or isinstance(slang_dtype, VectorType)
-            or isinstance(slang_dtype, MatrixType)
-        )
-        if not can_convert or len(slang_dtype.shape) > 2:
+        if not castable_to_scalar(slang_dtype) or len(slang_dtype.shape) > 2:
             raise ValueError(f"Torch tensors do not support data type {slang_dtype.full_name}")
 
         full_dims = dims + len(slang_dtype.shape)


### PR DESCRIPTION
`is_nested_array()` was only checked for `ScalarType` and `MatrixType` and it was missing `VectorType` checking. The change from this PR effectively treats `VectorType` as a valid tensor type as it is for `ScalarType` and `MatrixType`.

After discussions, the function is renamed to `castable_to_scalar` in order to reflect what it does better.