### PR TITLE
Fix VRAM leak in PyTorch autograd backward pass

### DIFF
--- a/slangpy/torchintegration/autogradhook.py
+++ b/slangpy/torchintegration/autogradhook.py
@@ -81,6 +81,13 @@ class TorchAutoGradHook(torch.autograd.Function):
         :param grad_outputs: Gradients for each output tensor.
         :return: Tuple of gradients for each input, with None for the options arg.
         """
+        if ctx.forwards_cd is None:
+            raise RuntimeError(
+                "TorchAutoGradHook.backward() called more than once on the same "
+                "graph. This can happen when backward(retain_graph=True) is used, "
+                "which is not supported by SlangPy's autograd integration."
+            )
+
         # Native C++ handles: tensor restoration, grad creation, bwds dispatch
         input_grads = ctx.forwards_cd.autograd_backward(
             ctx.function,
@@ -90,5 +97,15 @@ class TorchAutoGradHook(torch.autograd.Function):
             list(ctx.saved_tensors),
             grad_outputs,
         )
+
+        # Release references to GPU resources so they can be garbage-collected
+        # between iterations.  Without this, ctx keeps args/kwargs/pairs (which
+        # hold torch tensors and native diff-pairs) alive until the *next*
+        # backward pass replaces them, causing VRAM to grow linearly.
+        ctx.function = None
+        ctx.forwards_cd = None
+        ctx.args = None
+        ctx.kwargs = None
+        ctx.pairs = None
 
         return (None,) + tuple(input_grads)


### PR DESCRIPTION
TorchAutoGradHook.backward() held references to function, call data,
args, kwargs, and diff pairs on the autograd ctx after the backward
pass completed. These kept GPU resources alive until the next forward
pass replaced them, causing VRAM to grow ~0.5MB per iteration.

Clear ctx attributes after backward finishes. Add a guard that raises
a clear error if backward is called twice on the same graph
(retain_graph=True), which is currently unsupported.

Fixes #896

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent errors when backward propagation is invoked multiple times on the same computation graph.
  * Improved memory management by explicitly releasing GPU and native resource references between iterations, enabling more efficient garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->