### PR TITLE
Fix Slang checkout step to use bash shell on Windows

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -96,6 +96,7 @@ jobs:
 
       # Checkout Slang.
       - name: Checkout Slang
+        shell: bash
         run: |
           git clone https://github.com/shader-slang/slang.git
           cd slang


### PR DESCRIPTION
## Summary
- Add `shell: bash` to the Checkout Slang step
- Windows runners default to PowerShell, which can't parse `if [ ... ]; then` syntax

Relates to shader-slang/slang#9220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow reliability for improved pull request validation and branch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->