### PR TITLE
Add DescriptorHandle default constructor

### DIFF
--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -212,6 +212,8 @@ struct SGL_API DescriptorHandle {
     DescriptorHandleType type{DescriptorHandleType::undefined};
     uint64_t value{0};
 
+    DescriptorHandle() = default;
+
     explicit DescriptorHandle(const rhi::DescriptorHandle& handle)
     {
         type = static_cast<DescriptorHandleType>(handle.type);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced descriptor handle initialization flexibility by allowing default construction without explicit parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->