### PR TITLE
Report passing CI status when path filter skips builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: "2"
+          fetch-depth: 0
       - id: filter
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch origin ${{ github.base_ref }}
             BASE=origin/${{ github.base_ref }}
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            BASE=${{ github.event.before }}
           else
             BASE=HEAD^1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,23 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "LICENSES/**"
-      - "LICENSE"
-      - "**.md"
-      - .github/workflows/wheels.yml
-      - .github/workflows/ci-gcp.yml
-      - .github/workflows/ci-latest-slang.yml
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "LICENSES/**"
-      - "LICENSE"
-      - "**.md"
-      - .github/workflows/wheels.yml
-      - .github/workflows/ci-gcp.yml
-      - .github/workflows/ci-latest-slang.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -31,7 +16,46 @@ permissions:
   id-token: write
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.filter.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "2"
+      - id: filter
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin ${{ github.base_ref }}
+            BASE=origin/${{ github.base_ref }}
+          else
+            BASE=HEAD^1
+          fi
+
+          shouldRun=true
+          if files="$(git diff --name-only $BASE...HEAD)"; then
+            IGNORE_PATTERN='^(LICENSES/|LICENSE$|\.github/workflows/(wheels|ci-gcp|ci-latest-slang)\.yml$)'
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              IGNORE_PATTERN='^(docs/|LICENSES/|LICENSE$|\.github/workflows/(wheels|ci-gcp|ci-latest-slang)\.yml$)'
+            fi
+            # Also always ignore markdown files
+            IGNORE_PATTERN="${IGNORE_PATTERN}|\.md$"
+            if echo "$files" | grep -qvE "$IGNORE_PATTERN"; then
+              shouldRun=true
+            else
+              echo "Only ignored files changed, skipping build"
+              shouldRun=false
+            fi
+          else
+            echo "Git diff failed, conservatively running build"
+            shouldRun=true
+          fi
+          echo "should-run=$shouldRun" >> $GITHUB_OUTPUT
+
   build:
+    needs: filter
+    if: needs.filter.outputs.should-run == 'true'
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Replace `paths-ignore` with a `dorny/paths-filter` changes detection job so that skipped builds are reported as "skipped" instead of missing
- Prevents PRs from getting stuck waiting on required status checks when only docs/markdown/license files change
- Preserves existing filter behavior: `docs/**` excluded on push to main but not on PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now conditionally skips builds for documentation, license, workflow YAML edits, and markdown-only changes to avoid unnecessary runs.
  * A new pre-check filter gates downstream jobs so builds only run when relevant code changes are detected.
  * This reduces CI load and speeds feedback on pull requests by preventing redundant build executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->