### PR TITLE
Fix Linux wheel builds: QEMU for aarch64, missing perl/openssl deps

### DIFF
--- a/.github/workflows/wheels-dev.yml
+++ b/.github/workflows/wheels-dev.yml
@@ -9,10 +9,9 @@ env:
   CIBW_BUILD_VERBOSITY: 1
   CIBW_SKIP: "*-musllinux*"
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
-  CIBW_ARCHS_WINDOWS: auto64
-  CIBW_ARCHS_LINUX: auto64
+  CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_34
   CIBW_TEST_COMMAND: "python -c \"import slangpy\""
-  CIBW_BEFORE_ALL_LINUX: yum install -y zip wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel ninja-build perl-IPC-Cmd
+  CIBW_BEFORE_ALL_LINUX: yum install -y zip wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel ninja-build perl-IPC-Cmd kernel-headers perl-FindBin perl-Time-Piece perl-lib clang
   CIBW_ENVIRONMENT: BUILD_RELEASE_WHEEL=1 SLANGPY_DEV_SUFFIX=$SLANGPY_DEV_SUFFIX
   MACOSX_DEPLOYMENT_TARGET: 14.0
   BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -38,6 +37,12 @@ jobs:
           - { os: macos, runs-on: [macos-latest] }
 
     steps:
+      - name: Set up QEMU
+        if: matrix.os == 'linux' && matrix.platform == 'aarch64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,11 +15,10 @@ env:
   CIBW_BUILD_VERBOSITY: 1
   CIBW_SKIP: "*-musllinux*"
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
-  CIBW_ARCHS_WINDOWS: auto64
-  CIBW_ARCHS_LINUX: auto64
+  CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_34
   CIBW_TEST_COMMAND: "python -c \"import slangpy\""
   # zip required for vcpkg, rest for glfw
-  CIBW_BEFORE_ALL_LINUX: yum install -y zip wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel ninja-build perl-IPC-Cmd
+  CIBW_BEFORE_ALL_LINUX: yum install -y zip wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel ninja-build perl-IPC-Cmd kernel-headers perl-FindBin perl-Time-Piece perl-lib clang
   # make sure slangpy wheel is build with testing data + corrected project directory
   CIBW_ENVIRONMENT: BUILD_RELEASE_WHEEL=1
   MACOSX_DEPLOYMENT_TARGET: 14.0
@@ -49,6 +48,12 @@ jobs:
           - { os: macos, runs-on: [macos-latest] }
 
     steps:
+      - name: Set up QEMU
+        if: matrix.os == 'linux' && matrix.platform == 'aarch64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -58,6 +63,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Set CIBW_ARCHS
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "macos" ]; then
+            echo "CIBW_ARCHS=arm64" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" = "windows" ]; then
+            echo "CIBW_ARCHS=AMD64" >> $GITHUB_ENV
+          else
+            echo "CIBW_ARCHS=${{ matrix.platform }}" >> $GITHUB_ENV
+          fi
 
       # Install cibuildwheel.
       - name: Install cibuildwheel

--- a/external/vcpkg-overlays/crashpad/fix-memset-nontrivial.patch
+++ b/external/vcpkg-overlays/crashpad/fix-memset-nontrivial.patch
@@ -1,0 +1,21 @@
+diff --git a/util/linux/thread_info.cc b/util/linux/thread_info.cc
+index 1234567..abcdefg 100644
+--- a/util/linux/thread_info.cc
++++ b/util/linux/thread_info.cc
+@@ -18,13 +18,13 @@
+
+ namespace crashpad {
+
+ ThreadContext::ThreadContext() {
+-  memset(this, 0, sizeof(*this));
++  memset(static_cast<void*>(this), 0, sizeof(*this));
+ }
+
+ ThreadContext::~ThreadContext() {}
+
+ FloatContext::FloatContext() {
+-  memset(this, 0, sizeof(*this));
++  memset(static_cast<void*>(this), 0, sizeof(*this));
+ }
+
+ FloatContext::~FloatContext() {}

--- a/external/vcpkg-overlays/crashpad/portfile.cmake
+++ b/external/vcpkg-overlays/crashpad/portfile.cmake
@@ -9,6 +9,15 @@ vcpkg_from_git(
         fix-lib-name-conflict.patch
 )
 
+# Apply Linux-specific memset fix for clang 20+ compatibility
+if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_ANDROID)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/fix-memset-nontrivial.patch"
+    )
+endif()
+
 vcpkg_find_acquire_program(PYTHON3)
 x_vcpkg_get_python_packages(OUT_PYTHON_VAR PYTHON3
     PYTHON_EXECUTABLE "${PYTHON3}"


### PR DESCRIPTION
## Summary
Fixes Linux wheel builds (both x86_64 and aarch64) by addressing multiple dependency and configuration issues that have been blocking wheel generation.

## Changes

### 1. aarch64 Cross-Compilation Support
- Add `docker/setup-qemu-action@v3` to enable aarch64 builds on x86_64 runners
- Add `CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_34` to match x86_64 image

### 2. CIBW_ARCHS Configuration
- Remove `CIBW_ARCHS_LINUX`/`CIBW_ARCHS_WINDOWS` globals that were overriding per-job settings
- Add `Set CIBW_ARCHS` step to `wheels.yml` (already existed in `wheels-dev.yml`)

### 3. vcpkg openssl 3.5.2 Dependencies
- Add `perl-lib`, `perl-FindBin`, `perl-Time-Piece` modules required by openssl Configure script
- Add `kernel-headers` required by openssl 3.5.2 build

### 4. Crashpad Build Dependencies
- Add `clang` compiler required by crashpad's GN build system
- Add Linux-specific patch to fix clang 20+ `-Werror,-Wnontrivial-memcall` error in `util/linux/thread_info.cc`

## Testing
Tested on fork with all matrix combinations:
- ✅ Linux x86_64: cp39, cp310, cp311, cp312, cp313
- ✅ Linux aarch64: cp39, cp310, cp311, cp312, cp313  
- ✅ Windows x86_64: all versions
- ✅ macOS aarch64: all versions

Test run: https://github.com/szihs/slangpy/actions/runs/22763541327

## Notes
- The crashpad memset patch is applied conditionally only for Linux/Android targets where the file exists
- All changes are backward compatible with existing wheel builds
- No functional changes to the built wheels, only fixes for the build process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Added ARM64 (aarch64) architecture support for builds and package distribution.
  * Enhanced Linux build environment with expanded toolchain dependencies.
  * Introduced multi-architecture build capabilities using QEMU.

* **Bug Fixes**
  * Fixed memory initialization issue for Linux/Android builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->