### PR TITLE
Support merge queue ref checkout for Slang CI

### DIFF
--- a/.github/actions/build-and-test-with-slang/action.yml
+++ b/.github/actions/build-and-test-with-slang/action.yml
@@ -23,6 +23,12 @@ inputs:
   slang-pr-number:
     description: "Slang PR number to checkout (pr mode)"
     default: ""
+  slang-ref:
+    description: "Slang ref to checkout (ref mode)"
+    default: ""
+  slang-repo:
+    description: "Slang repository to clone for ref mode"
+    default: "shader-slang/slang"
   shell:
     description: "Shell to use for run steps (bash on Linux/macOS, pwsh on Windows)"
     required: true
@@ -90,6 +96,16 @@ runs:
         git clone https://github.com/shader-slang/slang.git
         cd slang
         git fetch origin pull/${{ inputs.slang-pr-number }}/head
+        git checkout FETCH_HEAD
+        git submodule update --init --recursive
+
+    - name: Checkout Slang (ref)
+      if: inputs.slang-checkout-mode == 'ref'
+      shell: ${{ inputs.shell }}
+      run: |
+        git clone https://github.com/${{ inputs.slang-repo }}.git slang
+        cd slang
+        git fetch origin ${{ inputs.slang-ref }}
         git checkout FETCH_HEAD
         git submodule update --init --recursive
 

--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -1,5 +1,5 @@
 name: ci-latest-slang
-run-name: "${{ github.event_name == 'repository_dispatch' && format('Slang PR #{0}', github.event.client_payload.slang_pr_number) || format('Slang branch: {0}', github.event.inputs.slang_branch || 'master') }}"
+run-name: "${{ github.event_name == 'repository_dispatch' && (github.event.client_payload.slang_pr_number && format('Slang PR #{0}', github.event.client_payload.slang_pr_number) || format('Slang ref: {0}', github.event.client_payload.slang_ref || github.event.client_payload.slang_commit_sha)) || format('Slang branch: {0}', github.event.inputs.slang_branch || 'master') }}"
 
 on:
   schedule:
@@ -20,7 +20,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: ${{ github.event_name == 'repository_dispatch' && format('slang-pr-{0}', github.event.client_payload.slang_pr_number) || github.run_id }}
+  group: ${{ github.event_name == 'repository_dispatch' && format('slang-{0}', github.event.client_payload.slang_pr_number || github.event.client_payload.slang_commit_sha) || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -105,8 +105,10 @@ jobs:
           python: ${{ matrix.python }}
           flags: ${{ matrix.flags }}
           shell: ${{ matrix.os == 'windows' && 'pwsh' || 'bash' }}
-          slang-checkout-mode: pr
+          slang-checkout-mode: ${{ github.event.client_payload.slang_checkout_mode || 'pr' }}
           slang-pr-number: ${{ github.event.client_payload.slang_pr_number }}
+          slang-ref: ${{ github.event.client_payload.slang_ref }}
+          slang-repo: ${{ github.event.client_payload.slang_checkout_repo || 'shader-slang/slang' }}
 
   # Post aggregate status to Slang PR after all matrix jobs complete
   report-status:


### PR DESCRIPTION
## Summary
- allow repository_dispatch runs to select PR or ref-based Slang checkout
- fetch the dispatched merge queue ref directly when testing merge queue candidates
- keep reporting SlangPy status back to the dispatched Slang commit SHA

## Testing
- parsed updated workflow and action YAML locally with python yaml.safe_load


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CI workflows now support checking out Slang by reference or commit SHA, enabling more flexible build configurations.
  * Enhanced workflow naming to reflect repository dispatch context with PR numbers or commit identifiers.

* **Improvements**
  * Optimized concurrency group management for better workflow coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->