### PR TITLE
Added setters for enums, converting to underlying ints

### DIFF
--- a/src/sgl/device/buffer_cursor.h
+++ b/src/sgl/device/buffer_cursor.h
@@ -14,6 +14,7 @@
 #include "sgl/device/cursor_access_wrappers.h"
 
 #include <string_view>
+#include <type_traits>
 
 namespace sgl {
 
@@ -69,6 +70,7 @@ public:
     template<typename T>
     void get(T& value) const;
 
+    /// Set a value that implements the write_to_cursor interface.
     template<typename T>
         requires(HasWriteToCursor<T, BufferElementCursor>)
     void set(const T& value)
@@ -76,8 +78,17 @@ public:
         value.write_to_cursor(*this);
     }
 
+    /// Set an enum value by converting it to its underlying integer type.
     template<typename T>
-        requires(!HasWriteToCursor<T, BufferElementCursor>)
+        requires(std::is_enum_v<T>)
+    void set(const T& value)
+    {
+        set(static_cast<std::underlying_type_t<T>>(value));
+    }
+
+    /// Set a plain data value by writing its bytes directly.
+    template<typename T>
+        requires(!HasWriteToCursor<T, BufferElementCursor> && !std::is_enum_v<T>)
     void set(const T& value);
 
     void _set_offset(size_t new_offset) { m_offset = new_offset; }

--- a/src/sgl/device/shader_cursor.h
+++ b/src/sgl/device/shader_cursor.h
@@ -13,6 +13,7 @@
 #include "sgl/device/cursor_access_wrappers.h"
 
 #include <string_view>
+#include <type_traits>
 
 namespace sgl {
 
@@ -93,6 +94,7 @@ public:
         return *this;
     }
 
+    /// Set a value that implements the write_to_cursor interface.
     template<typename T>
         requires(HasWriteToCursor<T, BufferElementCursor>)
     void set(const T& value) const
@@ -100,6 +102,15 @@ public:
         value.write_to_cursor(*this);
     }
 
+    /// Set an enum value by converting it to its underlying integer type.
+    template<typename T>
+        requires(std::is_enum_v<T>)
+    void set(const T& value)
+    {
+        set(static_cast<std::underlying_type_t<T>>(value));
+    }
+
+    /// Set a plain data value by writing its bytes directly.
     template<typename T>
         requires(!HasWriteToCursor<T, BufferElementCursor>)
     void set(const T& value) const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal buffer and shader cursor APIs to support enum value assignment, with automatic conversion to underlying types for improved type safety and developer ergonomics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->