### PR TITLE
Fix composite action shell for Windows self-hosted runners

### DIFF
--- a/.github/actions/build-and-test-with-slang/action.yml
+++ b/.github/actions/build-and-test-with-slang/action.yml
@@ -23,12 +23,15 @@ inputs:
   slang-pr-number:
     description: "Slang PR number to checkout (pr mode)"
     default: ""
+  shell:
+    description: "Shell to use for run steps (bash on Linux/macOS, pwsh on Windows)"
+    required: true
 
 runs:
   using: composite
   steps:
     - name: Cleanup submodules # Fix for https://github.com/actions/checkout/issues/358
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         git submodule foreach --recursive git clean -ffdx
         git submodule foreach --recursive git reset --hard
@@ -48,7 +51,7 @@ runs:
 
     # Setup Python environment.
     - name: Setup Python environment
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         python -m pip install -r requirements-dev.txt
         python -m pip install -r samples/requirements.txt
@@ -57,7 +60,7 @@ runs:
     # Setup PyTorch environment
     - name: Setup PyTorch environment
       if: runner.os != 'macos' && contains(inputs.flags, 'unit-test')
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         python -m pip install torch==2.8.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
 
@@ -72,7 +75,7 @@ runs:
     # Checkout Slang (branch mode).
     - name: Checkout Slang
       if: inputs.slang-checkout-mode == 'branch'
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         git clone --recursive https://github.com/shader-slang/slang.git
         cd slang
@@ -82,7 +85,7 @@ runs:
     # Checkout Slang (PR mode).
     - name: Checkout Slang (PR)
       if: inputs.slang-checkout-mode == 'pr'
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         git clone https://github.com/shader-slang/slang.git
         cd slang
@@ -92,7 +95,7 @@ runs:
 
     # Build Slang.
     - name: Build Slang
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         cd slang
         mkdir build
@@ -101,7 +104,7 @@ runs:
 
     # Setup.
     - name: Setup
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py setup
 
     # Setup vcpkg caching (GitHub-hosted runners only).
@@ -121,41 +124,41 @@ runs:
 
     # Configure.
     - name: Configure
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py --cmake-args="-DSGL_LOCAL_SLANG=ON -DSGL_LOCAL_SLANG_DIR=slang -DSGL_LOCAL_SLANG_BUILD_DIR=build/${{ inputs.config }}" configure
 
     # Build.
     - name: Build
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py build
 
     # Install slangpy-torch extension (requires MSVC on Windows, PyTorch installed)
     - name: Install slangpy-torch
       if: runner.os != 'macos' && contains(inputs.flags, 'unit-test')
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py install-slangpy-torch
 
     # Typing Checks (Python)
     - name: Typing Checks (Python)
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py typing-check-python
 
     # Unit Tests (C++)
     - name: Unit Tests (C++)
       if: contains(inputs.flags, 'unit-test')
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py unit-test-cpp
 
     # Unit Tests (Python)
     - name: Unit Tests (Python)
       if: contains(inputs.flags, 'unit-test')
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py unit-test-python --parallel
 
     # Test Examples
     - name: Test Examples
       if: contains(inputs.flags, 'test-examples')
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py test-examples -p
 
     # Upload Crashpad Reports
@@ -170,7 +173,7 @@ runs:
     # Generate Coverage Report
     - name: Generate Coverage Report
       if: contains(inputs.flags, 'coverage')
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python tools/ci.py coverage-report
 
     # Coverage Report
@@ -184,6 +187,6 @@ runs:
     # Cleanup slangpy-torch
     - name: Uninstall slangpy-torch
       if: always()
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: python -m pip uninstall slangpy-torch -y
       continue-on-error: true

--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -65,6 +65,7 @@ jobs:
           config: ${{ matrix.config }}
           python: ${{ matrix.python }}
           flags: ${{ matrix.flags }}
+          shell: ${{ matrix.os == 'windows' && 'pwsh' || 'bash' }}
           slang-checkout-mode: branch
           slang-branch: ${{ github.event.inputs.slang_branch || 'master' }}
 
@@ -103,6 +104,7 @@ jobs:
           config: ${{ matrix.config }}
           python: ${{ matrix.python }}
           flags: ${{ matrix.flags }}
+          shell: ${{ matrix.os == 'windows' && 'pwsh' || 'bash' }}
           slang-checkout-mode: pr
           slang-pr-number: ${{ github.event.client_payload.slang_pr_number }}
 


### PR DESCRIPTION
## Summary
- Self-hosted Windows runners don't have bash — `bash: command not found`
- Add configurable `shell` input to the composite action
- Workflow passes `pwsh` for Windows, `bash` for Linux/macOS
- Linux-specific steps (apt install, vcpkg env) keep `shell: bash`

Relates to shader-slang/slang#9220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and test infrastructure to better support different operating systems with optimized shell configuration for Windows, Linux, and macOS. These updates enhance the reliability and consistency of the continuous integration and testing processes, ensuring builds are executed with the most appropriate shell environment for each platform. This change strengthens cross-platform compatibility and reduces potential environment-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->