### PR TITLE
Bump Slang version from 2026.1.2 to 2026.2.1

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -74,7 +74,7 @@ set(SGL_LOCAL_SLANG OFF CACHE BOOL "Use a local build of slang instead of downlo
 set(SGL_LOCAL_SLANG_DIR "${CMAKE_SOURCE_DIR}/../slang" CACHE PATH "Path to a local slang build")
 set(SGL_LOCAL_SLANG_BUILD_DIR "build/Debug" CACHE STRING "Build directory of the local slang build")
 
-set(SGL_SLANG_VERSION "2026.1.2" CACHE STRING "Slang version to download when not using a local build")
+set(SGL_SLANG_VERSION "2026.2.1" CACHE STRING "Slang version to download when not using a local build")
 
 set(SLANG_URL_BASE "https://github.com/shader-slang/slang/releases/download/v${SGL_SLANG_VERSION}/slang-${SGL_SLANG_VERSION}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Slang compiler dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->