### PR TITLE
Fix Slang checkout for fork PRs

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -97,9 +97,15 @@ jobs:
       # Checkout Slang.
       - name: Checkout Slang
         run: |
-          git clone --recursive https://github.com/shader-slang/slang.git
+          git clone https://github.com/shader-slang/slang.git
           cd slang
-          git checkout ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.slang_ref || github.event.inputs.slang_branch || 'master' }}
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            # Fetch the PR head ref (works for both fork and non-fork PRs)
+            git fetch origin pull/${{ github.event.client_payload.slang_pr_number }}/head
+            git checkout FETCH_HEAD
+          else
+            git checkout ${{ github.event.inputs.slang_branch || 'master' }}
+          fi
           git submodule update --init --recursive
 
       # Build Slang.


### PR DESCRIPTION
## Summary
- Use `git fetch origin pull/N/head` instead of checking out by commit SHA
- Fork PR commits only exist in the fork repo and aren't directly accessible via SHA in the upstream clone
- The `pull/N/head` ref is available for all PRs regardless of origin

Relates to shader-slang/slang#9220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline configuration to better handle different build scenarios and event types. Enhanced flexibility in branch checkout and submodule update processes for more robust continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->