### PR TITLE
Support _threadcount and float<N> for TensorView/DiffTensorview

### DIFF
--- a/docs/src/basics/firstfunctions.rst
+++ b/docs/src/basics/firstfunctions.rst
@@ -60,6 +60,59 @@ This eliminates common, error-prone tasks:
 This capability is a core feature of modern numerical computing libraries like SlangPy, NumPy, and PyTorch, allowing you to focus on the logic of your function rather than the low-level details of GPU kernel management.
 For example, to add two buffers element-wise, you simply call the function with the buffers as arguments, and SlangPy handles the rest. This also extends to more complex scenarios, like adding a scalar value to every element of a multi-dimensional tensor, significantly reducing the chances of bugs and amount of boilerplate.
 
+Explicit Thread Count
+---------------------
+
+Automatic vectorization infers the number of GPU threads from the shapes of the input arguments. However, there are cases where you want direct control over thread dispatch, for example, when writing a ``[CUDAKernel]`` function that manages its own indexing using ``cudaThreadIdx()`` rather than relying on SlangPy's vectorization.
+For these kernels, SlangPy cannot infer a thread count from the inputs (since none of the arguments are being vectorized over). You can specify it explicitly using the special ``_thread_count`` keyword argument:
+
+.. code-block::
+
+    // example.slang
+
+    // A kernel that squares each element, managing its own thread index.
+    [CUDAKernel]
+    [Differentiable]
+    void square_kernel(uint count, DiffTensorView<float> input, DiffTensorView<float> output)
+    {
+        uint tid = cudaBlockIdx().x * cudaBlockDim().x + cudaThreadIdx().x;
+        if (tid >= count)
+            return;
+        float x = input.load(tid);
+        output.store(tid, x * x);
+    }
+
+.. code-block:: python
+
+    ## main_cuda_kernel.py
+
+    # ... initialization here ...
+
+    import torch
+
+    N = 5
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda")
+    output = torch.zeros(N, device="cuda")
+
+    # Dispatch exactly N threads — SlangPy cannot infer this from the inputs alone
+    module.square_kernel(count=N, input=x, output=output, _thread_count=N)
+
+``_thread_count`` is a special keyword (like ``_result``) consumed by SlangPy and never forwarded to the kernel itself. It is only valid when no arguments trigger automatic vectorization (i.e. call dimensionality is 0). Passing ``_thread_count`` alongside vectorized inputs will raise a ``ValueError``.
+
+Differentiable ``[CUDAKernel]`` functions work the same way — pass ``_thread_count`` to the ``.bwds()`` call as well:
+
+.. code-block:: python
+
+    x_grad = torch.zeros(N, device="cuda")
+    output_grad = torch.ones(N, device="cuda")
+
+    module.square_kernel.bwds(
+        count=N,
+        input=diff_pair(x, x_grad),
+        output=diff_pair(output, output_grad),
+        _thread_count=N,
+    )
+
 A simple example
 -----------------
 

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -114,21 +114,7 @@ class CallData(NativeCallData):
         self.build(build_info, *args, **kwargs)
 
     def build(self, build_info: "FunctionBuildInfo", *args: Any, **kwargs: Any):
-        # The follow section explain how _thread_count is handled.
-        # Phase 1 (C++, every call): read_thread_count_kwarg() reads the value from kwargs
-        #   into opts->m_thread_count, but leaves _thread_count in kwargs so Phase 2 can
-        #   see it. The signature naturally includes "_thread_count:int" when present,
-        #   creating a separate cache entry for calls with vs. without it.
-        #
-        # Phase 2 (Python, cache miss only): pop _thread_count before the
-        #   shader binding machinery runs, since it is not a Slang parameter and would
-        #   cause a binding error if left in kwargs.
-        #
-        # Phase 3 (C++, every call): exec() uses opts->has_thread_count() / thread_count()
-        #   to set total_threads. opts was already populated in Phase 1, so exec() never
-        #   needs to look at kwargs for this value.
-        has_thread_count = "_thread_count" in kwargs
-        kwargs.pop("_thread_count", None)
+        self.has_thread_count = "_thread_count" in kwargs
 
         try:
 
@@ -170,6 +156,7 @@ class CallData(NativeCallData):
             # Unpack args (handles IThis wrappers)
             unpacked_args, args_had_unpack = unpack_args(*args)
             unpacked_kwargs, kwargs_had_unpack = unpack_kwargs(**kwargs)
+            unpacked_kwargs.pop("_thread_count", None)  # not a Slang parameter
             self.needs_unpack = args_had_unpack or kwargs_had_unpack
 
             # If we have torch tensors, enable torch integration
@@ -257,10 +244,8 @@ class CallData(NativeCallData):
             context.call_dimensionality = self.call_dimensionality
             self.log_debug(f"  Call dimensionality: {self.call_dimensionality}")
 
-            # _thread_count is only valid when call_dimensionality is 0 (all args are whole
-            # buffers/values and the kernel manages its own thread indexing). For auto-vectorized
-            # kernels (call_dimensionality > 0) the thread count is inferred from arg shapes.
-            if has_thread_count and self.call_dimensionality > 0:
+            # _thread_count is only valid when call_dimensionality is 0
+            if self.has_thread_count and self.call_dimensionality > 0:
                 raise ValueError(
                     f"_thread_count is only valid for kernels with call dimensionality 0 "
                     f"(i.e., all parameters are passed as whole buffers/values and the kernel "

--- a/slangpy/tests/slangpy_tests/test_difftensorview.py
+++ b/slangpy/tests/slangpy_tests/test_difftensorview.py
@@ -107,7 +107,7 @@ def test_difftensorview_diff_square_torch(device_type: DeviceType):
 
 
 # ============================================================================
-# Tests for _threadcount with CUDAKernel + Differentiable
+# Tests for _thread_count with CUDAKernel + Differentiable
 # ============================================================================
 
 
@@ -115,14 +115,14 @@ def test_difftensorview_diff_square_torch(device_type: DeviceType):
 @pytest.mark.skipif(not (HAS_TORCH and torch.cuda.is_available()), reason="CUDA not available")
 @pytest.mark.parametrize("device_type", DEVICE_TYPES)
 def test_difftensorview_kernel_forward(device_type: DeviceType):
-    """Test forward pass of CUDAKernel diff_square_kernel with _threadcount."""
+    """Test forward pass of CUDAKernel diff_square_kernel with _thread_count."""
     module = load_module_torch(device_type)
 
     x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=torch.float32)
     output = torch.zeros(5, device="cuda", dtype=torch.float32)
     count = x.numel()
 
-    module.diff_square_kernel(count=count, input=x, output=output, _threadcount=count)
+    module.diff_square_kernel(count=count, input=x, output=output, _thread_count=count)
     torch.cuda.synchronize()
 
     expected = x * x
@@ -146,7 +146,7 @@ def test_difftensorview_kernel_backward(device_type: DeviceType):
         count=count,
         input=diff_pair(x, x_grad),
         output=diff_pair(output, output_grad),
-        _threadcount=count,
+        _thread_count=count,
     )
     torch.cuda.synchronize()
 

--- a/slangpy/tests/slangpy_tests/test_difftensorview.py
+++ b/slangpy/tests/slangpy_tests/test_difftensorview.py
@@ -104,3 +104,53 @@ def test_difftensorview_diff_square_torch(device_type: DeviceType):
     assert torch.allclose(
         x_grad, expected_grad, atol=1e-5
     ), f"Expected grad {expected_grad}, got {x_grad}"
+
+
+# ============================================================================
+# Tests for _threadcount with CUDAKernel + Differentiable
+# ============================================================================
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+@pytest.mark.skipif(not (HAS_TORCH and torch.cuda.is_available()), reason="CUDA not available")
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_difftensorview_kernel_forward(device_type: DeviceType):
+    """Test forward pass of CUDAKernel diff_square_kernel with _threadcount."""
+    module = load_module_torch(device_type)
+
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=torch.float32)
+    output = torch.zeros(5, device="cuda", dtype=torch.float32)
+    count = x.numel()
+
+    module.diff_square_kernel(count=count, input=x, output=output, _threadcount=count)
+    torch.cuda.synchronize()
+
+    expected = x * x
+    assert torch.allclose(output, expected), f"Expected {expected}, got {output}"
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+@pytest.mark.skipif(not (HAS_TORCH and torch.cuda.is_available()), reason="CUDA not available")
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_difftensorview_kernel_backward(device_type: DeviceType):
+    """Test backward pass of CUDAKernel diff_square_kernel: f(x) = x^2, df/dx = 2x."""
+    module = load_module_torch(device_type)
+
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=torch.float32)
+    x_grad = torch.zeros(5, device="cuda", dtype=torch.float32)
+    output = torch.zeros(5, device="cuda", dtype=torch.float32)
+    output_grad = torch.ones(5, device="cuda", dtype=torch.float32)
+    count = x.numel()
+
+    module.diff_square_kernel.bwds(
+        count=count,
+        input=diff_pair(x, x_grad),
+        output=diff_pair(output, output_grad),
+        _threadcount=count,
+    )
+    torch.cuda.synchronize()
+
+    expected_grad = 2.0 * x
+    assert torch.allclose(
+        x_grad, expected_grad, atol=1e-5
+    ), f"Expected grad {expected_grad}, got {x_grad}"

--- a/slangpy/tests/slangpy_tests/test_difftensorview.slang
+++ b/slangpy/tests/slangpy_tests/test_difftensorview.slang
@@ -23,7 +23,7 @@ void diff_square(DiffTensorView<float> input, DiffTensorView<float> output)
     }
 }
 
-// CUDAKernel + Differentiable: f(x) = x^2, requires _threadcount.
+// CUDAKernel + Differentiable: f(x) = x^2, requires _thread_count.
 [CUDAKernel]
 [Differentiable]
 void diff_square_kernel(uint count, DiffTensorView<float> input, DiffTensorView<float> output)

--- a/slangpy/tests/slangpy_tests/test_difftensorview.slang
+++ b/slangpy/tests/slangpy_tests/test_difftensorview.slang
@@ -22,3 +22,15 @@ void diff_square(DiffTensorView<float> input, DiffTensorView<float> output)
         output.store(i, x * x);
     }
 }
+
+// CUDAKernel + Differentiable: f(x) = x^2, requires _threadcount.
+[CUDAKernel]
+[Differentiable]
+void diff_square_kernel(uint count, DiffTensorView<float> input, DiffTensorView<float> output)
+{
+    uint tid = cudaBlockIdx().x * cudaBlockDim().x + cudaThreadIdx().x;
+    if (tid >= count)
+        return;
+    float x = input.load(tid);
+    output.store(tid, x * x);
+}

--- a/slangpy/tests/slangpy_tests/test_tensorview.py
+++ b/slangpy/tests/slangpy_tests/test_tensorview.py
@@ -134,5 +134,97 @@ def test_tensorview_grid_dispatch(device_type: DeviceType):
     assert np.array_equal(result, expected), f"Expected all markers to be 1, got {result}"
 
 
+# ============================================================================
+# Tests for TensorView<float2> / <float4> (vector element types)
+# ============================================================================
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+@pytest.mark.skipif(not (HAS_TORCH and torch.cuda.is_available()), reason="CUDA not available")
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_tensorview_float2_torch(device_type: DeviceType):
+    """Test TensorView<float2> with a float32 torch tensor (2 floats per element)."""
+    device = helpers.get_torch_device(device_type)
+    module = load_module(device)
+
+    input_tensor = torch.tensor(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device="cuda", dtype=torch.float32
+    )
+    output_tensor = torch.zeros(3, 2, device="cuda", dtype=torch.float32)
+
+    module.copy_tensorview_float2(input_tensor, output_tensor, _threadcount=1)
+    torch.cuda.synchronize()
+
+    assert torch.allclose(
+        input_tensor, output_tensor
+    ), f"Expected {input_tensor}, got {output_tensor}"
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+@pytest.mark.skipif(not (HAS_TORCH and torch.cuda.is_available()), reason="CUDA not available")
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_tensorview_float4_torch(device_type: DeviceType):
+    """Test TensorView<float4> with a float32 torch tensor (4 floats per element)."""
+    device = helpers.get_torch_device(device_type)
+    module = load_module(device)
+
+    input_tensor = torch.tensor(
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=torch.float32
+    )
+    output_tensor = torch.zeros(2, 4, device="cuda", dtype=torch.float32)
+
+    module.copy_tensorview_float4(input_tensor, output_tensor, _threadcount=1)
+    torch.cuda.synchronize()
+
+    assert torch.allclose(
+        input_tensor, output_tensor
+    ), f"Expected {input_tensor}, got {output_tensor}"
+
+
+# ============================================================================
+# Tests for _threadcount (CUDAKernel dispatch)
+# ============================================================================
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+@pytest.mark.skipif(not (HAS_TORCH and torch.cuda.is_available()), reason="CUDA not available")
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_threadcount_fill_ids(device_type: DeviceType):
+    """Test _threadcount with a CUDAKernel that fills thread IDs."""
+    device = helpers.get_torch_device(device_type)
+    module = load_module(device)
+
+    count = 64
+    output = torch.zeros(count, device="cuda", dtype=torch.int32)
+
+    module.fill_thread_ids(count=count, output=output, _threadcount=count)
+    torch.cuda.synchronize()
+
+    expected = torch.arange(count, device="cuda", dtype=torch.int32)
+    assert torch.equal(output, expected), f"Expected {expected}, got {output}"
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+@pytest.mark.skipif(not (HAS_TORCH and torch.cuda.is_available()), reason="CUDA not available")
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_threadcount_append_to(device_type: DeviceType):
+    """Test _threadcount goes through the append_to dispatch path."""
+    device = helpers.get_torch_device(device_type)
+    module = load_module(device)
+
+    count = 64
+    output = torch.zeros(count, device="cuda", dtype=torch.int32)
+
+    command_encoder = device.create_command_encoder()
+    module.fill_thread_ids.append_to(
+        command_encoder, count=count, output=output, _threadcount=count
+    )
+
+    # Nothing should have executed yet
+    assert torch.all(output == 0), "Output should be zero before command buffer submission"
+
+    device.submit_command_buffer(command_encoder.finish())
+    torch.cuda.synchronize()
+
+    expected = torch.arange(count, device="cuda", dtype=torch.int32)
+    assert torch.equal(output, expected), f"Expected {expected}, got {output}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/slangpy_tests/test_tensorview.slang
+++ b/slangpy/tests/slangpy_tests/test_tensorview.slang
@@ -32,7 +32,7 @@ void copy_tensorview_float4(TensorView<float4> input, TensorView<float4> output)
         output.store(i, input.load(i));
 }
 
-// CUDAKernel that fills thread IDs - requires _threadcount to dispatch.
+// CUDAKernel that fills thread IDs - requires _thread_count to dispatch.
 [CUDAKernel]
 void fill_thread_ids(uint count, TensorView<int> output)
 {

--- a/slangpy/tests/slangpy_tests/test_tensorview.slang
+++ b/slangpy/tests/slangpy_tests/test_tensorview.slang
@@ -17,3 +17,27 @@ void mark_thread(int coord, TensorView<int> markers)
 {
     markers.store(coord, 1);
 }
+
+// Copy float2 elements between TensorView<float2>.
+void copy_tensorview_float2(TensorView<float2> input, TensorView<float2> output)
+{
+    for (uint i = 0; i < input.size(0); i++)
+        output.store(i, input.load(i));
+}
+
+// Copy float4 elements between TensorView<float4>.
+void copy_tensorview_float4(TensorView<float4> input, TensorView<float4> output)
+{
+    for (uint i = 0; i < input.size(0); i++)
+        output.store(i, input.load(i));
+}
+
+// CUDAKernel that fills thread IDs - requires _threadcount to dispatch.
+[CUDAKernel]
+void fill_thread_ids(uint count, TensorView<int> output)
+{
+    uint tid = cudaBlockIdx().x * cudaBlockDim().x + cudaThreadIdx().x;
+    if (tid >= count)
+        return;
+    output.store(tid, int(tid));
+}

--- a/slangpy/tests/slangpy_tests/test_type_resolution.py
+++ b/slangpy/tests/slangpy_tests/test_type_resolution.py
@@ -1232,6 +1232,13 @@ TESTS = [
     ("func_tensorview_generic", _Tensor("float", 1, True), "TensorView<float>", 1),
     ("func_tensorview_generic", _Tensor("int", 2, True), "TensorView<int>", 2),
 
+    # TensorView<float2> / <float4>: scalar float tensor should resolve to vector TensorView
+    ("func_tensorview_float2", _TorchTensor("float", 2), "TensorView<float2>", 1),
+    ("func_tensorview_float4", _TorchTensor("float", 2), "TensorView<float4>", 1),
+    # Non-float scalar should not resolve to TensorView<float2/float4>
+    ("func_tensorview_float2", _TorchTensor("int", 2), None, None),
+    ("func_tensorview_float4", _TorchTensor("int", 2), None, None),
+
     # DiffTensorView type resolution tests (CUDA-only, requires PyTorch)
     # NativeTorchTensorDiffPair should resolve to DiffTensorView<T>
     ("func_difftensorview_float", _TorchTensorDiffPair("float", 1), "DiffTensorView<float>", 1),

--- a/slangpy/tests/slangpy_tests/type_resolution.slang
+++ b/slangpy/tests/slangpy_tests/type_resolution.slang
@@ -486,6 +486,14 @@ void func_tensorview_generic<T>(TensorView<T> a)
 {
     return;
 }
+void func_tensorview_float2(TensorView<float2> a)
+{
+    return;
+}
+void func_tensorview_float4(TensorView<float4> a)
+{
+    return;
+}
 void func_difftensorview_float(DiffTensorView<float> a)
 {
     return;

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -1699,6 +1699,13 @@ SGL_PY_EXPORT(utils_slangpy)
             D_NA(NativeCallData, needs_unpack)
         )
         .def_prop_rw(
+            "has_thread_count",
+            &NativeCallData::has_thread_count,
+            &NativeCallData::set_has_thread_count,
+            nb::arg(),
+            D_NA(NativeCallData, has_thread_count)
+        )
+        .def_prop_rw(
             "autograd_access_list",
             &NativeCallData::autograd_access_list,
             &NativeCallData::set_autograd_access_list,

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -767,6 +767,11 @@ nb::object NativeCallData::exec(
         current_stride *= call_grid_data[i];
     }
 
+    // Override total_threads if _threadcount was explicitly provided.
+    if (opts->has_threadcount()) {
+        total_threads = opts->threadcount();
+    }
+
     nb::list read_back;
 
     if (is_log_enabled(LogLevel::debug)) {
@@ -1574,6 +1579,12 @@ SGL_PY_EXPORT(utils_slangpy)
             &NativeCallRuntimeOptions::cuda_stream,
             &NativeCallRuntimeOptions::set_cuda_stream,
             D_NA(NativeCallRuntimeOptions, cuda_stream)
+        )
+        .def_prop_rw(
+            "threadcount",
+            &NativeCallRuntimeOptions::threadcount,
+            &NativeCallRuntimeOptions::set_threadcount,
+            D_NA(NativeCallRuntimeOptions, threadcount)
         );
 
     // clang-format off

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -620,6 +620,123 @@ nb::object NativeCallData::append_to(
     return exec(opts, command_encoder, args, kwargs);
 }
 
+CallShapeInfo NativeCallData::compute_call_shape_info(
+    const ref<NativeCallRuntimeOptions>& opts,
+    const nb::list& unpacked_args,
+    const nb::dict& unpacked_kwargs
+)
+{
+    CallShapeInfo si;
+
+    if (opts->has_thread_count()) {
+        si.total_threads = opts->thread_count();
+        return si;
+    }
+
+    si.call_shape = m_runtime->calculate_call_shape(m_call_dimensionality, unpacked_args, unpacked_kwargs, this);
+    m_last_call_shape = si.call_shape;
+
+    const size_t num_dims = si.call_shape.size();
+
+    // Calculate strides from call_shape
+    si.strides = Shape(num_dims);
+    int* strides_data = si.strides.data();
+    int current_stride = 1;
+    for (int i = static_cast<int>(num_dims) - 1; i >= 0; --i) {
+        strides_data[i] = current_stride;
+        current_stride *= si.call_shape[i];
+    }
+
+    // Get call group shape from build info.
+    si.call_group_shape = Shape(num_dims, 1); // Initialize to all 1s (default)
+    int* call_group_data = si.call_group_shape.data();
+
+    if (m_call_group_shape.valid() && m_call_group_shape.size() > 0) {
+        const size_t src_size = m_call_group_shape.size();
+
+        if (src_size > num_dims) {
+            throw std::runtime_error(
+                fmt::format(
+                    "call_group_shape dimensionality ({}) must be <= call_shape dimensionality ({}). "
+                    "call_group_shape cannot have more dimensions than call_shape.",
+                    src_size,
+                    num_dims
+                )
+            );
+        }
+
+        const size_t padding = num_dims - src_size;
+        if (padding > 0 && is_log_enabled(LogLevel::debug)) {
+            log_debug(
+                "call_group_shape dimensionality ({}) < call_shape dimensionality ({}). "
+                "Padding call_group_shape with {} leading 1's. "
+                "Consider specifying full dimensions for better performance.",
+                src_size,
+                num_dims,
+                padding
+            );
+        }
+
+        const int* src_data = m_call_group_shape.data();
+        for (size_t i = 0; i < src_size; ++i) {
+            int val = src_data[i];
+            if (val < 1) {
+                throw std::runtime_error(
+                    fmt::format(
+                        "call_group_shape[{}] = {} is invalid. All call_group_shape elements must be >= 1.",
+                        i,
+                        val
+                    )
+                );
+            }
+            call_group_data[padding + i] = val;
+        }
+    }
+
+    // Calculate the group strides
+    si.call_group_strides = Shape(num_dims);
+    int* call_group_strides_data = si.call_group_strides.data();
+    current_stride = 1;
+    for (int i = static_cast<int>(num_dims) - 1; i >= 0; --i) {
+        call_group_strides_data[i] = current_stride;
+        current_stride *= call_group_data[i];
+    }
+
+    // Calculate the grid shape and total threads.
+    //
+    // Note: The call shape may not be call group shape aligned, in which case we
+    //       will align up the call shape. This will result in
+    //       aligned_call_shape.size - call_shape.size wasted threads. It might be
+    //       possible to create some logic to avoid waste, but a call group would
+    //       likely end up torn and representing different regions of the call shape,
+    //       which would likely defeat the purpose of using call groups for better
+    //       memory coherency and uses of shared memory.
+    si.total_threads = 1;
+    si.call_grid_shape = Shape(num_dims);
+    si.aligned_call_shape = Shape(num_dims);
+    int* call_grid_data = si.call_grid_shape.data();
+    int* aligned_call_data = si.aligned_call_shape.data();
+    const int* call_shape_data = si.call_shape.data();
+    for (size_t i = 0; i < num_dims; i++) {
+        call_grid_data[i] = (call_shape_data[i] + call_group_data[i] - 1) / call_group_data[i];
+        aligned_call_data[i] = call_grid_data[i] * call_group_data[i];
+        if (aligned_call_data[i] != call_shape_data[i])
+            si.is_call_shape_unaligned = true;
+        si.total_threads *= aligned_call_data[i];
+    }
+
+    // Calculate the grid strides
+    si.call_grid_strides = Shape(num_dims);
+    int* call_grid_strides_data = si.call_grid_strides.data();
+    current_stride = 1;
+    for (int i = static_cast<int>(num_dims) - 1; i >= 0; --i) {
+        call_grid_strides_data[i] = current_stride;
+        current_stride *= call_grid_data[i];
+    }
+
+    return si;
+}
+
 nb::object NativeCallData::exec(
     ref<NativeCallRuntimeOptions> opts,
     CommandEncoder* command_encoder,
@@ -642,9 +759,16 @@ nb::object NativeCallData::exec(
             unpacked_kwargs[k] = v;
     }
 
-    // Calculate call shape.
-    Shape call_shape = m_runtime->calculate_call_shape(m_call_dimensionality, unpacked_args, unpacked_kwargs, this);
-    m_last_call_shape = call_shape;
+    auto si = compute_call_shape_info(opts, unpacked_args, unpacked_kwargs);
+    auto& call_shape = si.call_shape;
+    auto& strides = si.strides;
+    auto& call_group_shape = si.call_group_shape;
+    auto& call_group_strides = si.call_group_strides;
+    auto& call_grid_shape = si.call_grid_shape;
+    auto& call_grid_strides = si.call_grid_strides;
+    auto& aligned_call_shape = si.aligned_call_shape;
+    auto& is_call_shape_unaligned = si.is_call_shape_unaligned;
+    int total_threads = si.total_threads;
 
     // Setup context.
     auto context = make_ref<CallContext>(m_device, call_shape, m_call_mode);
@@ -660,116 +784,6 @@ nb::object NativeCallData::exec(
             Shape call_shape_copy = call_shape;
             rv_node->populate_call_shape(call_shape_copy, output, this);
         }
-    }
-
-    // Calculate strides from call_shape
-    Shape strides(call_shape.size());
-    int* strides_data = strides.data();
-    int current_stride = 1;
-    for (int i = static_cast<int>(call_shape.size()) - 1; i >= 0; --i) {
-        strides_data[i] = current_stride;
-        current_stride *= call_shape[i];
-    }
-
-    // Get call group shape from build info.
-    // Pre-allocate to call_shape size since we know the final size will match.
-    const size_t num_dims = call_shape.size();
-    Shape call_group_shape(num_dims, 1); // Initialize to all 1s (default)
-    int* call_group_data = call_group_shape.data();
-
-    if (m_call_group_shape.valid() && m_call_group_shape.size() > 0) {
-        const size_t src_size = m_call_group_shape.size();
-
-        // Verify that call_group_shape has valid dimensions.
-        if (src_size > num_dims) {
-            throw std::runtime_error(
-                fmt::format(
-                    "call_group_shape dimensionality ({}) must be <= call_shape dimensionality ({}). "
-                    "call_group_shape cannot have more dimensions than call_shape.",
-                    src_size,
-                    num_dims
-                )
-            );
-        }
-
-        // Calculate padding offset if source is smaller than destination
-        const size_t padding = num_dims - src_size;
-        if (padding > 0 && is_log_enabled(LogLevel::debug)) {
-            log_debug(
-                "call_group_shape dimensionality ({}) < call_shape dimensionality ({}). "
-                "Padding call_group_shape with {} leading 1's. "
-                "Consider specifying full dimensions for better performance.",
-                src_size,
-                num_dims,
-                padding
-            );
-        }
-
-        // Copy source data with padding offset (leading 1s are already set)
-        const int* src_data = m_call_group_shape.data();
-        for (size_t i = 0; i < src_size; ++i) {
-            int val = src_data[i];
-            if (val < 1) {
-                throw std::runtime_error(
-                    fmt::format(
-                        "call_group_shape[{}] = {} is invalid. All call_group_shape elements must be >= 1.",
-                        i,
-                        val
-                    )
-                );
-            }
-            call_group_data[padding + i] = val;
-        }
-    }
-    // else: call_group_shape is already initialized to all 1s
-
-    // Calculate the group strides
-    Shape call_group_strides(num_dims);
-    int* call_group_strides_data = call_group_strides.data();
-    current_stride = 1;
-    for (int i = static_cast<int>(num_dims) - 1; i >= 0; --i) {
-        call_group_strides_data[i] = current_stride;
-        current_stride *= call_group_data[i];
-    }
-
-    // Calculate the grid shape and total threads.
-    //
-    // Note: The call shape may not be call group shape aligned, in which case we
-    //       will align up the call shape. This will result in
-    //       aligned_call_shape.size - call_shape.size wasted threads. It might be
-    //       possible to create some logic to avoid waste, but a call group would
-    //       likely end up torn and representing different regions of the call shape,
-    //       which would likely defeat the purpose of using call groups for better
-    //       memory coherency and uses of shared memory.
-    int total_threads = 1;
-    Shape call_grid_shape(num_dims);
-    Shape aligned_call_shape(num_dims);
-    int* call_grid_data = call_grid_shape.data();
-    int* aligned_call_data = aligned_call_shape.data();
-    const int* call_shape_data = call_shape.data();
-    bool is_call_shape_unaligned = false;
-    for (size_t i = 0; i < num_dims; i++) {
-        // When the call shape is not call group shape aligned, we will add some
-        // padding to align up.
-        call_grid_data[i] = (call_shape_data[i] + call_group_data[i] - 1) / call_group_data[i]; // ceil division
-        aligned_call_data[i] = call_grid_data[i] * call_group_data[i];
-        if (aligned_call_data[i] != call_shape_data[i])
-            is_call_shape_unaligned = true;
-        total_threads *= aligned_call_data[i];
-    }
-
-    // Calculate the grid strides
-    Shape call_grid_strides(num_dims);
-    int* call_grid_strides_data = call_grid_strides.data();
-    current_stride = 1;
-    for (int i = static_cast<int>(num_dims) - 1; i >= 0; --i) {
-        call_grid_strides_data[i] = current_stride;
-        current_stride *= call_grid_data[i];
-    }
-
-    // Override total_threads if _threadcount was explicitly provided.
-    if (opts->has_threadcount()) {
-        total_threads = opts->threadcount();
     }
 
     nb::list read_back;
@@ -1581,10 +1595,10 @@ SGL_PY_EXPORT(utils_slangpy)
             D_NA(NativeCallRuntimeOptions, cuda_stream)
         )
         .def_prop_rw(
-            "threadcount",
-            &NativeCallRuntimeOptions::threadcount,
-            &NativeCallRuntimeOptions::set_threadcount,
-            D_NA(NativeCallRuntimeOptions, threadcount)
+            "thread_count",
+            &NativeCallRuntimeOptions::thread_count,
+            &NativeCallRuntimeOptions::set_thread_count,
+            D_NA(NativeCallRuntimeOptions, thread_count)
         );
 
     // clang-format off

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -775,6 +775,12 @@ public:
     /// Set whether args need unpacking.
     void set_needs_unpack(bool needs_unpack) { m_needs_unpack = needs_unpack; }
 
+    /// Get whether this call data expects a _thread_count kwarg.
+    bool has_thread_count() const { return m_has_thread_count; }
+
+    /// Set whether this call data expects a _thread_count kwarg.
+    void set_has_thread_count(bool has_thread_count) { m_has_thread_count = has_thread_count; }
+
     /// Get the autograd access list.
     /// This is a flat list of AutogradAccess values precomputed at build time.
     /// At dispatch time, find_torch_tensors steps through this list as it encounters tensors.
@@ -905,6 +911,7 @@ private:
     bool m_torch_integration{false};
     bool m_torch_autograd{false};
     bool m_needs_unpack{true};
+    bool m_has_thread_count{false};
     std::vector<AutogradAccess> m_autograd_access_list;
     ref<NativeCallData> m_bwds_call_data;
     mutable CallDataOffsets m_cached_call_data_offsets;

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -643,13 +643,13 @@ public:
     void set_is_ray_tracing(bool is_ray_tracing) { m_is_ray_tracing = is_ray_tracing; }
 
     /// Get the thread count override.
-    int threadcount() const { return m_threadcount; }
+    int thread_count() const { return m_thread_count; }
 
     /// Set the thread count override.
-    void set_threadcount(int threadcount) { m_threadcount = threadcount; }
+    void set_thread_count(int thread_count) { m_thread_count = thread_count; }
 
     /// Check if thread count override is set.
-    bool has_threadcount() const { return m_threadcount > 0; }
+    bool has_thread_count() const { return m_thread_count > 0; }
 
     /// Clear internal data for garbage collection
     void garbage_collect()
@@ -663,7 +663,7 @@ private:
     nb::object m_this{nb::none()};
     NativeHandle m_cuda_stream;
     bool m_is_ray_tracing{false};
-    int m_threadcount{0};
+    int m_thread_count{0};
 };
 
 /// Defines the common logging functions for a given log level.
@@ -680,6 +680,18 @@ private:
     {                                                                                                                  \
         log(level, fmt::format(fmt, std::forward<Args>(args)...), LogFrequency::always);                               \
     }
+
+struct CallShapeInfo {
+    Shape call_shape = Shape(0, 0);
+    Shape strides = Shape(0, 0);
+    Shape call_group_shape = Shape(0, 0);
+    Shape call_group_strides = Shape(0, 0);
+    Shape call_grid_shape = Shape(0, 0);
+    Shape call_grid_strides = Shape(0, 0);
+    Shape aligned_call_shape = Shape(0, 0);
+    bool is_call_shape_unaligned{false};
+    int total_threads{0};
+};
 
 /// Contains the compute pipeline for a call, the corresponding bindings and any additional
 /// options provided by the user.
@@ -899,6 +911,12 @@ private:
 
     /// Recursive helper for find_torch_tensors.
     nb::object find_torch_tensors_recurse(nb::object arg, nb::list& pairs, size_t& access_idx);
+
+    CallShapeInfo compute_call_shape_info(
+        const ref<NativeCallRuntimeOptions>& opts,
+        const nb::list& unpacked_args,
+        const nb::dict& unpacked_kwargs
+    );
 
     nb::object
     exec(ref<NativeCallRuntimeOptions> opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -642,6 +642,15 @@ public:
     /// Set ray tracing pipeline flag.
     void set_is_ray_tracing(bool is_ray_tracing) { m_is_ray_tracing = is_ray_tracing; }
 
+    /// Get the thread count override.
+    int threadcount() const { return m_threadcount; }
+
+    /// Set the thread count override.
+    void set_threadcount(int threadcount) { m_threadcount = threadcount; }
+
+    /// Check if thread count override is set.
+    bool has_threadcount() const { return m_threadcount > 0; }
+
     /// Clear internal data for garbage collection
     void garbage_collect()
     {
@@ -654,6 +663,7 @@ private:
     nb::object m_this{nb::none()};
     NativeHandle m_cuda_stream;
     bool m_is_ray_tracing{false};
+    int m_threadcount{0};
 };
 
 /// Defines the common logging functions for a given log level.

--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -27,6 +27,7 @@ ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cac
 {
     auto options = make_ref<NativeCallRuntimeOptions>();
     gather_runtime_options(options);
+    gather_kwargs_runtime_options(options, kwargs);
 
     nb::tuple full_args;
     if (!options->get_this().is_none()) {
@@ -50,6 +51,7 @@ nb::object NativeFunctionNode::call(NativeCallDataCache* cache, nb::args args, n
 {
     auto options = make_ref<NativeCallRuntimeOptions>();
     gather_runtime_options(options);
+    gather_kwargs_runtime_options(options, kwargs);
 
     nb::tuple full_args;
     if (!options->get_this().is_none()) {
@@ -94,6 +96,7 @@ void NativeFunctionNode::append_to(
 {
     auto options = make_ref<NativeCallRuntimeOptions>();
     gather_runtime_options(options);
+    gather_kwargs_runtime_options(options, kwargs);
 
     nb::tuple full_args;
     if (!options->get_this().is_none()) {
@@ -103,7 +106,6 @@ void NativeFunctionNode::append_to(
     auto builder = make_ref<SignatureBuilder>();
     read_signature(builder);
     cache->get_args_signature(builder, args, kwargs);
-
 
     std::string sig = builder->str();
     NativeCallData* call_data = cache->find_call_data(sig);

--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -30,13 +30,9 @@ namespace sgl::slangpy {
 // kwargs.contains() string lookup is avoided entirely on the common no-thread-count path.
 static bool read_thread_count_kwarg(ref<NativeCallRuntimeOptions> options, nb::kwargs& kwargs)
 {
-    if (!kwargs.contains("_thread_count"))
-        return false;
+    SGL_ASSERT(kwargs.contains("_thread_count"));
     int thread_count = nb::cast<int>(kwargs["_thread_count"]);
-    if (thread_count <= 0)
-        throw nb::value_error(
-            ("_thread_count must be a positive integer, got " + std::to_string(thread_count)).c_str()
-        );
+    SGL_CHECK(thread_count > 0, "_thread_count must be a positive integer, got {}", thread_count);
     options->set_thread_count(thread_count);
     return true;
 }

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -91,6 +91,20 @@ public:
         }
     }
 
+    /// Extract runtime options from special underscore kwargs (e.g. _threadcount).
+    static void gather_kwargs_runtime_options(ref<NativeCallRuntimeOptions> options, nb::kwargs& kwargs)
+    {
+        if (kwargs.contains("_threadcount")) {
+            int threadcount = nb::cast<int>(kwargs["_threadcount"]);
+            if (threadcount <= 0)
+                throw nb::value_error(
+                    ("_threadcount must be a positive integer, got " + std::to_string(threadcount)).c_str()
+                );
+            options->set_threadcount(threadcount);
+            nb::del(kwargs["_threadcount"]);
+        }
+    }
+
     NativeFunctionNode* parent() const { return m_parent.get(); }
 
     FunctionNodeType type() const { return m_type; }

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -91,19 +91,6 @@ public:
         }
     }
 
-    /// Extract runtime options from special underscore kwargs (e.g. _threadcount).
-    static void gather_kwargs_runtime_options(ref<NativeCallRuntimeOptions> options, nb::kwargs& kwargs)
-    {
-        if (kwargs.contains("_threadcount")) {
-            int threadcount = nb::cast<int>(kwargs["_threadcount"]);
-            if (threadcount <= 0)
-                throw nb::value_error(
-                    ("_threadcount must be a positive integer, got " + std::to_string(threadcount)).c_str()
-                );
-            options->set_threadcount(threadcount);
-            nb::del(kwargs["_threadcount"]);
-        }
-    }
 
     NativeFunctionNode* parent() const { return m_parent.get(); }
 


### PR DESCRIPTION
This CL adds support for 2 features.

Fixes #819

### 1. Optional _threadcount argument when launching kernels.

Slangpy's internal thrad count calculation is based on argument shapes. For eg: if we have a normal slangpy function with vectorizable arguments:

`void add(float a, float b) {}`

then slangpy launches 1000 threads if the user passed in two 1000 sized tensors. Now, when all arguments have call_dim = 0, i.e no arguments are vectorized, slangpy cannot determine how many threads to launch. In this case, a _threadcount helps slangpy to launch proper number of threads.
`[CUDAKernel]` functions typically take TensorView<T> / DiffTensorView<T> and this _threadcount helps in that case.

### 2. Support float<N> with TensorView and DiffTensorView

```
void _trampoline(Context __slangpy_context__, CallData __calldata__)
  {
      TensorView<vector<float,2>> input;
      TensorView<vector<float,2>> output;
      input = __calldata__.input;
      output = __calldata__.output;
      copy_tensorview_float2(input, output);
  }
```
Also notice from the bindings:
```
input  | RWTensor<float, 2> | TensorView<vector<float,2>> | [-1, -1] | Call Dim: 0
output | RWTensor<float, 2> | TensorView<vector<float,2>> | [-1, -1] | Call Dim: 0

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TensorView resolution now accepts vector element types (e.g., float2/float4) for compatible scalar→vector bindings.
  * Expose a writable thread-count override on runtime options and a flag to indicate when it’s used.

* **Bug Fixes**
  * Validation added to reject thread-count usage for dispatch shapes where it’s invalid (clearer error).

* **Tests**
  * Added CUDA/differentiable kernel tests plus TensorView/vector-resolution tests covering forward/backward and dispatch paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->