### PR TITLE
Fix LMDBCache eviction

### DIFF
--- a/src/sgl/core/lmdb_cache.h
+++ b/src/sgl/core/lmdb_cache.h
@@ -6,9 +6,10 @@
 
 #include <atomic>
 #include <filesystem>
+#include <mutex>
+#include <optional>
 #include <span>
 #include <vector>
-#include <optional>
 
 // Forward declaration
 struct MDB_env;
@@ -161,6 +162,8 @@ private:
     DB m_db;
 
     size_t m_max_key_size{0};
+
+    std::mutex m_evict_mutex;
 
     std::atomic<uint64_t> m_evictions{0};
 


### PR DESCRIPTION
Eviction is now blocking. This is required because we compute the size to be evicted before starting to remove entries. We used to evict more than necessary if multiple threads ran eviction concurrently.

When writing entries, we now check for MDB_MAP_FULL and retry after running eviction once. This should improve reliability under load.