### PR TITLE
Fix #833 - Reject writes to broadcasted torch tensors (stride=0)

### DIFF
--- a/slangpy/tests/slangpy_tests/test_torchintegration.py
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.py
@@ -645,5 +645,26 @@ def test_nn_module_parameter_gradient(device_type: DeviceType):
     compare_tensors(bias.grad, torch.ones_like(bias))
 
 
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_broadcast_tensor_read(device_type: DeviceType):
+    """Reading from a broadcasted tensor (stride=0) should work correctly."""
+    module = load_test_module(device_type)
+    a = torch.tensor([1.0], device="cuda").expand(4)  # shape=[4], stride=[0]
+    b = torch.tensor([2.0, 3.0, 4.0, 5.0], device="cuda")
+    result = module.add(a, b)
+    compare_tensors(result, torch.tensor([3.0, 4.0, 5.0, 6.0], device="cuda"))
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_broadcast_tensor_write_raises(device_type: DeviceType):
+    """Writing to a broadcasted tensor (stride=0) should raise an error."""
+    module = load_test_module(device_type)
+    a = torch.tensor([1.0, 2.0, 3.0], device="cuda")
+    b = torch.tensor([1.0, 2.0, 3.0], device="cuda")
+    res = torch.tensor([0.0], device="cuda").expand(3)  # broadcasted output
+    with pytest.raises(RuntimeError, match="broadcasted tensor"):
+        module.add_out(a, b, res=res)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/src/slangpy_ext/utils/slangpytorchtensor.cpp
+++ b/src/slangpy_ext/utils/slangpytorchtensor.cpp
@@ -63,6 +63,16 @@ namespace {
         return result;
     }
 
+    /// Check if a tensor has any broadcasted dimensions (stride=0 with shape > 1).
+    bool has_broadcast_stride(const TensorBridgeInfo& info)
+    {
+        for (int i = 0; i < info.ndim; i++) {
+            if (info.strides[i] == 0 && info.shape[i] > 1)
+                return true;
+        }
+        return false;
+    }
+
     /// Validate tensor shape against expected vector type shape
     void validate_tensor_shape(const Shape& tensor_shape, const Shape& vector_shape)
     {
@@ -369,6 +379,25 @@ void NativeTorchTensorMarshall::write_shader_cursor_pre_dispatch(
     // For meta tensors (backward pass outputs), is_cuda comes from grad
     if (!primal_info.is_cuda && primal_info.data_ptr != nullptr) {
         SGL_THROW("Non-CUDA torch tensors are not yet supported. Tensor must be on CUDA device.");
+    }
+
+    // Reject writes to broadcasted tensors (stride=0 with shape > 1).
+    // Reading from broadcast tensors works correctly (all threads read same element),
+    // but writing causes a race condition (all threads write to same address).
+    auto [primal_access, grad_access] = binding->access();
+    if (has_broadcast_stride(primal_info)
+        && (primal_access == AccessType::write || primal_access == AccessType::readwrite)) {
+        SGL_THROW(
+            "Cannot write to a broadcasted tensor (has stride 0). "
+            "Call .contiguous() before passing to slangpy."
+        );
+    }
+    if (has_grad && has_broadcast_stride(grad_info)
+        && (grad_access == AccessType::write || grad_access == AccessType::readwrite)) {
+        SGL_THROW(
+            "Cannot write to a broadcasted gradient tensor (has stride 0). "
+            "Call .contiguous() on the gradient before passing to slangpy."
+        );
     }
 
     ShaderObject* shader_object = cursor.shader_object();


### PR DESCRIPTION
Validate tensor strides before GPU dispatch. Reading from broadcast tensors is allowed; writing raises an error to prevent silent corruption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent write operations on broadcasted tensors. Users will now receive a clear error message if attempting to write to a broadcasted tensor and must call `.contiguous()` first to resolve the issue.

* **Tests**
  * Added integration tests to verify proper handling of broadcasted tensor read/write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->