### PR TITLE
Add `SLANGPY_SKIP_PY_DOC_INCLUDE`

### DIFF
--- a/src/slangpy_ext/nanobind.h
+++ b/src/slangpy_ext/nanobind.h
@@ -31,7 +31,9 @@
 
 #include "sgl/device/cuda_interop.h"
 
+#ifndef SLANGPY_SKIP_PY_DOC_INCLUDE
 #include "py_doc.h"
+#endif
 
 #include <span>
 


### PR DESCRIPTION
This is another tweak for a downstream application to allow using the `nanobind.h` helper include without pulling in all the pydoc strings.