### PR TITLE
Add std::hash specialization for sgl::math::matrix

### DIFF
--- a/src/sgl/math/matrix_math.h
+++ b/src/sgl/math/matrix_math.h
@@ -820,6 +820,18 @@ bool lex_lt(const matrix<T, R, C>& lhs, const matrix<T, R, C>& rhs)
 } // namespace sgl::math
 
 template<typename T, int R, int C>
+struct std::hash<::sgl::math::matrix<T, R, C>> {
+    constexpr size_t operator()(const ::sgl::math::matrix<T, R, C>& m) const
+    {
+        size_t result = 0;
+        for (int r = 0; r < R; ++r)
+            for (int c = 0; c < C; ++c)
+                result ^= std::hash<T>()(m[r][c]) + 0x9e3779b9 + (result << 6) + (result >> 2);
+        return result;
+    }
+};
+
+template<typename T, int R, int C>
 struct fmt::formatter<sgl::math::matrix<T, R, C>> : formatter<typename sgl::math::matrix<T, R, C>::row_type> {
     using row_type = typename sgl::math::matrix<T, R, C>::row_type;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Matrix types now support hashing, enabling their use in standard library hash-based containers and algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->