### PR TITLE
Fix scalar DiffPair backward pass codegen

### DIFF
--- a/slangpy/builtin/diffpair.py
+++ b/slangpy/builtin/diffpair.py
@@ -34,30 +34,77 @@ def generate_differential_pair(
     assert deriv_storage
     assert primal_target
 
+    # Derivative is writable (RWValueRef) → __slangpy_load backward writes gradients out.
+    # Derivative is readable (ValueType)  → __slangpy_store backward reads gradient seed.
+    deriv_is_writable = deriv_storage.startswith("RWValueRef")
+    deriv_is_readable = deriv_storage.startswith("ValueType") or deriv_is_writable
+    needs_diff = deriv_storage != "NoneType"
+
     DIFF_PAIR_CODE = f"""
 struct _t_{name}
 {{
     {primal_storage} primal;
     {deriv_storage} derivative;
-    void load({context} context, out DifferentialPair<{primal_target}> value)
+"""
+
+    if needs_diff and deriv_is_writable:
+        # Inner helper that returns the primal value, with a custom backward
+        # that writes the adjoint into the derivative buffer.
+        DIFF_PAIR_CODE += f"""
+    [Differentiable]
+    [BackwardDerivative(_read_bwd)]
+    {primal_target} _read({context} context)
     {{
         {primal_target} p;
-        primal.load(context, p);"""
-    if deriv_storage == "NoneType":
-        DIFF_PAIR_CODE += """
-        value = diffPair(p);"""
+        primal.__slangpy_load(context, p);
+        return p;
+    }}
+    void _read_bwd({context} context, {deriv_target} grad)
+    {{
+        derivative.__slangpy_store(context, grad);
+    }}
+    [Differentiable]
+    void __slangpy_load({context} context, out {primal_target} value)
+    {{
+        value = this._read(context);
+    }}"""
     else:
         DIFF_PAIR_CODE += f"""
-        {deriv_target} d;
-        derivative.load(d);
-        value = diffPair(p, d);"""
-    DIFF_PAIR_CODE += f"""}}
-    void store({context} context, in DifferentialPair<{primal_target}> value)
+    void __slangpy_load({context} context, out {primal_target} value)
     {{
-        primal.store(context, value.p);
-        derivative.store(context, value.d);
+        primal.__slangpy_load(context, value);
+    }}"""
+
+    if needs_diff and deriv_is_readable:
+        # Inner helper that consumes the primal value, with a custom backward
+        # that reads the gradient seed from the derivative buffer.
+        DIFF_PAIR_CODE += f"""
+    [Differentiable]
+    [BackwardDerivative(_write_bwd)]
+    void _write({context} context, {primal_target} value)
+    {{
+        primal.__slangpy_store(context, value);
     }}
-}}
+    void _write_bwd({context} context, inout DifferentialPair<{primal_target}> value)
+    {{
+        {deriv_target} d;
+        derivative.__slangpy_load(context, d);
+        value = diffPair(value.p, d);
+    }}
+    [Differentiable]
+    void __slangpy_store({context} context, in {primal_target} value)
+    {{
+        this._write(context, value);
+    }}"""
+    else:
+        DIFF_PAIR_CODE += f"""
+    void __slangpy_store({context} context, in {primal_target} value)
+    {{
+        primal.__slangpy_store(context, value);
+    }}"""
+
+    DIFF_PAIR_CODE += """
+}
 """
     return DIFF_PAIR_CODE
 

--- a/slangpy/tests/slangpy_tests/test_differential_function_call.py
+++ b/slangpy/tests/slangpy_tests/test_differential_function_call.py
@@ -83,7 +83,6 @@ def test_call_with_none_diff_scalars(device_type: DeviceType):
     function.bwds(a, b, res)
 
 
-@pytest.mark.skip("Awaiting auto-diff changes")
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_call_with_diff_scalars(device_type: DeviceType):
 
@@ -119,7 +118,6 @@ def test_call_with_diff_scalars(device_type: DeviceType):
     assert b_diff.grad == exprected_grad
 
 
-@pytest.mark.skip("Awaiting auto-diff changes")
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_call_with_diff_pairs(device_type: DeviceType):
 


### PR DESCRIPTION
The generated Slang struct for `DiffPairMarshall` had two bugs preventing
scalar backward passes from working:

1. Used bare `load`/`store` method names instead of `__slangpy_load`/
   `__slangpy_store` (the convention used by all SlangPy Slang types).

2. Generated `__slangpy_load` that output `DifferentialPair<T>` instead
   of `T`, causing a type mismatch with the trampoline temporaries.
   The methods were also not `[Differentiable]`, so `bwd_diff` could
   not propagate gradients through them.

Rewrites `generate_differential_pair` to follow the same pattern as
`DiffTensor`: the struct's load/store methods operate on the primal type
and, when gradients are needed, use `[Differentiable]` methods with
`[BackwardDerivative]` custom backward functions that explicitly
read/write the derivative buffer.

Removes the "Awaiting auto-diff changes" skip markers from
`test_call_with_diff_scalars` and `test_call_with_diff_pairs`, which
have been skipped since the tests were first added.

Related: #782

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic differentiation handling for differential pairs with better support for various derivative storage configurations enabling more flexible gradient computation.

* **Tests**
  * Enabled automatic differentiation tests for differential function calls that were previously skipped, improving overall test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->