### PR TITLE
Add is_input parameter to diff_pair()

### DIFF
--- a/slangpy/torchintegration/__init__.py
+++ b/slangpy/torchintegration/__init__.py
@@ -4,12 +4,14 @@ from typing import Any
 from slangpy.core.native import NativeTorchTensorDiffPair
 
 
-def diff_pair(primal: Any, grad: Any) -> NativeTorchTensorDiffPair:
+def diff_pair(primal: Any, grad: Any, is_input: bool = True) -> NativeTorchTensorDiffPair:
     """
     Create a differentiable tensor pair for use in backward passes.
 
     :param primal: The primal (value) tensor.
     :param grad: The gradient tensor.
+    :param is_input: True if this is an input (kernel writes gradients),
+        False if this is an output (kernel reads upstream gradients).
     :return: A NativeTorchTensorDiffPair wrapping the primal and gradient tensors.
     """
-    return NativeTorchTensorDiffPair(primal, grad)
+    return NativeTorchTensorDiffPair(primal, grad, -1, is_input)


### PR DESCRIPTION
Without this, diff_pair() always created pairs with is_input=True, so there was no way to mark an output pair (is_input=False) without dropping down to the raw NativeTorchTensorDiffPair constructor.


Without the is_input parameter, users would have to use the raw NativeTorchTensorDiffPair constructor directly:
```
  from slangpy.core.native import NativeTorchTensorDiffPair

  # Input pair (is_input=True) — diff_pair works fine for this
  input_pair = diff_pair(x, x_grad)

  # Output pair (is_input=False) — no way to express this with diff_pair()
  output_pair = NativeTorchTensorDiffPair(output, output_grad, -1, False)

  module.diff_square.bwds(input_pair, output_pair)
```

With the tweak:

```
  input_pair = diff_pair(x, x_grad, is_input=True)
  output_pair = diff_pair(output, output_grad, is_input=False)
  module.diff_square.bwds(input_pair, output_pair)
```





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional flag when creating tensor gradient pairs to mark them as "input" (kernel writes gradients) or "output" (kernel reads upstream gradients). Default behavior is preserved for compatibility; factories now carry the flag through created gradient-pair objects.

* **Tests**
  * Added a PyTorch/CUDA test validating the new flag and ensuring gradients propagate as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->