### PR TITLE
Use SLANG_STATUS_TOKEN for posting status to Slang PRs

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -194,7 +194,7 @@ jobs:
         if: always() && github.event_name == 'repository_dispatch'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.SLANG_STATUS_TOKEN }}
           script: |
             await github.rest.repos.createCommitStatus({
               owner: 'shader-slang',


### PR DESCRIPTION
## Summary
- Use dedicated `SLANG_STATUS_TOKEN` PAT instead of `GITHUB_TOKEN` for posting commit statuses back to Slang PRs
- `GITHUB_TOKEN` from SlangPy repo cannot write statuses to the Slang repo (cross-repo limitation)

Relates to shader-slang/slang#9220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication token configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->