### PR TITLE
Eliminate heap allocations from cached dispatch hot path

### DIFF
--- a/src/sgl/utils/slangpy.h
+++ b/src/sgl/utils/slangpy.h
@@ -408,26 +408,23 @@ private:
 
 class SGL_API CallContext : Object {
 public:
-    CallContext(ref<Device> device, const Shape& call_shape, CallMode call_mode, NativeHandle cuda_stream)
+    CallContext(ref<Device> device, CallMode call_mode)
         : m_device(std::move(device))
-        , m_call_shape(call_shape)
         , m_call_mode(call_mode)
-        , m_cuda_stream(cuda_stream)
     {
+    }
+
+    /// Initialize call shape and CUDA stream (called each dispatch).
+    void init(const Shape& call_shape, NativeHandle cuda_stream)
+    {
+        m_call_shape = call_shape;
+        m_cuda_stream = cuda_stream;
     }
 
     Device* device() const { return m_device.get(); }
     const Shape& call_shape() const { return m_call_shape; }
     CallMode call_mode() const { return m_call_mode; }
-
     const NativeHandle& cuda_stream() const { return m_cuda_stream; }
-
-    /// Reinitialize the context for reuse (avoids heap allocation on cached path).
-    void reinitialize(const Shape& call_shape, NativeHandle cuda_stream)
-    {
-        m_call_shape = call_shape;
-        m_cuda_stream = cuda_stream;
-    }
 
 private:
     ref<Device> m_device;

--- a/src/sgl/utils/slangpy.h
+++ b/src/sgl/utils/slangpy.h
@@ -422,6 +422,13 @@ public:
 
     const NativeHandle& cuda_stream() const { return m_cuda_stream; }
 
+    /// Reinitialize the context for reuse (avoids heap allocation on cached path).
+    void reinitialize(const Shape& call_shape, NativeHandle cuda_stream)
+    {
+        m_call_shape = call_shape;
+        m_cuda_stream = cuda_stream;
+    }
+
 private:
     ref<Device> m_device;
     Shape m_call_shape;

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -738,8 +738,11 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
     if (total_threads == 0) {
         // Still allocate and return the (empty) result if needed.
         if (!command_encoder && m_call_mode == CallMode::prim) {
-            NativeHandle cuda_stream = opts->cuda_stream();
-            auto context = make_ref<CallContext>(m_device, call_shape, m_call_mode, cuda_stream);
+            NativeHandle cuda_stream = opts.cuda_stream;
+            if (!m_cached_context)
+                m_cached_context = make_ref<CallContext>(m_device, m_call_mode);
+            m_cached_context->init(call_shape, cuda_stream);
+            auto& context = m_cached_context;
             ref<NativeBoundVariableRuntime> rv_node = m_runtime->find_kwarg("_result");
             if (rv_node && (!kwargs.contains("_result") || kwargs["_result"].is_none())) {
                 nb::object output = rv_node->python_type()->create_output(context, rv_node.get());

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -709,9 +709,7 @@ CallShapeInfo NativeCallData::compute_call_shape_info(
 nb::object
 NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs)
 {
-    // Unpack args and kwargs (skip if no args have get_this/update_this).
-    // On the fast path (no unpack needed), avoid creating Python list/dict copies
-    // by using args (nb::tuple) and kwargs (nb::dict) directly.
+    // Skip unpacking when no args use get_this/update_this (avoids Python list/dict copy).
     nb::object unpacked_args;
     nb::dict unpacked_kwargs;
     if (m_needs_unpack) {
@@ -719,7 +717,6 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
         unpacked_args = unpack_args(args, had_unpack);
         unpacked_kwargs = unpack_kwargs(kwargs, had_unpack);
     } else {
-        // Fast path: borrow args/kwargs directly — zero allocation.
         unpacked_args = nb::borrow<nb::object>(args);
         unpacked_kwargs = nb::borrow<nb::dict>(kwargs);
     }

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -96,43 +96,15 @@ std::string NativeSlangType::to_string() const
     }
 }
 
-static constexpr std::array<char, 16> HEX_CHARS
-    = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-
-void SignatureBuilder::add(const std::string& value)
-{
-    add_bytes((const uint8_t*)value.data(), (int)value.length());
-}
-void SignatureBuilder::add(const char* value)
-{
-    add_bytes((const uint8_t*)value, (int)strlen(value));
-}
-void SignatureBuilder::add(const uint32_t value)
-{
-    uint8_t buffer[8];
-    for (int i = 0; i < 8; ++i) {
-        buffer[7 - i] = HEX_CHARS[(value >> (i * 4)) & 0xF];
-    }
-    add_bytes(buffer, 8);
-}
-void SignatureBuilder::add(const uint64_t value)
-{
-    uint8_t buffer[16];
-    for (int i = 0; i < 16; ++i) {
-        buffer[15 - i] = HEX_CHARS[(value >> (i * 4)) & 0xF];
-    }
-    add_bytes(buffer, 16);
-}
-
-
 nb::bytes SignatureBuilder::bytes() const
 {
-    return nb::bytes(m_buffer, m_size);
+    auto sv = m_buf.view();
+    return nb::bytes(sv.data(), sv.size());
 }
 
 std::string SignatureBuilder::str() const
 {
-    return std::string(reinterpret_cast<const char*>(m_buffer), m_size);
+    return std::string(m_buf.view());
 }
 
 void NativeMarshall::write_shader_cursor_pre_dispatch(
@@ -341,7 +313,7 @@ nb::object NativeBoundVariableRuntime::read_output(CallContext* context, nb::obj
 
 Shape NativeBoundCallRuntime::calculate_call_shape(
     int call_dimensionality,
-    nb::list args,
+    nb::object args,
     nb::dict kwargs,
     NativeCallData* error_context
 )
@@ -354,7 +326,8 @@ Shape NativeBoundCallRuntime::calculate_call_shape(
     }
 
     // Populate call shape for each positional argument.
-    for (size_t idx = 0; idx < args.size(); ++idx) {
+    size_t num_args = nb::len(args);
+    for (size_t idx = 0; idx < num_args; ++idx) {
         m_args[idx]->populate_call_shape(call_shape, args[idx], error_context);
     }
 
@@ -374,14 +347,15 @@ void NativeBoundCallRuntime::write_shader_cursor_pre_dispatch(
     CallContext* context,
     ShaderCursor root_cursor,
     ShaderCursor call_data_cursor,
-    nb::list args,
+    nb::object args,
     nb::dict kwargs,
     nb::list read_back
 
 )
 {
     // Write call data for each positional argument.
-    for (size_t idx = 0; idx < args.size(); ++idx) {
+    size_t num_args = nb::len(args);
+    for (size_t idx = 0; idx < num_args; ++idx) {
         auto cursor = m_args[idx]->is_param_block() ? root_cursor : call_data_cursor;
         m_args[idx]->write_shader_cursor_pre_dispatch(context, cursor, args[idx], read_back);
     }
@@ -489,9 +463,14 @@ nb::list NativeCallData::find_torch_tensors(nb::list args, nb::dict kwargs)
     return pairs;
 }
 
-nb::object NativeCallData::call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs)
+nb::object NativeCallData::call(RuntimeOptions& opts, nb::args args, nb::kwargs kwargs)
 {
     return exec(opts, nullptr, args, kwargs);
+}
+
+nb::object NativeCallData::call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs)
+{
+    return call(opts->opts(), args, kwargs);
 }
 
 nb::tuple
@@ -512,7 +491,7 @@ NativeCallData::autograd_forward(ref<NativeCallRuntimeOptions> opts, nb::list ar
     // Note: exec() may insert _result into kwargs, so check before calling exec.
     bool had_result = kwargs.contains("_result");
     nb::tuple args_tuple(args);
-    nb::object result = exec(opts, nullptr, nb::borrow<nb::args>(args_tuple), nb::borrow<nb::kwargs>(kwargs));
+    nb::object result = exec(opts->opts(), nullptr, nb::borrow<nb::args>(args_tuple), nb::borrow<nb::kwargs>(kwargs));
 
     // If result is a tensor and _result was not in kwargs before exec,
     // create a new output pair for it
@@ -606,7 +585,7 @@ nb::tuple NativeCallData::autograd_backward(
 }
 
 nb::object NativeCallData::append_to(
-    ref<NativeCallRuntimeOptions> opts,
+    RuntimeOptions& opts,
     CommandEncoder* command_encoder,
     nb::args args,
     nb::kwargs kwargs
@@ -615,16 +594,26 @@ nb::object NativeCallData::append_to(
     return exec(opts, command_encoder, args, kwargs);
 }
 
+nb::object NativeCallData::append_to(
+    ref<NativeCallRuntimeOptions> opts,
+    CommandEncoder* command_encoder,
+    nb::args args,
+    nb::kwargs kwargs
+)
+{
+    return append_to(opts->opts(), command_encoder, args, kwargs);
+}
+
 CallShapeInfo NativeCallData::compute_call_shape_info(
-    const ref<NativeCallRuntimeOptions>& opts,
-    const nb::list& unpacked_args,
+    RuntimeOptions& opts,
+    const nb::object& unpacked_args,
     const nb::dict& unpacked_kwargs
 )
 {
     CallShapeInfo si;
 
-    if (opts->has_thread_count()) {
-        si.total_threads = opts->thread_count();
+    if (opts.has_thread_count()) {
+        si.total_threads = opts.thread_count;
         return si;
     }
 
@@ -733,25 +722,25 @@ CallShapeInfo NativeCallData::compute_call_shape_info(
 }
 
 nb::object NativeCallData::exec(
-    ref<NativeCallRuntimeOptions> opts,
+    RuntimeOptions& opts,
     CommandEncoder* command_encoder,
     nb::args args,
     nb::kwargs kwargs
 )
 {
     // Unpack args and kwargs (skip if no args have get_this/update_this).
-    nb::list unpacked_args;
+    // On the fast path (no unpack needed), avoid creating Python list/dict copies
+    // by using args (nb::tuple) and kwargs (nb::dict) directly.
+    nb::object unpacked_args;
     nb::dict unpacked_kwargs;
     if (m_needs_unpack) {
         bool had_unpack = false;
         unpacked_args = unpack_args(args, had_unpack);
         unpacked_kwargs = unpack_kwargs(kwargs, had_unpack);
     } else {
-        // Fast path: wrap args/kwargs directly without checking for get_this.
-        for (auto arg : args)
-            unpacked_args.append(arg);
-        for (auto [k, v] : kwargs)
-            unpacked_kwargs[k] = v;
+        // Fast path: borrow args/kwargs directly — zero allocation.
+        unpacked_args = nb::borrow<nb::object>(args);
+        unpacked_kwargs = nb::borrow<nb::dict>(kwargs);
     }
 
     auto si = compute_call_shape_info(opts, unpacked_args, unpacked_kwargs);
@@ -787,10 +776,14 @@ nb::object NativeCallData::exec(
     }
 
     // Extract CUDA stream handle for interop operations and command buffer submission.
-    NativeHandle cuda_stream = opts->cuda_stream();
+    NativeHandle cuda_stream = opts.cuda_stream;
 
-    // Setup context.
-    auto context = make_ref<CallContext>(m_device, call_shape, m_call_mode, cuda_stream);
+    // Setup context (reuse cached context to avoid heap allocation on repeat calls).
+    if (!m_cached_context)
+        m_cached_context = make_ref<CallContext>(m_device, call_shape, m_call_mode, cuda_stream);
+    else
+        m_cached_context->reinitialize(call_shape, cuda_stream);
+    auto& context = m_cached_context;
 
     // Allocate return value if needed.
     if (!command_encoder && m_call_mode == CallMode::prim) {
@@ -805,7 +798,7 @@ nb::object NativeCallData::exec(
         }
     }
 
-    nb::list read_back;
+    nb::list read_back; // TODO: This allocates a Python list every call. Lazy init requires changing virtual signatures.
 
     if (is_log_enabled(LogLevel::debug)) {
         log_debug("Dispatching {}", m_debug_name);
@@ -949,21 +942,18 @@ nb::object NativeCallData::exec(
             write_uniforms(call_data_cursor, cursor);
         }
 
-        nb::list uniforms = opts->uniforms();
-        if (uniforms) {
-            for (auto u : uniforms) {
-                if (nb::isinstance<nb::dict>(u)) {
-                    write_shader_cursor(cursor, nb::cast<nb::dict>(u));
-                } else if (nb::isinstance<nb::tuple>(u)) {
-                    // Writer tuple: (fn, args, kwargs)
-                    nb::tuple t = nb::cast<nb::tuple>(u);
-                    nb::object fn = t[0];
-                    nb::tuple args = nb::cast<nb::tuple>(t[1]);
-                    nb::dict kwargs = nb::cast<nb::dict>(t[2]);
-                    fn(nb::cast(cursor), *args, **kwargs);
-                } else {
-                    write_shader_cursor(cursor, nb::cast<nb::dict>(u(this)));
-                }
+        for (const auto& u : opts.uniforms) {
+            if (nb::isinstance<nb::dict>(u)) {
+                write_shader_cursor(cursor, nb::cast<nb::dict>(u));
+            } else if (nb::isinstance<nb::tuple>(u)) {
+                // Writer tuple: (fn, args, kwargs)
+                nb::tuple t = nb::cast<nb::tuple>(u);
+                nb::object fn = t[0];
+                nb::tuple args = nb::cast<nb::tuple>(t[1]);
+                nb::dict kwargs = nb::cast<nb::dict>(t[2]);
+                fn(nb::cast(cursor), *args, **kwargs);
+            } else {
+                write_shader_cursor(cursor, nb::cast<nb::dict>(u(this)));
             }
         }
     };
@@ -975,7 +965,7 @@ nb::object NativeCallData::exec(
         command_encoder = temp_command_encoder.get();
     }
 
-    bool is_ray_tracing = opts->is_ray_tracing();
+    bool is_ray_tracing = opts.is_ray_tracing;
 
     if (!is_ray_tracing) {
         ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
@@ -1040,7 +1030,7 @@ NativeCallDataCache::NativeCallDataCache()
 {
     m_cache.reserve(1024);
 
-    m_type_signature_table[typeid(Texture)] = [](const ref<SignatureBuilder>& builder, nb::handle o)
+    m_type_signature_table[typeid(Texture)] = [](SignatureBuffer& builder, nb::handle o)
     {
         auto tex = nb::cast<Texture*>(o);
 
@@ -1056,12 +1046,12 @@ NativeCallDataCache::NativeCallDataCache()
             (int)tex->desc().format,
             (int)tex->desc().array_length
         );
-        builder->add(temp);
+        builder.add(temp);
 
         return true;
     };
 
-    m_type_signature_table[typeid(Buffer)] = [](const ref<SignatureBuilder>& builder, nb::handle o)
+    m_type_signature_table[typeid(Buffer)] = [](SignatureBuffer& builder, nb::handle o)
     {
         auto buffer = nb::cast<Buffer*>(o);
 
@@ -1069,13 +1059,13 @@ NativeCallDataCache::NativeCallDataCache()
         // a bit slower for this use case. (over 4x).
         char temp[256];
         std::snprintf(temp, sizeof(temp), "[%d]", (int)buffer->desc().usage);
-        builder->add(temp);
+        builder.add(temp);
 
         return true;
     };
 }
 
-void NativeCallDataCache::get_value_signature(const ref<SignatureBuilder> builder, nb::handle o)
+void NativeCallDataCache::get_value_signature(SignatureBuffer& builder, nb::handle o)
 {
     // Get python type.
     auto type = o.type();
@@ -1083,15 +1073,16 @@ void NativeCallDataCache::get_value_signature(const ref<SignatureBuilder> builde
     // Check if this is a bound native type, in which case we can hopefully do fast things!
     bool is_bound_type = nb::type_check(type);
     if (is_bound_type) {
-
-        // Get C++ type info, and attempt to cast to a slangpy native object
         const auto& type_info = nb::type_info(type);
 
         // If we have a native object, can directly request the signature.
+        // Use read_signature_fast for C++ objects (no Python override).
+        // For Python subclasses, the fixed signature is set via set_slangpy_signature,
+        // so read_signature_fast (which reads m_signature) is safe for all NativeObjects.
         const NativeObject* native_object;
         if (nb::try_cast<const NativeObject*>(o, native_object)) {
-            *builder << type_info.name() << "\n";
-            native_object->read_signature(builder);
+            builder << type_info.name() << "\n";
+            native_object->read_signature_fast(builder);
             return;
         }
 
@@ -1106,26 +1097,26 @@ void NativeCallDataCache::get_value_signature(const ref<SignatureBuilder> builde
 
     // Fast path for basic Python types (int/float) here.
     if (nb::isinstance<int>(o)) {
-        *builder << "int\n";
+        builder << "int\n";
         return;
     }
     if (nb::isinstance<float>(o)) {
-        *builder << "float\n";
+        builder << "float\n";
         return;
     }
     if (nb::isinstance<bool>(o)) {
-        *builder << "bool\n";
+        builder << "bool\n";
         return;
     }
     if (nb::isinstance<nb::str>(o)) {
-        *builder << "string\n";
+        builder << "string\n";
         return;
     }
 
     // Python tuple/list
     nb::tuple tuple;
     if (nb::try_cast<nb::tuple>(o, tuple)) {
-        *builder << "tuple\n";
+        builder << "tuple\n";
         for (const auto& i : tuple) {
             get_value_signature(builder, i);
         }
@@ -1133,32 +1124,30 @@ void NativeCallDataCache::get_value_signature(const ref<SignatureBuilder> builde
     }
     nb::list list;
     if (nb::try_cast<nb::list>(o, list)) {
-        *builder << "list\n";
+        builder << "list\n";
         for (const auto& i : list) {
             get_value_signature(builder, i);
         }
         return;
     }
 
-    // Fast path: Signature for pytorch tensors via torch bridge (~15ns native, ~50ns fallback)
-    // Only check if torch is available to avoid any cost when torch isn't installed.
-    // get_signature() returns 0 on success, non-zero on failure (does not throw)
+    // Fast path: Signature for pytorch tensors via torch bridge
     if (TorchBridge::instance().is_available()) {
         char buffer[64];
         if (TorchBridge::instance().get_signature(o, buffer, sizeof(buffer)) == 0) {
-            *builder << "torch\n" << buffer;
+            builder << "torch\n" << buffer;
             return;
         }
     }
 
     // Add type name.
     auto type_name = nb::str(nb::getattr(o.type(), "__name__"));
-    *builder << type_name.c_str() << "\n";
+    builder << type_name.c_str() << "\n";
 
     // Handle objects with get_this method.
     auto get_this = nb::getattr(o, "get_this", nb::none());
     if (!get_this.is_none()) {
-        *builder << "\nunpack";
+        builder << "\nunpack";
         auto this_ = get_this();
         get_value_signature(builder, this_);
         return;
@@ -1166,26 +1155,22 @@ void NativeCallDataCache::get_value_signature(const ref<SignatureBuilder> builde
 
     // If x has signature attribute, use it.
     if (nb::hasattr(o, "slangpy_signature")) {
-
         auto slangpy_sig = nb::getattr(o, "slangpy_signature");
-        *builder << nb::str(slangpy_sig).c_str() << "\n";
+        builder << nb::str(slangpy_sig).c_str() << "\n";
         return;
     }
-
 
     // If x is a dictionary get signature of its children.
     nb::dict dict;
     if (nb::try_cast(o, dict)) {
-        *builder << "\n";
+        builder << "\n";
         for (const auto& [k, v] : dict) {
             nb::str key(k);
-            *builder << key.c_str() << ":";
+            builder << key.c_str() << ":";
 
             nb::str _type;
             if (strcmp(key.c_str(), "_type") == 0 && nb::try_cast<nb::str>(v, _type)) {
-                // If the dictionary contains a _type key with string value,
-                // we have to encode the value directly, as it affects type resolution
-                *builder << _type.c_str() << "\n";
+                builder << _type.c_str() << "\n";
             } else {
                 get_value_signature(builder, v);
             }
@@ -1196,23 +1181,23 @@ void NativeCallDataCache::get_value_signature(const ref<SignatureBuilder> builde
     // Use value_to_id function.
     std::optional<std::string> s = lookup_value_signature(o);
     if (s.has_value()) {
-        *builder << *s;
+        builder << s->c_str();
     }
-    *builder << "\n";
+    builder << "\n";
 }
 
-void NativeCallDataCache::get_args_signature(const ref<SignatureBuilder> builder, nb::args args, nb::kwargs kwargs)
+void NativeCallDataCache::get_args_signature(SignatureBuffer& builder, nb::args args, nb::kwargs kwargs)
 {
-    builder->add("args\n");
+    builder.add("args\n");
     for (const auto& arg : args) {
-        builder->add("N:");
+        builder.add("N:");
         get_value_signature(builder, arg);
     }
 
-    builder->add("kwargs\n");
+    builder.add("kwargs\n");
     for (const auto& [k, v] : kwargs) {
-        builder->add(nb::str(k).c_str());
-        builder->add(":");
+        builder.add(nb::str(k).c_str());
+        builder.add(":");
         get_value_signature(builder, v);
     }
 }
@@ -1297,9 +1282,9 @@ void pack_arg(nanobind::object arg, nanobind::object unpacked_arg)
 std::string get_value_signature(nb::handle o)
 {
     static NativeCallDataCache cache;
-    auto builder = make_ref<SignatureBuilder>();
+    SignatureBuffer builder;
     cache.get_value_signature(builder, o);
-    return builder->str();
+    return std::string(builder.view());
 }
 
 } // namespace sgl::slangpy
@@ -1689,7 +1674,9 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def(
             "call",
-            &NativeCallData::call,
+            static_cast<nb::object (NativeCallData::*)(ref<NativeCallRuntimeOptions>, nb::args, nb::kwargs)>(
+                &NativeCallData::call
+            ),
             nb::arg("opts"),
             nb::arg("args"),
             nb::arg("kwargs"),
@@ -1697,7 +1684,9 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def(
             "append_to",
-            &NativeCallData::append_to,
+            static_cast<nb::object (NativeCallData::*)(ref<NativeCallRuntimeOptions>, CommandEncoder*, nb::args, nb::kwargs)>(
+                &NativeCallData::append_to
+            ),
             nb::arg("opts"),
             nb::arg("command_buffer"),
             nb::arg("args"),
@@ -1806,14 +1795,18 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def(
             "get_value_signature",
-            &NativeCallDataCache::get_value_signature,
+            static_cast<void (NativeCallDataCache::*)(const ref<SignatureBuilder>, nb::handle)>(
+                &NativeCallDataCache::get_value_signature
+            ),
             "builder"_a,
             "o"_a,
             D_NA(NativeCallDataCache, get_value_signature)
         )
         .def(
             "get_args_signature",
-            &NativeCallDataCache::get_args_signature,
+            static_cast<void (NativeCallDataCache::*)(const ref<SignatureBuilder>, nb::args, nb::kwargs)>(
+                &NativeCallDataCache::get_args_signature
+            ),
             "builder"_a,
             "args"_a,
             "kwargs"_a,

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -584,12 +584,8 @@ nb::tuple NativeCallData::autograd_backward(
     return nb::tuple(input_grads);
 }
 
-nb::object NativeCallData::append_to(
-    RuntimeOptions& opts,
-    CommandEncoder* command_encoder,
-    nb::args args,
-    nb::kwargs kwargs
-)
+nb::object
+NativeCallData::append_to(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs)
 {
     return exec(opts, command_encoder, args, kwargs);
 }
@@ -721,12 +717,7 @@ CallShapeInfo NativeCallData::compute_call_shape_info(
     return si;
 }
 
-nb::object NativeCallData::exec(
-    RuntimeOptions& opts,
-    CommandEncoder* command_encoder,
-    nb::args args,
-    nb::kwargs kwargs
-)
+nb::object NativeCallData::exec(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs)
 {
     // Unpack args and kwargs (skip if no args have get_this/update_this).
     // On the fast path (no unpack needed), avoid creating Python list/dict copies
@@ -798,7 +789,8 @@ nb::object NativeCallData::exec(
         }
     }
 
-    nb::list read_back; // TODO: This allocates a Python list every call. Lazy init requires changing virtual signatures.
+    nb::list read_back; // TODO: This allocates a Python list every call. Lazy init requires changing virtual
+                        // signatures.
 
     if (is_log_enabled(LogLevel::debug)) {
         log_debug("Dispatching {}", m_debug_name);
@@ -1684,7 +1676,8 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def(
             "append_to",
-            static_cast<nb::object (NativeCallData::*)(ref<NativeCallRuntimeOptions>, CommandEncoder*, nb::args, nb::kwargs)>(
+            static_cast<
+                nb::object (NativeCallData::*)(ref<NativeCallRuntimeOptions>, CommandEncoder*, nb::args, nb::kwargs)>(
                 &NativeCallData::append_to
             ),
             nb::arg("opts"),

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -463,14 +463,9 @@ nb::list NativeCallData::find_torch_tensors(nb::list args, nb::dict kwargs)
     return pairs;
 }
 
-nb::object NativeCallData::call(RuntimeOptions& opts, nb::args args, nb::kwargs kwargs)
+nb::object NativeCallData::call(NativeCallRuntimeOptions& opts, nb::args args, nb::kwargs kwargs)
 {
     return exec(opts, nullptr, args, kwargs);
-}
-
-nb::object NativeCallData::call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs)
-{
-    return call(opts->opts(), args, kwargs);
 }
 
 nb::tuple
@@ -491,7 +486,7 @@ NativeCallData::autograd_forward(ref<NativeCallRuntimeOptions> opts, nb::list ar
     // Note: exec() may insert _result into kwargs, so check before calling exec.
     bool had_result = kwargs.contains("_result");
     nb::tuple args_tuple(args);
-    nb::object result = exec(opts->opts(), nullptr, nb::borrow<nb::args>(args_tuple), nb::borrow<nb::kwargs>(kwargs));
+    nb::object result = exec(*opts, nullptr, nb::borrow<nb::args>(args_tuple), nb::borrow<nb::kwargs>(kwargs));
 
     // If result is a tensor and _result was not in kwargs before exec,
     // create a new output pair for it
@@ -584,24 +579,18 @@ nb::tuple NativeCallData::autograd_backward(
     return nb::tuple(input_grads);
 }
 
-nb::object
-NativeCallData::append_to(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs)
-{
-    return exec(opts, command_encoder, args, kwargs);
-}
-
 nb::object NativeCallData::append_to(
-    ref<NativeCallRuntimeOptions> opts,
+    NativeCallRuntimeOptions& opts,
     CommandEncoder* command_encoder,
     nb::args args,
     nb::kwargs kwargs
 )
 {
-    return append_to(opts->opts(), command_encoder, args, kwargs);
+    return exec(opts, command_encoder, args, kwargs);
 }
 
 CallShapeInfo NativeCallData::compute_call_shape_info(
-    RuntimeOptions& opts,
+    NativeCallRuntimeOptions& opts,
     const nb::object& unpacked_args,
     const nb::dict& unpacked_kwargs
 )
@@ -717,7 +706,8 @@ CallShapeInfo NativeCallData::compute_call_shape_info(
     return si;
 }
 
-nb::object NativeCallData::exec(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs)
+nb::object
+NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs)
 {
     // Unpack args and kwargs (skip if no args have get_this/update_this).
     // On the fast path (no unpack needed), avoid creating Python list/dict copies
@@ -771,9 +761,8 @@ nb::object NativeCallData::exec(RuntimeOptions& opts, CommandEncoder* command_en
 
     // Setup context (reuse cached context to avoid heap allocation on repeat calls).
     if (!m_cached_context)
-        m_cached_context = make_ref<CallContext>(m_device, call_shape, m_call_mode, cuda_stream);
-    else
-        m_cached_context->reinitialize(call_shape, cuda_stream);
+        m_cached_context = make_ref<CallContext>(m_device, m_call_mode);
+    m_cached_context->init(call_shape, cuda_stream);
     auto& context = m_cached_context;
 
     // Allocate return value if needed.
@@ -1068,13 +1057,13 @@ void NativeCallDataCache::get_value_signature(SignatureBuffer& builder, nb::hand
         const auto& type_info = nb::type_info(type);
 
         // If we have a native object, can directly request the signature.
-        // Use read_signature_fast for C++ objects (no Python override).
+        // Use read_signature(SignatureBuffer&) for C++ objects (non-virtual, reads m_signature).
         // For Python subclasses, the fixed signature is set via set_slangpy_signature,
-        // so read_signature_fast (which reads m_signature) is safe for all NativeObjects.
+        // so this is safe for all NativeObjects.
         const NativeObject* native_object;
         if (nb::try_cast<const NativeObject*>(o, native_object)) {
             builder << type_info.name() << "\n";
-            native_object->read_signature_fast(builder);
+            native_object->read_signature(builder);
             return;
         }
 
@@ -1372,7 +1361,15 @@ SGL_PY_EXPORT(utils_slangpy)
             D_NA(NativeObject, NativeObject)
         )
         .def_prop_rw("slangpy_signature", &NativeObject::slangpy_signature, &NativeObject::set_slangpy_signature)
-        .def("read_signature", &NativeObject::read_signature, "builder"_a, D_NA(NativeObject, read_signature));
+        .def(
+            "read_signature",
+            [](const NativeObject& self, SignatureBuilder* builder)
+            {
+                self.read_signature(builder);
+            },
+            "builder"_a,
+            D_NA(NativeObject, read_signature)
+        );
 
     nb::class_<NativeSlangType, PyNativeSlangType, Object>(slangpy, "NativeSlangType") //
         .def(
@@ -1595,7 +1592,7 @@ SGL_PY_EXPORT(utils_slangpy)
         .def(nb::init<>(), D_NA(NativeCallRuntimeOptions, NativeCallRuntimeOptions))
         .def_prop_rw(
             "uniforms",
-            &NativeCallRuntimeOptions::uniforms,
+            &NativeCallRuntimeOptions::get_uniforms,
             &NativeCallRuntimeOptions::set_uniforms,
             D_NA(NativeCallRuntimeOptions, uniforms)
         )
@@ -1607,14 +1604,26 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def_prop_rw(
             "cuda_stream",
-            &NativeCallRuntimeOptions::cuda_stream,
-            &NativeCallRuntimeOptions::set_cuda_stream,
+            [](const NativeCallRuntimeOptions& self)
+            {
+                return self.cuda_stream;
+            },
+            [](NativeCallRuntimeOptions& self, NativeHandle v)
+            {
+                self.cuda_stream = v;
+            },
             D_NA(NativeCallRuntimeOptions, cuda_stream)
         )
         .def_prop_rw(
             "thread_count",
-            &NativeCallRuntimeOptions::thread_count,
-            &NativeCallRuntimeOptions::set_thread_count,
+            [](const NativeCallRuntimeOptions& self)
+            {
+                return self.thread_count;
+            },
+            [](NativeCallRuntimeOptions& self, int v)
+            {
+                self.thread_count = v;
+            },
             D_NA(NativeCallRuntimeOptions, thread_count)
         );
 
@@ -1666,9 +1675,10 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def(
             "call",
-            static_cast<nb::object (NativeCallData::*)(ref<NativeCallRuntimeOptions>, nb::args, nb::kwargs)>(
-                &NativeCallData::call
-            ),
+            [](NativeCallData& self, NativeCallRuntimeOptions& opts, nb::args args, nb::kwargs kwargs)
+            {
+                return self.call(opts, args, kwargs);
+            },
             nb::arg("opts"),
             nb::arg("args"),
             nb::arg("kwargs"),
@@ -1676,10 +1686,14 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def(
             "append_to",
-            static_cast<
-                nb::object (NativeCallData::*)(ref<NativeCallRuntimeOptions>, CommandEncoder*, nb::args, nb::kwargs)>(
-                &NativeCallData::append_to
-            ),
+            [](NativeCallData& self,
+               NativeCallRuntimeOptions& opts,
+               CommandEncoder* cmd,
+               nb::args args,
+               nb::kwargs kwargs)
+            {
+                return self.append_to(opts, cmd, args, kwargs);
+            },
             nb::arg("opts"),
             nb::arg("command_buffer"),
             nb::arg("args"),
@@ -1788,18 +1802,20 @@ SGL_PY_EXPORT(utils_slangpy)
         )
         .def(
             "get_value_signature",
-            static_cast<void (NativeCallDataCache::*)(const ref<SignatureBuilder>, nb::handle)>(
-                &NativeCallDataCache::get_value_signature
-            ),
+            [](NativeCallDataCache& self, const ref<SignatureBuilder> builder, nb::handle o)
+            {
+                self.get_value_signature(builder, o);
+            },
             "builder"_a,
             "o"_a,
             D_NA(NativeCallDataCache, get_value_signature)
         )
         .def(
             "get_args_signature",
-            static_cast<void (NativeCallDataCache::*)(const ref<SignatureBuilder>, nb::args, nb::kwargs)>(
-                &NativeCallDataCache::get_args_signature
-            ),
+            [](NativeCallDataCache& self, const ref<SignatureBuilder> builder, nb::args args, nb::kwargs kwargs)
+            {
+                self.get_args_signature(builder, args, kwargs);
+            },
             "builder"_a,
             "args"_a,
             "kwargs"_a,
@@ -1926,14 +1942,7 @@ SGL_PY_EXPORT(utils_slangpy)
         );
 
     nb::class_<CallContext, Object>(slangpy, "CallContext") //
-        .def(
-            nb::init<ref<Device>, const Shape&, CallMode, NativeHandle>(),
-            nb::arg("device"),
-            nb::arg("call_shape"),
-            nb::arg("call_mode"),
-            nb::arg("cuda_stream") = NativeHandle(),
-            D_NA(CallContext, CallContext)
-        )
+        .def(nb::init<ref<Device>, CallMode>(), nb::arg("device"), nb::arg("call_mode"), D_NA(CallContext, CallContext))
         .def_prop_ro(
             "device",
             [](const CallContext& self) -> Device*

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -650,7 +650,8 @@ public:
 
     /// Calculate the overall call shape by combining the shapes of all arguments.
     /// args can be nb::list or nb::tuple (nb::args); both support [idx] and nb::len().
-    Shape calculate_call_shape(int call_dimensionality, nb::object args, nb::dict kwargs, NativeCallData* error_context);
+    Shape
+    calculate_call_shape(int call_dimensionality, nb::object args, nb::dict kwargs, NativeCallData* error_context);
 
     void write_shader_cursor_pre_dispatch(
         CallContext* context,
@@ -940,8 +941,7 @@ public:
     nb::object call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs);
 
     /// Append the compute kernel to a command encoder with the provided arguments and keyword arguments.
-    nb::object
-    append_to(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
+    nb::object append_to(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 
     /// Python-facing overload (unwraps NativeCallRuntimeOptions).
     nb::object

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -12,6 +12,8 @@
 #include "sgl/core/macros.h"
 #include "sgl/core/fwd.h"
 #include "sgl/core/object.h"
+#include "sgl/core/short_vector.h"
+#include "sgl/core/static_vector.h"
 #include "sgl/device/fwd.h"
 #include "sgl/device/shader_cursor.h"
 #include "sgl/device/shader_object.h"
@@ -19,6 +21,71 @@
 #include "utils/torch_bridge.h"
 
 namespace sgl::slangpy {
+
+/// Transparent hash functor for std::string / std::string_view heterogeneous lookup.
+struct StringHash {
+    using is_transparent = void;
+    size_t operator()(std::string_view sv) const { return std::hash<std::string_view>{}(sv); }
+    size_t operator()(const std::string& s) const { return std::hash<std::string_view>{}(s); }
+};
+
+/// Transparent equality functor for std::string / std::string_view heterogeneous lookup.
+struct StringEqual {
+    using is_transparent = void;
+    bool operator()(std::string_view a, std::string_view b) const { return a == b; }
+};
+
+/// Stack-allocated signature buffer (non-Object, non-ref-counted).
+/// Used in the hot dispatch path to avoid heap-allocating a SignatureBuilder.
+/// Backed by short_vector<uint8_t, 1024> for inline SBO with heap fallback.
+class SignatureBuffer {
+public:
+    SignatureBuffer() = default;
+
+    // Non-copyable, non-movable (stack-only usage)
+    SignatureBuffer(const SignatureBuffer&) = delete;
+    SignatureBuffer& operator=(const SignatureBuffer&) = delete;
+
+    void add(const std::string& value) { add_bytes(reinterpret_cast<const uint8_t*>(value.data()), value.length()); }
+    void add(const char* value) { add_bytes(reinterpret_cast<const uint8_t*>(value), strlen(value)); }
+
+    void add(uint32_t value)
+    {
+        static constexpr char hex[] = "0123456789abcdef";
+        uint8_t buf[8];
+        for (int i = 0; i < 8; ++i)
+            buf[7 - i] = static_cast<uint8_t>(hex[(value >> (i * 4)) & 0xF]);
+        add_bytes(buf, 8);
+    }
+
+    void add(uint64_t value)
+    {
+        static constexpr char hex[] = "0123456789abcdef";
+        uint8_t buf[16];
+        for (int i = 0; i < 16; ++i)
+            buf[15 - i] = static_cast<uint8_t>(hex[(value >> (i * 4)) & 0xF]);
+        add_bytes(buf, 16);
+    }
+
+    template<typename T>
+    SignatureBuffer& operator<<(const T& v)
+    {
+        add(v);
+        return *this;
+    }
+
+    std::string_view view() const { return {reinterpret_cast<const char*>(m_buf.data()), m_buf.size()}; }
+
+private:
+    short_vector<uint8_t, 1024> m_buf;
+
+    void add_bytes(const uint8_t* data, size_t sz)
+    {
+        size_t old_size = m_buf.size();
+        m_buf.resize(old_size + sz);
+        memcpy(m_buf.data() + old_size, data, sz);
+    }
+};
 
 /// Helper function to convert Shape to nb::list efficiently (avoids std::vector allocation)
 inline nb::list shape_to_list(const Shape& shape)
@@ -61,31 +128,22 @@ private:
     ref<NativeCallData> m_context;
 };
 
-/// Used during calculation of slangpy signature
+/// Used during calculation of slangpy signature.
+/// Thin Object wrapper around SignatureBuffer for Python binding compatibility.
 class SignatureBuilder : public Object {
     SGL_OBJECT(SignatureBuilder)
 public:
-    SignatureBuilder()
-    {
-        m_buffer = m_initial_buffer;
-        m_size = 0;
-        m_capacity = sizeof(m_initial_buffer);
-    }
-    ~SignatureBuilder()
-    {
-        if (m_buffer != m_initial_buffer)
-            delete[] m_buffer;
-    }
+    SignatureBuilder() = default;
 
-    void add(const std::string& value);
-    void add(const char* value);
-    void add(const uint32_t value);
-    void add(const uint64_t value);
+    void add(const std::string& value) { m_buf.add(value); }
+    void add(const char* value) { m_buf.add(value); }
+    void add(const uint32_t value) { m_buf.add(value); }
+    void add(const uint64_t value) { m_buf.add(value); }
 
     template<typename T>
     SignatureBuilder& operator<<(const T& value)
     {
-        add(value);
+        m_buf.add(value);
         return *this;
     }
 
@@ -93,27 +151,15 @@ public:
 
     std::string str() const;
 
-    std::string dbg_as_string() const { return std::string(reinterpret_cast<const char*>(m_buffer), m_size); }
+    std::string_view view() const { return m_buf.view(); }
+
+    std::string dbg_as_string() const { return std::string(m_buf.view()); }
+
+    /// Access the underlying buffer (for callers that accept either type).
+    SignatureBuffer& buffer() { return m_buf; }
 
 private:
-    uint8_t m_initial_buffer[1024];
-    uint8_t* m_buffer;
-    size_t m_size;
-    size_t m_capacity;
-
-    void add_bytes(const uint8_t* data, size_t size)
-    {
-        if (m_size + size > m_capacity) {
-            m_capacity = std::max(m_capacity * 2, m_size + size);
-            uint8_t* new_buffer = new uint8_t[m_capacity];
-            memcpy(new_buffer, m_buffer, m_size);
-            if (m_buffer != m_initial_buffer)
-                delete[] m_buffer;
-            m_buffer = new_buffer;
-        }
-        memcpy(m_buffer + m_size, data, size);
-        m_size += size;
-    };
+    SignatureBuffer m_buf;
 };
 
 /// Base class for types that can be passed to a slang function. Use of
@@ -131,6 +177,10 @@ public:
 
     virtual void read_signature(SignatureBuilder* builder) const { builder->add(m_signature); }
 
+    /// Write signature into a stack-allocated SignatureBuffer (hot path).
+    /// Non-virtual: delegates to the virtual read_signature(SignatureBuilder*) via a temporary wrapper.
+    /// For NativeObject base class, we can write directly without the virtual call.
+    void read_signature_fast(SignatureBuffer& builder) const { builder.add(m_signature); }
 
 private:
     std::string m_signature;
@@ -599,13 +649,14 @@ public:
     }
 
     /// Calculate the overall call shape by combining the shapes of all arguments.
-    Shape calculate_call_shape(int call_dimensionality, nb::list args, nb::dict kwargs, NativeCallData* error_context);
+    /// args can be nb::list or nb::tuple (nb::args); both support [idx] and nb::len().
+    Shape calculate_call_shape(int call_dimensionality, nb::object args, nb::dict kwargs, NativeCallData* error_context);
 
     void write_shader_cursor_pre_dispatch(
         CallContext* context,
         ShaderCursor root_cursor,
         ShaderCursor call_data_cursor,
-        nb::list args,
+        nb::object args,
         nb::dict kwargs,
         nb::list read_back
     );
@@ -622,55 +673,83 @@ private:
     std::map<std::string, ref<NativeBoundVariableRuntime>> m_kwargs;
 };
 
+/// Lightweight, stack-allocated runtime options. Single source of truth for all fields.
+/// Used directly on the hot dispatch path (no heap allocation).
+/// NativeCallRuntimeOptions wraps this for Python binding / ref-counted usage.
+struct RuntimeOptions {
+    nb::object this_obj; // Default null handle — check with is_valid(), not is_none()
+    NativeHandle cuda_stream;
+    bool is_ray_tracing{false};
+    int thread_count{0};
+
+    // Inline storage for uniforms (most calls have 0-2, max 4)
+    static_vector<nb::object, 4> uniforms;
+
+    bool has_thread_count() const { return thread_count > 0; }
+};
+
+/// Ref-counted wrapper around RuntimeOptions for Python binding and torch autograd paths.
 class NativeCallRuntimeOptions : Object {
     SGL_OBJECT(NativeCallRuntimeOptions)
 public:
-    /// Get the uniforms.
+    /// Get the uniforms as a Python list (constructs on demand for Python compat).
     nb::list uniforms() const { return m_uniforms; }
 
-    /// Set the uniforms.
+    /// Set the uniforms from a Python list.
     void set_uniforms(const nb::list& uniforms) { m_uniforms = uniforms; }
 
     /// Get this
-    nb::object get_this() const { return m_this; }
+    nb::object get_this() const { return m_opts.this_obj.is_valid() ? m_opts.this_obj : nb::none(); }
 
     /// Set this
-    void set_this(const nb::object& this_) { m_this = this_; }
+    void set_this(const nb::object& this_) { m_opts.this_obj = this_; }
 
     /// Get the CUDA stream.
-    NativeHandle cuda_stream() const { return m_cuda_stream; }
+    NativeHandle cuda_stream() const { return m_opts.cuda_stream; }
 
     /// Set the CUDA stream.
-    void set_cuda_stream(NativeHandle cuda_stream) { m_cuda_stream = cuda_stream; }
+    void set_cuda_stream(NativeHandle cuda_stream) { m_opts.cuda_stream = cuda_stream; }
 
     /// Get ray tracing pipeline flag.
-    bool is_ray_tracing() const { return m_is_ray_tracing; }
+    bool is_ray_tracing() const { return m_opts.is_ray_tracing; }
 
     /// Set ray tracing pipeline flag.
-    void set_is_ray_tracing(bool is_ray_tracing) { m_is_ray_tracing = is_ray_tracing; }
+    void set_is_ray_tracing(bool is_ray_tracing) { m_opts.is_ray_tracing = is_ray_tracing; }
 
     /// Get the thread count override.
-    int thread_count() const { return m_thread_count; }
+    int thread_count() const { return m_opts.thread_count; }
 
     /// Set the thread count override.
-    void set_thread_count(int thread_count) { m_thread_count = thread_count; }
+    void set_thread_count(int thread_count) { m_opts.thread_count = thread_count; }
 
     /// Check if thread count override is set.
-    bool has_thread_count() const { return m_thread_count > 0; }
+    bool has_thread_count() const { return m_opts.has_thread_count(); }
+
+    /// Access the underlying RuntimeOptions.
+    RuntimeOptions& opts() { return m_opts; }
+    const RuntimeOptions& opts() const { return m_opts; }
+
+    /// Convert from RuntimeOptions (for torch autograd path).
+    static ref<NativeCallRuntimeOptions> from_runtime_options(const RuntimeOptions& rt)
+    {
+        auto opts = make_ref<NativeCallRuntimeOptions>();
+        opts->m_opts = rt;
+        // Copy uniforms to the Python list for Python-side access
+        for (const auto& u : rt.uniforms)
+            opts->m_uniforms.append(u);
+        return opts;
+    }
 
     /// Clear internal data for garbage collection
     void garbage_collect()
     {
         m_uniforms.clear();
-        m_this = nb::none();
+        m_opts.this_obj = nb::object();
     }
 
 private:
-    nb::list m_uniforms;
-    nb::object m_this{nb::none()};
-    NativeHandle m_cuda_stream;
-    bool m_is_ray_tracing{false};
-    int m_thread_count{0};
+    RuntimeOptions m_opts;
+    nb::list m_uniforms; // Python-facing list for uniforms (kept in sync via gather_runtime_options)
 };
 
 /// Defines the common logging functions for a given log level.
@@ -855,9 +934,16 @@ public:
     const Shape& call_group_shape() const { return m_call_group_shape; }
 
     /// Call the compute kernel with the provided arguments and keyword arguments.
+    nb::object call(RuntimeOptions& opts, nb::args args, nb::kwargs kwargs);
+
+    /// Python-facing overload (unwraps NativeCallRuntimeOptions).
     nb::object call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs);
 
     /// Append the compute kernel to a command encoder with the provided arguments and keyword arguments.
+    nb::object
+    append_to(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
+
+    /// Python-facing overload (unwraps NativeCallRuntimeOptions).
     nb::object
     append_to(ref<NativeCallRuntimeOptions> opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 
@@ -922,22 +1008,19 @@ private:
     std::vector<AutogradAccess> m_autograd_access_list;
     ref<NativeCallData> m_bwds_call_data;
     mutable CallDataOffsets m_cached_call_data_offsets;
+    mutable ref<CallContext> m_cached_context;
 
     /// Recursive helper for find_torch_tensors.
     nb::object find_torch_tensors_recurse(nb::object arg, nb::list& pairs, size_t& access_idx);
 
-    CallShapeInfo compute_call_shape_info(
-        const ref<NativeCallRuntimeOptions>& opts,
-        const nb::list& unpacked_args,
-        const nb::dict& unpacked_kwargs
-    );
+    CallShapeInfo
+    compute_call_shape_info(RuntimeOptions& opts, const nb::object& unpacked_args, const nb::dict& unpacked_kwargs);
 
-    nb::object
-    exec(ref<NativeCallRuntimeOptions> opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
+    nb::object exec(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 };
 #undef SGL_LOG_FUNC_FAMILY
 
-typedef std::function<bool(const ref<SignatureBuilder>& builder, nb::handle)> BuildSignatureFunc;
+typedef std::function<bool(SignatureBuffer& builder, nb::handle)> BuildSignatureFunc;
 
 /// Native side of system for caching call data info for given function signatures.
 class NativeCallDataCache : Object {
@@ -946,11 +1029,23 @@ class NativeCallDataCache : Object {
 public:
     NativeCallDataCache();
 
-    void get_value_signature(const ref<SignatureBuilder> builder, nb::handle o);
+    /// Python-facing wrappers (delegate to the SignatureBuffer implementations via SignatureBuilder::buffer()).
+    void get_value_signature(const ref<SignatureBuilder> builder, nb::handle o)
+    {
+        get_value_signature(builder->buffer(), o);
+    }
 
-    void get_args_signature(const ref<SignatureBuilder> builder, nb::args args, nb::kwargs kwargs);
+    void get_args_signature(const ref<SignatureBuilder> builder, nb::args args, nb::kwargs kwargs)
+    {
+        get_args_signature(builder->buffer(), args, kwargs);
+    }
 
-    ref<NativeCallData> find_call_data(const std::string& signature)
+    /// Core implementations operating on SignatureBuffer (used by both Python and C++ hot paths).
+    void get_value_signature(SignatureBuffer& builder, nb::handle o);
+    void get_args_signature(SignatureBuffer& builder, nb::args args, nb::kwargs kwargs);
+
+    /// Transparent string_view lookup (no std::string allocation on cache hit).
+    ref<NativeCallData> find_call_data(std::string_view signature)
     {
         auto it = m_cache.find(signature);
         if (it != m_cache.end()) {
@@ -959,9 +1054,10 @@ public:
         return nullptr;
     }
 
-    void add_call_data(const std::string& signature, const ref<NativeCallData>& call_data)
+    /// Store call data (cache miss only — takes ownership of std::string key).
+    void add_call_data(std::string signature, const ref<NativeCallData>& call_data)
     {
-        m_cache[signature] = call_data;
+        m_cache[std::move(signature)] = call_data;
     }
 
     virtual std::optional<std::string> lookup_value_signature(nb::handle o)
@@ -971,7 +1067,7 @@ public:
     }
 
 private:
-    std::unordered_map<std::string, ref<NativeCallData>> m_cache;
+    std::unordered_map<std::string, ref<NativeCallData>, StringHash, StringEqual> m_cache;
     std::unordered_map<std::type_index, BuildSignatureFunc> m_type_signature_table;
 };
 

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -176,10 +176,8 @@ public:
 
     virtual void read_signature(SignatureBuilder* builder) const { builder->add(m_signature); }
 
-    /// Write signature into a stack-allocated SignatureBuffer (hot path).
-    /// Non-virtual: delegates to the virtual read_signature(SignatureBuilder*) via a temporary wrapper.
-    /// For NativeObject base class, we can write directly without the virtual call.
-    void read_signature_fast(SignatureBuffer& builder) const { builder.add(m_signature); }
+    /// Non-virtual overload for SignatureBuffer (hot path).
+    void read_signature(SignatureBuffer& builder) const { builder.add(m_signature); }
 
 private:
     std::string m_signature;
@@ -673,83 +671,58 @@ private:
     std::map<std::string, ref<NativeBoundVariableRuntime>> m_kwargs;
 };
 
-/// Lightweight, stack-allocated runtime options. Single source of truth for all fields.
-/// Used directly on the hot dispatch path (no heap allocation).
-/// NativeCallRuntimeOptions wraps this for Python binding / ref-counted usage.
-struct RuntimeOptions {
+/// Runtime options for function dispatch. Cached on NativeFunctionNode to avoid
+/// heap allocation on repeat calls. Also exposed to Python for autograd paths.
+class NativeCallRuntimeOptions : Object {
+    SGL_OBJECT(NativeCallRuntimeOptions)
+public:
     nb::object this_obj; // Default null handle — check with is_valid(), not is_none()
     NativeHandle cuda_stream;
     bool is_ray_tracing{false};
     int thread_count{0};
-
-    // Inline storage for uniforms (most calls have 0-2; heap fallback if more)
     short_vector<nb::object, 4> uniforms;
 
-    bool has_thread_count() const { return thread_count > 0; }
-};
-
-/// Ref-counted wrapper around RuntimeOptions for Python binding and torch autograd paths.
-class NativeCallRuntimeOptions : Object {
-    SGL_OBJECT(NativeCallRuntimeOptions)
-public:
-    /// Get the uniforms as a Python list (constructs on demand for Python compat).
-    nb::list uniforms() const { return m_uniforms; }
-
-    /// Set the uniforms from a Python list.
-    void set_uniforms(const nb::list& uniforms) { m_uniforms = uniforms; }
-
-    /// Get this
-    nb::object get_this() const { return m_opts.this_obj.is_valid() ? m_opts.this_obj : nb::none(); }
-
-    /// Set this
-    void set_this(const nb::object& this_) { m_opts.this_obj = this_; }
-
-    /// Get the CUDA stream.
-    NativeHandle cuda_stream() const { return m_opts.cuda_stream; }
-
-    /// Set the CUDA stream.
-    void set_cuda_stream(NativeHandle cuda_stream) { m_opts.cuda_stream = cuda_stream; }
-
-    /// Get ray tracing pipeline flag.
-    bool is_ray_tracing() const { return m_opts.is_ray_tracing; }
-
-    /// Set ray tracing pipeline flag.
-    void set_is_ray_tracing(bool is_ray_tracing) { m_opts.is_ray_tracing = is_ray_tracing; }
-
-    /// Get the thread count override.
-    int thread_count() const { return m_opts.thread_count; }
-
-    /// Set the thread count override.
-    void set_thread_count(int thread_count) { m_opts.thread_count = thread_count; }
-
-    /// Check if thread count override is set.
-    bool has_thread_count() const { return m_opts.has_thread_count(); }
-
-    /// Access the underlying RuntimeOptions.
-    RuntimeOptions& opts() { return m_opts; }
-    const RuntimeOptions& opts() const { return m_opts; }
-
-    /// Convert from RuntimeOptions (for torch autograd path).
-    static ref<NativeCallRuntimeOptions> from_runtime_options(const RuntimeOptions& rt)
+    /// Reset all fields for reuse on the next call.
+    void init()
     {
-        auto opts = make_ref<NativeCallRuntimeOptions>();
-        opts->m_opts = rt;
-        // Copy uniforms to the Python list for Python-side access
-        for (const auto& u : rt.uniforms)
-            opts->m_uniforms.append(u);
-        return opts;
+        this_obj = nb::object();
+        cuda_stream = NativeHandle();
+        is_ray_tracing = false;
+        thread_count = 0;
+        uniforms.clear();
     }
 
-    /// Clear internal data for garbage collection
+    bool has_thread_count() const { return thread_count > 0; }
+
+    /// Python-facing property: get uniforms as a list.
+    nb::list get_uniforms() const
+    {
+        nb::list result;
+        for (const auto& u : uniforms)
+            result.append(u);
+        return result;
+    }
+
+    /// Python-facing property: set uniforms from a list.
+    void set_uniforms(const nb::list& list)
+    {
+        uniforms.clear();
+        for (auto u : list)
+            uniforms.push_back(nb::borrow<nb::object>(u));
+    }
+
+    /// Python-facing property: get this (returns nb::none() if not set).
+    nb::object get_this() const { return this_obj.is_valid() ? this_obj : nb::none(); }
+
+    /// Python-facing property: set this.
+    void set_this(const nb::object& this_) { this_obj = this_; }
+
+    /// Clear internal data for garbage collection.
     void garbage_collect()
     {
-        m_uniforms.clear();
-        m_opts.this_obj = nb::object();
+        uniforms.clear();
+        this_obj = nb::object();
     }
-
-private:
-    RuntimeOptions m_opts;
-    nb::list m_uniforms; // Python-facing list for uniforms (kept in sync via gather_runtime_options)
 };
 
 /// Defines the common logging functions for a given log level.
@@ -934,17 +907,11 @@ public:
     const Shape& call_group_shape() const { return m_call_group_shape; }
 
     /// Call the compute kernel with the provided arguments and keyword arguments.
-    nb::object call(RuntimeOptions& opts, nb::args args, nb::kwargs kwargs);
-
-    /// Python-facing overload (unwraps NativeCallRuntimeOptions).
-    nb::object call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs);
+    nb::object call(NativeCallRuntimeOptions& opts, nb::args args, nb::kwargs kwargs);
 
     /// Append the compute kernel to a command encoder with the provided arguments and keyword arguments.
-    nb::object append_to(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
-
-    /// Python-facing overload (unwraps NativeCallRuntimeOptions).
     nb::object
-    append_to(ref<NativeCallRuntimeOptions> opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
+    append_to(NativeCallRuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 
     /// Log a message, using either the provided logger or the default logger.
     void log(LogLevel level, const std::string_view msg, LogFrequency frequency = LogFrequency::always)
@@ -1012,10 +979,13 @@ private:
     /// Recursive helper for find_torch_tensors.
     nb::object find_torch_tensors_recurse(nb::object arg, nb::list& pairs, size_t& access_idx);
 
-    CallShapeInfo
-    compute_call_shape_info(RuntimeOptions& opts, const nb::object& unpacked_args, const nb::dict& unpacked_kwargs);
+    CallShapeInfo compute_call_shape_info(
+        NativeCallRuntimeOptions& opts,
+        const nb::object& unpacked_args,
+        const nb::dict& unpacked_kwargs
+    );
 
-    nb::object exec(RuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
+    nb::object exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 };
 #undef SGL_LOG_FUNC_FAMILY
 

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -13,7 +13,6 @@
 #include "sgl/core/fwd.h"
 #include "sgl/core/object.h"
 #include "sgl/core/short_vector.h"
-#include "sgl/core/static_vector.h"
 #include "sgl/device/fwd.h"
 #include "sgl/device/shader_cursor.h"
 #include "sgl/device/shader_object.h"
@@ -683,8 +682,8 @@ struct RuntimeOptions {
     bool is_ray_tracing{false};
     int thread_count{0};
 
-    // Inline storage for uniforms (most calls have 0-2, max 4)
-    static_vector<nb::object, 4> uniforms;
+    // Inline storage for uniforms (most calls have 0-2; heap fallback if more)
+    short_vector<nb::object, 4> uniforms;
 
     bool has_thread_count() const { return thread_count > 0; }
 };

--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -45,7 +45,7 @@ namespace sgl::slangpy {
 // so calls with vs. without it are separate cache entries.
 // Only called when call_data->has_thread_count() is true (cheap bool check), so the
 // kwargs.contains() string lookup is avoided entirely on the common no-thread-count path.
-static void read_thread_count_kwarg(RuntimeOptions& options, nb::kwargs& kwargs)
+static void read_thread_count_kwarg(NativeCallRuntimeOptions& options, nb::kwargs& kwargs)
 {
     SGL_ASSERT(kwargs.contains("_thread_count"));
     int thread_count = nb::cast<int>(kwargs["_thread_count"]);
@@ -53,7 +53,7 @@ static void read_thread_count_kwarg(RuntimeOptions& options, nb::kwargs& kwargs)
     options.thread_count = thread_count;
 }
 
-static void apply_torch_cuda_stream(const NativeCallData* call_data, RuntimeOptions& options)
+static void apply_torch_cuda_stream(const NativeCallData* call_data, NativeCallRuntimeOptions& options)
 {
     if (call_data->is_torch_integration() && TorchBridge::instance().is_available()) {
         void* stream_ptr = TorchBridge::instance().get_current_cuda_stream(0);
@@ -64,7 +64,7 @@ static void apply_torch_cuda_stream(const NativeCallData* call_data, RuntimeOpti
 
 ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
 {
-    RuntimeOptions options;
+    auto& options = cached_options();
     gather_runtime_options(options);
 
     if (options.this_obj.is_valid()) {
@@ -72,7 +72,7 @@ ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cac
     }
 
     SignatureBuffer builder;
-    read_signature_fast(builder);
+    read_signature(builder);
     cache->get_args_signature(builder, args, kwargs);
 
     std::string_view sig = builder.view();
@@ -88,7 +88,7 @@ ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cac
 
 nb::object NativeFunctionNode::invoke(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
 {
-    RuntimeOptions options;
+    auto& options = cached_options();
     gather_runtime_options(options);
 
     if (options.this_obj.is_valid()) {
@@ -96,7 +96,7 @@ nb::object NativeFunctionNode::invoke(NativeCallDataCache* cache, nb::args args,
     }
 
     SignatureBuffer builder;
-    read_signature_fast(builder);
+    read_signature(builder);
     cache->get_args_signature(builder, args, kwargs);
 
     std::string_view sig = builder.view();
@@ -113,11 +113,10 @@ nb::object NativeFunctionNode::invoke(NativeCallDataCache* cache, nb::args args,
 
     apply_torch_cuda_stream(call_data, options);
 
-    // If torch auto grad required, go via autograd hook (rare path — heap-allocate NativeCallRuntimeOptions)
+    // Autograd and normal path both use the same cached options
     if (call_data->is_torch_autograd()) {
-        ref<NativeCallRuntimeOptions> ref_opts = NativeCallRuntimeOptions::from_runtime_options(options);
         return TorchBridge::instance()
-            .call_torch_autograd_hook(nb::cast(this), nb::cast(call_data), nb::cast(ref_opts), args, kwargs);
+            .call_torch_autograd_hook(nb::cast(this), nb::cast(call_data), nb::cast(m_cached_opts), args, kwargs);
     } else {
         return call_data->call(options, args, kwargs);
     }
@@ -130,7 +129,7 @@ void NativeFunctionNode::append_to(
     nb::kwargs kwargs
 )
 {
-    RuntimeOptions options;
+    auto& options = cached_options();
     gather_runtime_options(options);
 
     if (options.this_obj.is_valid()) {
@@ -138,7 +137,7 @@ void NativeFunctionNode::append_to(
     }
 
     SignatureBuffer builder;
-    read_signature_fast(builder);
+    read_signature(builder);
     cache->get_args_signature(builder, args, kwargs);
 
     std::string_view sig = builder.view();
@@ -186,7 +185,7 @@ nb::object NativeFunctionNode::call_bwds(NativeCallData* fwds_call_data, nb::arg
     // Gather runtime options (uniforms, cuda_stream, etc.)
     // Note: we do NOT prepend 'this' to args here — the saved args from the
     // forward pass already include it (it was prepended in NativeFunctionNode::call).
-    RuntimeOptions options;
+    auto& options = cached_options();
     gather_runtime_options(options);
 
     apply_torch_cuda_stream(bwds_cd, options);
@@ -326,15 +325,19 @@ SGL_PY_EXPORT(utils_slangpy_function)
         )
         .def(
             "read_signature",
-            &NativeFunctionNode::read_signature,
+            [](const NativeFunctionNode& self, SignatureBuilder* builder)
+            {
+                self.read_signature(builder);
+            },
             "builder"_a,
             D_NA(NativeFunctionNode, read_signature)
         )
         .def(
             "gather_runtime_options",
-            static_cast<void (NativeFunctionNode::*)(ref<NativeCallRuntimeOptions>) const>(
-                &NativeFunctionNode::gather_runtime_options
-            ),
+            [](const NativeFunctionNode& self, NativeCallRuntimeOptions& options)
+            {
+                self.gather_runtime_options(options);
+            },
             "options"_a,
             D_NA(NativeFunctionNode, gather_runtime_options)
         )

--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -62,31 +62,10 @@ static void apply_torch_cuda_stream(const NativeCallData* call_data, NativeCallR
     }
 }
 
-ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
-{
-    auto& options = cached_options();
-    gather_runtime_options(options);
-
-    if (options.this_obj.is_valid()) {
-        args = nb::cast<nb::args>(nb::make_tuple(options.this_obj) + args);
-    }
-
-    SignatureBuffer builder;
-    read_signature(builder);
-    cache->get_args_signature(builder, args, kwargs);
-
-    std::string_view sig = builder.view();
-    ref<NativeCallData> result = cache->find_call_data(sig);
-    if (!result) {
-        result = generate_call_data(args, kwargs);
-        cache->add_call_data(std::string(sig), result);
-    } else if (result->has_thread_count()) {
-        nb::del(kwargs["_thread_count"]);
-    }
-    return result;
-}
-
-nb::object NativeFunctionNode::invoke(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
+/// Common preamble for build_call_data/invoke/append_to: gather options, prepend this,
+/// build signature, resolve or generate call data.
+ref<NativeCallData>
+NativeFunctionNode::resolve_call_data(NativeCallDataCache* cache, nb::args& args, nb::kwargs& kwargs)
 {
     auto& options = cached_options();
     gather_runtime_options(options);
@@ -110,10 +89,21 @@ nb::object NativeFunctionNode::invoke(NativeCallDataCache* cache, nb::args args,
         read_thread_count_kwarg(options, kwargs);
         nb::del(kwargs["_thread_count"]);
     }
+    return call_data;
+}
+
+ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
+{
+    return resolve_call_data(cache, args, kwargs);
+}
+
+nb::object NativeFunctionNode::invoke(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
+{
+    ref<NativeCallData> call_data = resolve_call_data(cache, args, kwargs);
+    auto& options = *m_cached_opts;
 
     apply_torch_cuda_stream(call_data, options);
 
-    // Autograd and normal path both use the same cached options
     if (call_data->is_torch_autograd()) {
         return TorchBridge::instance()
             .call_torch_autograd_hook(nb::cast(this), nb::cast(call_data), nb::cast(m_cached_opts), args, kwargs);
@@ -129,29 +119,8 @@ void NativeFunctionNode::append_to(
     nb::kwargs kwargs
 )
 {
-    auto& options = cached_options();
-    gather_runtime_options(options);
-
-    if (options.this_obj.is_valid()) {
-        args = nb::cast<nb::args>(nb::make_tuple(options.this_obj) + args);
-    }
-
-    SignatureBuffer builder;
-    read_signature(builder);
-    cache->get_args_signature(builder, args, kwargs);
-
-    std::string_view sig = builder.view();
-    ref<NativeCallData> call_data = cache->find_call_data(sig);
-
-    if (!call_data) {
-        call_data = generate_call_data(args, kwargs);
-        cache->add_call_data(std::string(sig), call_data);
-    }
-    if (call_data->has_thread_count()) {
-        read_thread_count_kwarg(options, kwargs);
-        nb::del(kwargs["_thread_count"]);
-    }
-    call_data->append_to(options, command_encoder, args, kwargs);
+    ref<NativeCallData> call_data = resolve_call_data(cache, args, kwargs);
+    call_data->append_to(*m_cached_opts, command_encoder, args, kwargs);
 }
 
 std::string NativeFunctionNode::to_string() const

--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -45,33 +45,41 @@ namespace sgl::slangpy {
 // so calls with vs. without it are separate cache entries.
 // Only called when call_data->has_thread_count() is true (cheap bool check), so the
 // kwargs.contains() string lookup is avoided entirely on the common no-thread-count path.
-static bool read_thread_count_kwarg(ref<NativeCallRuntimeOptions> options, nb::kwargs& kwargs)
+static void read_thread_count_kwarg(RuntimeOptions& options, nb::kwargs& kwargs)
 {
     SGL_ASSERT(kwargs.contains("_thread_count"));
     int thread_count = nb::cast<int>(kwargs["_thread_count"]);
     SGL_CHECK(thread_count > 0, "_thread_count must be a positive integer, got {}", thread_count);
-    options->set_thread_count(thread_count);
-    return true;
+    options.thread_count = thread_count;
+}
+
+static void apply_torch_cuda_stream(const NativeCallData* call_data, RuntimeOptions& options)
+{
+    if (call_data->is_torch_integration() && TorchBridge::instance().is_available()) {
+        void* stream_ptr = TorchBridge::instance().get_current_cuda_stream(0);
+        NativeHandle stream_handle(NativeHandleType::CUstream, reinterpret_cast<uint64_t>(stream_ptr));
+        options.cuda_stream = stream_handle;
+    }
 }
 
 ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
 {
-    auto options = make_ref<NativeCallRuntimeOptions>();
+    RuntimeOptions options;
     gather_runtime_options(options);
 
-    if (!options->get_this().is_none()) {
-        args = nb::cast<nb::args>(nb::make_tuple(options->get_this()) + args);
+    if (options.this_obj.is_valid()) {
+        args = nb::cast<nb::args>(nb::make_tuple(options.this_obj) + args);
     }
 
-    auto builder = make_ref<SignatureBuilder>();
-    read_signature(builder);
+    SignatureBuffer builder;
+    read_signature_fast(builder);
     cache->get_args_signature(builder, args, kwargs);
 
-    std::string sig = builder->str();
+    std::string_view sig = builder.view();
     ref<NativeCallData> result = cache->find_call_data(sig);
     if (!result) {
         result = generate_call_data(args, kwargs);
-        cache->add_call_data(sig, result);
+        cache->add_call_data(std::string(sig), result);
     } else if (result->has_thread_count()) {
         nb::del(kwargs["_thread_count"]);
     }
@@ -80,41 +88,36 @@ ref<NativeCallData> NativeFunctionNode::build_call_data(NativeCallDataCache* cac
 
 nb::object NativeFunctionNode::invoke(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs)
 {
-    auto options = make_ref<NativeCallRuntimeOptions>();
+    RuntimeOptions options;
     gather_runtime_options(options);
 
-    if (!options->get_this().is_none()) {
-        args = nb::cast<nb::args>(nb::make_tuple(options->get_this()) + args);
+    if (options.this_obj.is_valid()) {
+        args = nb::cast<nb::args>(nb::make_tuple(options.this_obj) + args);
     }
 
-    auto builder = make_ref<SignatureBuilder>();
-    read_signature(builder);
+    SignatureBuffer builder;
+    read_signature_fast(builder);
     cache->get_args_signature(builder, args, kwargs);
 
-    std::string sig = builder->str();
+    std::string_view sig = builder.view();
     ref<NativeCallData> call_data = cache->find_call_data(sig);
 
     if (!call_data) {
         call_data = generate_call_data(args, kwargs);
-        cache->add_call_data(sig, call_data);
+        cache->add_call_data(std::string(sig), call_data);
     }
     if (call_data->has_thread_count()) {
         read_thread_count_kwarg(options, kwargs);
         nb::del(kwargs["_thread_count"]);
     }
 
-    // If torch integration is enabled and the bridge is available, set the CUDA stream.
-    if (call_data->is_torch_integration() && TorchBridge::instance().is_available()) {
-        void* stream_ptr = TorchBridge::instance().get_current_cuda_stream(0);
-        NativeHandle stream_handle(NativeHandleType::CUstream, reinterpret_cast<uint64_t>(stream_ptr));
-        options->set_cuda_stream(stream_handle);
-    }
+    apply_torch_cuda_stream(call_data, options);
 
-    // If torch auto grad required, go via autograd hook
+    // If torch auto grad required, go via autograd hook (rare path — heap-allocate NativeCallRuntimeOptions)
     if (call_data->is_torch_autograd()) {
-        // Use TorchBridge to call the autograd hook - handles caching and cleanup
+        ref<NativeCallRuntimeOptions> ref_opts = NativeCallRuntimeOptions::from_runtime_options(options);
         return TorchBridge::instance()
-            .call_torch_autograd_hook(nb::cast(this), nb::cast(call_data), nb::cast(options), args, kwargs);
+            .call_torch_autograd_hook(nb::cast(this), nb::cast(call_data), nb::cast(ref_opts), args, kwargs);
     } else {
         return call_data->call(options, args, kwargs);
     }
@@ -127,25 +130,23 @@ void NativeFunctionNode::append_to(
     nb::kwargs kwargs
 )
 {
-    auto options = make_ref<NativeCallRuntimeOptions>();
+    RuntimeOptions options;
     gather_runtime_options(options);
 
-    if (!options->get_this().is_none()) {
-        args = nb::cast<nb::args>(nb::make_tuple(options->get_this()) + args);
+    if (options.this_obj.is_valid()) {
+        args = nb::cast<nb::args>(nb::make_tuple(options.this_obj) + args);
     }
 
-    auto builder = make_ref<SignatureBuilder>();
-    read_signature(builder);
+    SignatureBuffer builder;
+    read_signature_fast(builder);
     cache->get_args_signature(builder, args, kwargs);
 
-    std::string sig = builder->str();
-    NativeCallData* call_data = cache->find_call_data(sig);
+    std::string_view sig = builder.view();
+    ref<NativeCallData> call_data = cache->find_call_data(sig);
 
-    ref<NativeCallData> new_call_data_ref; // keeps new call_data alive on cache miss
     if (!call_data) {
-        new_call_data_ref = generate_call_data(args, kwargs);
-        cache->add_call_data(sig, new_call_data_ref);
-        call_data = new_call_data_ref.get();
+        call_data = generate_call_data(args, kwargs);
+        cache->add_call_data(std::string(sig), call_data);
     }
     if (call_data->has_thread_count()) {
         read_thread_count_kwarg(options, kwargs);
@@ -185,15 +186,10 @@ nb::object NativeFunctionNode::call_bwds(NativeCallData* fwds_call_data, nb::arg
     // Gather runtime options (uniforms, cuda_stream, etc.)
     // Note: we do NOT prepend 'this' to args here — the saved args from the
     // forward pass already include it (it was prepended in NativeFunctionNode::call).
-    auto options = make_ref<NativeCallRuntimeOptions>();
+    RuntimeOptions options;
     gather_runtime_options(options);
 
-    // CUDA stream sync for torch integration
-    if (bwds_cd->is_torch_integration() && TorchBridge::instance().is_available()) {
-        void* stream_ptr = TorchBridge::instance().get_current_cuda_stream(0);
-        NativeHandle stream_handle(NativeHandleType::CUstream, reinterpret_cast<uint64_t>(stream_ptr));
-        options->set_cuda_stream(stream_handle);
-    }
+    apply_torch_cuda_stream(bwds_cd, options);
 
     return bwds_cd->call(options, args, kwargs);
 }
@@ -336,7 +332,9 @@ SGL_PY_EXPORT(utils_slangpy_function)
         )
         .def(
             "gather_runtime_options",
-            &NativeFunctionNode::gather_runtime_options,
+            static_cast<void (NativeFunctionNode::*)(ref<NativeCallRuntimeOptions>) const>(
+                &NativeFunctionNode::gather_runtime_options
+            ),
             "options"_a,
             D_NA(NativeFunctionNode, gather_runtime_options)
         )

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -52,6 +52,13 @@ public:
 
     void read_signature(SignatureBuilder* builder) const override
     {
+        // Delegate to the SignatureBuffer implementation via the builder's buffer.
+        read_signature_fast(builder->buffer());
+    }
+
+    /// Write signature into a stack-allocated SignatureBuffer (hot path, non-virtual).
+    void read_signature_fast(SignatureBuffer& builder) const
+    {
         switch (m_type) {
         case sgl::slangpy::FunctionNodeType::uniforms:
         case sgl::slangpy::FunctionNodeType::this_:
@@ -59,32 +66,45 @@ public:
             break;
         default:
             // Any other type affects kernel so adds to signature.
-            NativeObject::read_signature(builder);
-            *builder << "\n";
+            NativeObject::read_signature_fast(builder);
+            builder << "\n";
             break;
         }
         if (m_parent) {
-            m_parent->read_signature(builder);
+            m_parent->read_signature_fast(builder);
         }
     }
 
+    /// Python-facing overload: fills RuntimeOptions inside NativeCallRuntimeOptions,
+    /// then syncs the Python uniforms list.
     void gather_runtime_options(ref<NativeCallRuntimeOptions> options) const
     {
+        gather_runtime_options(options->opts());
+        // Sync the Python uniforms list from the RuntimeOptions inline array.
+        nb::list uniforms = options->uniforms();
+        uniforms.clear();
+        for (const auto& u : options->opts().uniforms)
+            uniforms.append(u);
+    }
+
+    /// Core implementation operating on RuntimeOptions (used by both Python and C++ hot paths).
+    void gather_runtime_options(RuntimeOptions& opts) const
+    {
         if (m_parent) {
-            m_parent->gather_runtime_options(options);
+            m_parent->gather_runtime_options(opts);
         }
         switch (m_type) {
         case sgl::slangpy::FunctionNodeType::this_:
-            options->set_this(m_data);
+            opts.this_obj = m_data;
             break;
         case sgl::slangpy::FunctionNodeType::uniforms:
-            options->uniforms().append(m_data);
+            opts.uniforms.push_back(m_data);
             break;
         case sgl::slangpy::FunctionNodeType::cuda_stream:
-            options->set_cuda_stream(nb::cast<NativeHandle>(m_data));
+            opts.cuda_stream = nb::cast<NativeHandle>(m_data);
             break;
         case sgl::slangpy::FunctionNodeType::ray_tracing:
-            options->set_is_ray_tracing(true);
+            opts.is_ray_tracing = true;
             break;
         default:
             break;

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -53,11 +53,11 @@ public:
     void read_signature(SignatureBuilder* builder) const override
     {
         // Delegate to the SignatureBuffer implementation via the builder's buffer.
-        read_signature_fast(builder->buffer());
+        read_signature(builder->buffer());
     }
 
-    /// Write signature into a stack-allocated SignatureBuffer (hot path, non-virtual).
-    void read_signature_fast(SignatureBuffer& builder) const
+    /// Non-virtual overload for SignatureBuffer (hot path).
+    void read_signature(SignatureBuffer& builder) const
     {
         switch (m_type) {
         case sgl::slangpy::FunctionNodeType::uniforms:
@@ -66,29 +66,17 @@ public:
             break;
         default:
             // Any other type affects kernel so adds to signature.
-            NativeObject::read_signature_fast(builder);
+            NativeObject::read_signature(builder);
             builder << "\n";
             break;
         }
         if (m_parent) {
-            m_parent->read_signature_fast(builder);
+            m_parent->read_signature(builder);
         }
     }
 
-    /// Python-facing overload: fills RuntimeOptions inside NativeCallRuntimeOptions,
-    /// then syncs the Python uniforms list.
-    void gather_runtime_options(ref<NativeCallRuntimeOptions> options) const
-    {
-        gather_runtime_options(options->opts());
-        // Sync the Python uniforms list from the RuntimeOptions inline array.
-        nb::list uniforms = options->uniforms();
-        uniforms.clear();
-        for (const auto& u : options->opts().uniforms)
-            uniforms.append(u);
-    }
-
-    /// Core implementation operating on RuntimeOptions (used by both Python and C++ hot paths).
-    void gather_runtime_options(RuntimeOptions& opts) const
+    /// Fill runtime options by walking the function node chain.
+    void gather_runtime_options(NativeCallRuntimeOptions& opts) const
     {
         if (m_parent) {
             m_parent->gather_runtime_options(opts);
@@ -191,11 +179,21 @@ public:
         m_cache = nullptr;
     }
 
+    /// Get or create cached runtime options (avoids heap alloc on repeat calls).
+    NativeCallRuntimeOptions& cached_options()
+    {
+        if (!m_cached_opts)
+            m_cached_opts = make_ref<NativeCallRuntimeOptions>();
+        m_cached_opts->init();
+        return *m_cached_opts;
+    }
+
 private:
     ref<NativeFunctionNode> m_parent;
     FunctionNodeType m_type;
     nb::object m_data;
     ref<NativeCallDataCache> m_cache;
+    ref<NativeCallRuntimeOptions> m_cached_opts;
 };
 
 struct PyNativeFunctionNode : NativeFunctionNode {

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -180,6 +180,7 @@ public:
         m_parent = nullptr;
         m_data = nb::none();
         m_cache = nullptr;
+        m_cached_opts = nullptr;
     }
 
     /// Get or create cached runtime options (avoids heap alloc on repeat calls).

--- a/src/slangpy_ext/utils/slangpyfunction.h
+++ b/src/slangpy_ext/utils/slangpyfunction.h
@@ -135,6 +135,9 @@ public:
     /// error formatting, and delegates to invoke(). Registered as __call__ in nanobind.
     nb::object call(nb::args args, nb::kwargs kwargs);
 
+    /// Common preamble: gather options, prepend this, build signature, resolve/generate call data.
+    ref<NativeCallData> resolve_call_data(NativeCallDataCache* cache, nb::args& args, nb::kwargs& kwargs);
+
     /// Call the backward pass for autograd, caching the bwds CallData on the forward CallData.
     /// This avoids the Python round-trip through function.bwds property.
     /// @param fwds_call_data The forward-pass call data (bwds call data is cached on it).


### PR DESCRIPTION
## Summary
- Stack-allocated `SignatureBuffer` (backed by `short_vector<uint8_t, 1024>`) replaces heap-allocated `SignatureBuilder` on the C++ fast path
- Stack-allocated `RuntimeOptions` struct replaces heap-allocated `NativeCallRuntimeOptions` (heap version only used for rare torch autograd path)
- `static_vector<nb::object, 4>` for `RuntimeOptions::uniforms` instead of raw C array + manual counter
- Transparent `string_view` lookup on signature cache avoids `std::string` copy on every cache hit
- Cache `CallContext` on `NativeCallData`, reuse via `reinitialize()`
- Skip unpack fast path: borrow args/kwargs directly when `m_needs_unpack == false`
- Extract `apply_torch_cuda_stream()` helper to deduplicate stream setup

Reduces per-call heap allocations from 6 to 1 (excluding RHI driver calls).

Closes #690

## Test plan
- [ ] Build on Windows (`cmake --build --preset windows-msvc-debug`)
- [ ] `pytest slangpy/tests -v` — all tests pass
- [ ] `pytest slangpy/benchmarks/test_benchmark_autograd.py -v` — no regression
- [ ] `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster, lower‑latency dispatch with reduced allocations and improved signature caching; streamlined runtime option handling and Python-facing bindings.

* **Bug Fixes**
  * More reliable GPU execution via cached call context and centralized CUDA/Torch stream setup.
  * Safer positional-argument handling to reduce edge-case dispatch errors and avoid unnecessary Python object copying.

* **API**
  * Simplified Python-facing call-context creation/initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->