### PR TITLE
Add Bitmap::resample() functions and reconstruction filters

### DIFF
--- a/slangpy/tests/core/test_bitmap_resampling.py
+++ b/slangpy/tests/core/test_bitmap_resampling.py
@@ -1,0 +1,762 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import math
+from typing import Tuple, Union
+
+import pytest
+import numpy as np
+from slangpy import (
+    Bitmap,
+    BoxFilter,
+    TentFilter,
+    GaussianFilter,
+    MitchellFilter,
+    LanczosFilter,
+    FilterBoundaryCondition,
+)
+
+# Type alias for any filter object that exposes eval() and radius.
+FilterType = Union[BoxFilter, TentFilter, GaussianFilter, MitchellFilter, LanczosFilter]
+
+ALL_FILTERS = [BoxFilter(), TentFilter(), GaussianFilter(), MitchellFilter(), LanczosFilter()]
+
+CHANNEL_FORMAT_PAIRS = [
+    (1, Bitmap.PixelFormat.y),
+    (2, Bitmap.PixelFormat.rg),
+    (3, Bitmap.PixelFormat.rgb),
+    (4, Bitmap.PixelFormat.rgba),
+]
+
+# ---------------------------------------------------------------------------
+# Numpy reference resampler — builds weights from native filter.eval(), then
+# applies them with numpy operations.  This is *not* a reimplementation of the
+# C++ resampler; it uses the same filter weights but an independent application
+# path so bugs in the C++ weighted-sum / boundary / separable logic are caught.
+# ---------------------------------------------------------------------------
+
+
+def _bc_lookup(source: np.ndarray, pos: int, n: int, bc: FilterBoundaryCondition) -> float:
+    """Boundary-condition-aware sample lookup."""
+    if 0 <= pos < n:
+        return float(source[pos])
+    if bc == FilterBoundaryCondition.clamp:
+        return float(source[max(0, min(pos, n - 1))])
+    if bc == FilterBoundaryCondition.repeat:
+        return float(source[pos % n])
+    if bc == FilterBoundaryCondition.mirror:
+        pos = pos % (2 * n - 2)
+        if pos >= n - 1:
+            pos = 2 * n - 2 - pos
+        return float(source[pos])
+    if bc == FilterBoundaryCondition.zero:
+        return 0.0
+    if bc == FilterBoundaryCondition.one:
+        return 1.0
+    raise ValueError(f"Unknown boundary condition: {bc}")
+
+
+def _reference_resample_1d(
+    source: np.ndarray,
+    target_res: int,
+    filt: FilterType,
+    bc: FilterBoundaryCondition = FilterBoundaryCondition.clamp,
+    clamp_range: Tuple[float, float] = (-math.inf, math.inf),
+) -> np.ndarray:
+    """Resample a 1D array using weights obtained from ``filt.eval()``."""
+    source_res = len(source)
+    filter_radius = filt.radius
+    is_box = isinstance(filt, BoxFilter)
+    inv_scale = 1.0
+
+    if target_res < source_res:
+        scale = source_res / target_res
+        inv_scale = 1.0 / scale
+        filter_radius *= scale
+
+    taps = math.ceil(filter_radius * 2)
+    if source_res == target_res and (taps % 2) != 1:
+        taps -= 1
+    if filt.radius < 1:
+        taps = min(taps, source_res)
+
+    do_clamp = clamp_range != (-math.inf, math.inf)
+    target = np.empty(target_res, dtype=np.float64)
+
+    if source_res == target_res:
+        # Filtering mode (same resolution).
+        half_taps = taps // 2
+        weights = np.array([filt.eval(float(j - half_taps)) for j in range(taps)], dtype=np.float64)
+        weights /= weights.sum()
+
+        for i in range(target_res):
+            offset = i - half_taps
+            samples = np.array(
+                [_bc_lookup(source, offset + j, source_res, bc) for j in range(taps)],
+                dtype=np.float64,
+            )
+            val = np.dot(samples, weights)
+            if do_clamp:
+                val = np.clip(val, clamp_range[0], clamp_range[1])
+            target[i] = val
+    else:
+        # Resampling mode (different resolution).
+        for i in range(target_res):
+            center = (i + 0.5) / target_res * source_res
+            start = int(math.floor(center - filter_radius + 0.5))
+
+            raw_weights = np.empty(taps, dtype=np.float64)
+            for j in range(taps):
+                pos = start + j + 0.5 - center
+                w = filt.eval(pos * inv_scale)
+                if is_box and target_res > source_res:
+                    w = 1.0
+                raw_weights[j] = w
+            raw_weights /= raw_weights.sum()
+
+            samples = np.array(
+                [_bc_lookup(source, start + j, source_res, bc) for j in range(taps)],
+                dtype=np.float64,
+            )
+            val = np.dot(samples, raw_weights)
+            if do_clamp:
+                val = np.clip(val, clamp_range[0], clamp_range[1])
+            target[i] = val
+
+    return target.astype(np.float32)
+
+
+def reference_resample_2d(
+    image: np.ndarray,
+    target_width: int,
+    target_height: int,
+    filt: FilterType,
+    bc: Tuple[FilterBoundaryCondition, FilterBoundaryCondition] = (
+        FilterBoundaryCondition.clamp,
+        FilterBoundaryCondition.clamp,
+    ),
+    clamp_range: Tuple[float, float] = (-math.inf, math.inf),
+) -> np.ndarray:
+    """Separable 2D resample. Horizontal pass then vertical pass.
+
+    Input is (H, W) or (H, W, C). Returns the same shape convention.
+    """
+    squeeze = image.ndim == 2
+    if squeeze:
+        image = image[:, :, np.newaxis]
+
+    src_h, src_w, channels = image.shape
+    needs_h = src_w != target_width
+    needs_v = src_h != target_height
+
+    if not needs_h and not needs_v:
+        return image[:, :, 0].copy() if squeeze else image.copy()
+
+    # Clamp only on the final pass (matches C++ logic).
+    h_clamp = clamp_range if not needs_v else (-math.inf, math.inf)
+    current = image
+
+    if needs_h:
+        inter = np.empty((src_h, target_width, channels), dtype=np.float32)
+        for y in range(src_h):
+            for ch in range(channels):
+                inter[y, :, ch] = _reference_resample_1d(
+                    current[y, :, ch], target_width, filt, bc[0], h_clamp
+                )
+        current = inter
+
+    if needs_v:
+        result = np.empty((target_height, target_width, channels), dtype=np.float32)
+        for x in range(target_width):
+            for ch in range(channels):
+                result[:, x, ch] = _reference_resample_1d(
+                    current[:, x, ch], target_height, filt, bc[1], clamp_range
+                )
+        current = result
+
+    return current[:, :, 0] if squeeze else current
+
+
+def make_float32_bitmap(
+    width: int,
+    height: int,
+    channels: int = 4,
+    value: float = 0.0,
+    srgb_gamma: bool = False,
+) -> Bitmap:
+    """Create a float32 bitmap filled with a constant value."""
+    pixel_format = {
+        1: Bitmap.PixelFormat.y,
+        2: Bitmap.PixelFormat.rg,
+        3: Bitmap.PixelFormat.rgb,
+        4: Bitmap.PixelFormat.rgba,
+    }[channels]
+    if channels == 1:
+        data = np.full((height, width), value, dtype=np.float32)
+    else:
+        data = np.full((height, width, channels), value, dtype=np.float32)
+    return Bitmap(data, pixel_format=pixel_format, srgb_gamma=srgb_gamma)
+
+
+# ---------------------------------------------------------------------------
+# Basic resample tests
+# ---------------------------------------------------------------------------
+
+
+def test_resample_identity():
+    """Identity resample (same dimensions) should be an exact copy."""
+    data = np.random.rand(32, 32, 4).astype(np.float32)
+    bmp = Bitmap(data, srgb_gamma=False)
+    target = make_float32_bitmap(32, 32, channels=4)
+    bmp.resample(target)
+    np.testing.assert_array_equal(np.array(target, copy=False), data)
+
+
+def test_resample_rejects_uint8():
+    """resample should reject non-float types."""
+    data = np.zeros((16, 16, 4), dtype=np.uint8)
+    bmp = Bitmap(data)
+    with pytest.raises(Exception, match="float"):
+        bmp.resample(8, 8)
+
+
+def test_resample_float16():
+    data = np.random.rand(32, 32, 4).astype(np.float16)
+    bmp = Bitmap(data)
+    result = bmp.resample(16, 16)
+    assert result.width == 16
+    assert result.height == 16
+    assert result.component_type == Bitmap.ComponentType.float16
+
+
+# ---------------------------------------------------------------------------
+# Format and metadata preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "channels,pixel_format", CHANNEL_FORMAT_PAIRS, ids=["y", "rg", "rgb", "rgba"]
+)
+def test_channel_format_preservation(channels: int, pixel_format: Bitmap.PixelFormat):
+    """resample should preserve channel count and pixel_format."""
+    bmp = make_float32_bitmap(32, 32, channels=channels)
+    result = bmp.resample(16, 16)
+    assert result.channel_count == channels
+    assert result.pixel_format == pixel_format
+
+
+def test_srgb_flag_preservation():
+    bmp = make_float32_bitmap(32, 32, srgb_gamma=True)
+    assert bmp.srgb_gamma is True
+    result = bmp.resample(16, 16)
+    assert result.srgb_gamma is True
+
+
+# ---------------------------------------------------------------------------
+# Boundary condition tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bc_val,value",
+    [
+        (FilterBoundaryCondition.clamp, 0.7),
+        (FilterBoundaryCondition.repeat, 0.5),
+        (FilterBoundaryCondition.mirror, 0.3),
+        (FilterBoundaryCondition.one, 1.0),
+    ],
+    ids=["clamp", "repeat", "mirror", "one"],
+)
+def test_boundary_solid_color(bc_val: FilterBoundaryCondition, value: float):
+    """Solid color image should be preserved regardless of boundary mode."""
+    data = np.full((8, 8, 1), value, dtype=np.float32)
+    bmp = Bitmap(data, srgb_gamma=False)
+    result = bmp.resample(4, 4, LanczosFilter(), bc=(bc_val, bc_val))
+    out = np.array(result, copy=False)
+    np.testing.assert_allclose(out, value, atol=1e-5)
+
+
+def test_boundary_asymmetric():
+    """Asymmetric H/V boundary conditions should match the numpy reference."""
+    rng = np.random.RandomState(22)
+    data = rng.rand(8, 8).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+    bc = (FilterBoundaryCondition.clamp, FilterBoundaryCondition.zero)
+    result = bmp.resample(12, 12, filt, bc=bc)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 12, 12, filt, bc=bc)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Edge case and error tests
+# ---------------------------------------------------------------------------
+
+
+def test_resample_zero_dimensions():
+    """resample with zero target dimensions should raise."""
+    bmp = make_float32_bitmap(16, 16)
+    with pytest.raises(Exception):
+        bmp.resample(0, 10)
+    with pytest.raises(Exception):
+        bmp.resample(10, 0)
+
+
+def test_resample_empty_bitmap():
+    """resample on an empty bitmap should raise."""
+    bmp = Bitmap(Bitmap.PixelFormat.rgba, Bitmap.ComponentType.float32, 0, 0)
+    with pytest.raises(Exception):
+        bmp.resample(8, 8)
+
+
+def test_lanczos_gradient_quality():
+    """Lanczos upscale of a gradient should match the numpy reference."""
+    gradient = np.linspace(0.0, 1.0, 64, dtype=np.float32).reshape(1, 64)
+    data = np.broadcast_to(gradient, (64, 64)).copy()
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+    result = bmp.resample(128, 128, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 128, 128, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+def test_large_downscale():
+    """Extreme downscale (1024 -> 1) should not crash and produce valid output."""
+    bmp = make_float32_bitmap(1024, 1024, channels=1, value=0.42)
+    result = bmp.resample(1, 1)
+    assert result.width == 1
+    assert result.height == 1
+    out = np.array(result, copy=False)
+    np.testing.assert_allclose(out.flat[0], 0.42, atol=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Resample into pre-allocated target tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src_size,dst_size,channels,filt",
+    [
+        ((64, 64), (32, 32), 4, LanczosFilter()),
+        ((16, 16), (64, 64), 3, MitchellFilter()),
+    ],
+    ids=["downscale-4ch", "upscale-3ch"],
+)
+def test_resample_into_target_matches_allocating(
+    src_size: Tuple[int, int],
+    dst_size: Tuple[int, int],
+    channels: int,
+    filt: FilterType,
+):
+    """Resample into pre-allocated target should match the allocating version."""
+    pixel_format = {3: Bitmap.PixelFormat.rgb, 4: Bitmap.PixelFormat.rgba}[channels]
+    data = np.random.rand(src_size[0], src_size[1], channels).astype(np.float32)
+    bmp = Bitmap(data, pixel_format=pixel_format, srgb_gamma=False)
+
+    expected = bmp.resample(dst_size[0], dst_size[1], filt)
+    target = make_float32_bitmap(dst_size[0], dst_size[1], channels=channels)
+    bmp.resample(target, filt)
+
+    np.testing.assert_allclose(
+        np.array(target, copy=False), np.array(expected, copy=False), atol=1e-6
+    )
+
+
+def test_resample_into_target_float16():
+    """Resample into pre-allocated float16 target."""
+    data = np.random.rand(32, 32, 4).astype(np.float16)
+    bmp = Bitmap(data)
+
+    expected = bmp.resample(16, 16)
+    target = Bitmap(
+        np.zeros((16, 16, 4), dtype=np.float16),
+        pixel_format=Bitmap.PixelFormat.rgba,
+    )
+    bmp.resample(target)
+
+    np.testing.assert_allclose(
+        np.array(target, copy=False), np.array(expected, copy=False), atol=1e-3
+    )
+
+
+def test_resample_into_target_rejects_format_mismatch():
+    """Resample into target with different format should raise an error."""
+    src = make_float32_bitmap(32, 32, channels=4)
+    target = make_float32_bitmap(16, 16, channels=3)
+    with pytest.raises(Exception):
+        src.resample(target)
+
+
+# ---------------------------------------------------------------------------
+# Output clamping tests
+# ---------------------------------------------------------------------------
+
+
+def test_resample_clamp_restricts_range():
+    """Clamped resample should match the numpy reference with clamp_range."""
+    data = np.zeros((16, 16), dtype=np.float32)
+    data[8, :] = 10.0  # Sharp spike that will cause ringing
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+
+    clamped = bmp.resample(16, 32, filt, clamp=(0.0, 10.0))
+    out_clamped = np.array(clamped, copy=False)
+    ref = reference_resample_2d(data, 16, 32, filt, clamp_range=(0.0, 10.0))
+    np.testing.assert_allclose(out_clamped, ref, atol=1e-5)
+    # Verify clamping actually did something.
+    assert out_clamped.min() >= 0.0 - 1e-6
+    assert out_clamped.max() <= 10.0 + 1e-6
+
+
+def test_resample_clamp_default_is_no_clamp():
+    """Default clamp should not alter results."""
+    data = np.random.rand(32, 32, 4).astype(np.float32)
+    bmp = Bitmap(data, srgb_gamma=False)
+
+    result_default = bmp.resample(16, 16, LanczosFilter())
+    result_explicit = bmp.resample(16, 16, LanczosFilter(), clamp=(-float("inf"), float("inf")))
+
+    np.testing.assert_allclose(
+        np.array(result_default, copy=False),
+        np.array(result_explicit, copy=False),
+        atol=1e-7,
+    )
+
+
+def test_resample_clamp_into_target():
+    """Clamp should work with the pre-allocated target overload."""
+    data = np.zeros((16, 16, 1), dtype=np.float32)
+    data[8, :, 0] = 10.0
+    bmp = Bitmap(data, pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+
+    target = make_float32_bitmap(16, 32, channels=1)
+    bmp.resample(target, LanczosFilter(), clamp=(0.0, 10.0))
+    out = np.array(target, copy=False)
+    assert out.min() >= 0.0 - 1e-6
+    assert out.max() <= 10.0 + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Single-axis resample tests
+# ---------------------------------------------------------------------------
+
+
+def test_resample_width_only():
+    """Width-only resample of solid color should preserve values."""
+    data = np.full((16, 32, 1), 0.6, dtype=np.float32)
+    bmp = Bitmap(data, pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    result = bmp.resample(64, 16)
+    assert result.width == 64
+    assert result.height == 16
+    out = np.array(result, copy=False)
+    np.testing.assert_allclose(out, 0.6, atol=1e-6)
+
+
+def test_resample_height_only():
+    """Height-only resample of solid color should preserve values."""
+    data = np.full((32, 16, 1), 0.4, dtype=np.float32)
+    bmp = Bitmap(data, pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    result = bmp.resample(16, 64)
+    assert result.width == 16
+    assert result.height == 64
+    out = np.array(result, copy=False)
+    np.testing.assert_allclose(out, 0.4, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Filter reconstruction quality tests
+# ---------------------------------------------------------------------------
+
+
+def test_box_filter_downscale():
+    """Box filter 2x downscale should match the numpy reference."""
+    rng = np.random.RandomState(10)
+    data = rng.rand(16, 16).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = BoxFilter()
+    result = bmp.resample(8, 8, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 8, 8, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+def test_tent_filter_upscale():
+    """Tent filter 2x upscale should match the numpy reference."""
+    rng = np.random.RandomState(11)
+    data = rng.rand(8, 8).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = TentFilter()
+    result = bmp.resample(16, 16, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 16, 16, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "filter_fn",
+    ALL_FILTERS,
+    ids=["box", "tent", "gaussian", "mitchell", "lanczos"],
+)
+@pytest.mark.parametrize("scale", [0.5, 1.5, 2.0, 3.0], ids=["0.5x", "1.5x", "2x", "3x"])
+def test_all_filters_preserve_dc(filter_fn: FilterType, scale: float):
+    """All normalized filters must preserve a constant (DC) signal at any scale."""
+    size = 32
+    value = 0.73
+    data = np.full((size, size, 1), value, dtype=np.float32)
+    bmp = Bitmap(data, pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    tw = max(1, int(size * scale))
+    th = max(1, int(size * scale))
+    result = bmp.resample(tw, th, filter_fn)
+    out = np.array(result, copy=False)
+    np.testing.assert_allclose(out, value, atol=1e-4)
+
+
+def test_lanczos_ringing_on_step_edge():
+    """Lanczos upscale of step function should match the numpy reference."""
+    data = np.zeros((32, 32), dtype=np.float32)
+    data[:, 16:] = 1.0
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+    result = bmp.resample(128, 32, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 128, 32, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+    # Verify ringing actually occurs (values outside [0, 1]).
+    assert ref.min() < -0.01, "Expected negative ringing from Lanczos on step edge"
+    assert ref.max() > 1.01, "Expected positive ringing from Lanczos on step edge"
+
+
+def test_mitchell_less_ringing_than_lanczos():
+    """Mitchell filter should produce less ringing than Lanczos on a step edge."""
+    data = np.zeros((1, 32, 1), dtype=np.float32)
+    data[0, 16:, 0] = 1.0
+    data = np.broadcast_to(data, (32, 32, 1)).copy()
+    bmp = Bitmap(data, pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+
+    lanczos_result = bmp.resample(128, 32, LanczosFilter())
+    mitchell_result = bmp.resample(128, 32, MitchellFilter())
+    out_l = np.array(lanczos_result, copy=False)
+    out_m = np.array(mitchell_result, copy=False)
+
+    # Mitchell(1/3,1/3) should have a tighter value range than Lanczos.
+    lanczos_range = out_l.max() - out_l.min()
+    mitchell_range = out_m.max() - out_m.min()
+    assert (
+        mitchell_range < lanczos_range
+    ), f"Mitchell range {mitchell_range:.4f} should be smaller than Lanczos range {lanczos_range:.4f}"
+
+
+def test_gaussian_point_spread():
+    """Gaussian filter on a single bright pixel should match the numpy reference."""
+    data = np.zeros((16, 16), dtype=np.float32)
+    data[8, 8] = 1.0
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = GaussianFilter()
+    result = bmp.resample(32, 32, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 32, 32, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+    # Verify the point spread actually happened.
+    assert ref.max() < 0.9, "Gaussian should diminish the peak of a point source"
+
+
+# ---------------------------------------------------------------------------
+# Boundary conditions on non-trivial images
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_repeat_tiled_pattern():
+    """Repeat BC should match the numpy reference on a periodic signal."""
+    x = np.linspace(0, 2 * np.pi, 16, endpoint=False, dtype=np.float32)
+    row = 0.5 + 0.5 * np.cos(x)
+    data = np.tile(row.reshape(1, 16), (16, 1))
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+    bc = (FilterBoundaryCondition.repeat, FilterBoundaryCondition.clamp)
+    result = bmp.resample(32, 16, filt, bc=bc)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 32, 16, filt, bc=bc)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+def test_boundary_mirror_gradient():
+    """Mirror BC should match the numpy reference on a gradient."""
+    gradient = np.linspace(0.0, 1.0, 16, dtype=np.float32).reshape(1, 16)
+    data = np.broadcast_to(gradient, (16, 16)).copy()
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+    bc = (FilterBoundaryCondition.mirror, FilterBoundaryCondition.mirror)
+    result = bmp.resample(16, 16, filt, bc=bc)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 16, 16, filt, bc=bc)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+def test_boundary_zero_vs_clamp_edge_pixels():
+    """Zero vs clamp BC should match their respective numpy references."""
+    rng = np.random.RandomState(20)
+    data = rng.rand(8, 8).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter(5)
+    for bc_val in [FilterBoundaryCondition.clamp, FilterBoundaryCondition.zero]:
+        bc = (bc_val, bc_val)
+        result = bmp.resample(12, 12, filt, bc=bc)
+        out = np.array(result, copy=False)
+        ref = reference_resample_2d(data, 12, 12, filt, bc=bc)
+        np.testing.assert_allclose(out, ref, atol=1e-5, err_msg=f"BC={bc_val}")
+
+
+# ---------------------------------------------------------------------------
+# Filter parameter variation tests
+# ---------------------------------------------------------------------------
+
+
+def test_tent_custom_radius():
+    """TentFilter with non-default radius should match the numpy reference."""
+    rng = np.random.RandomState(30)
+    data = rng.rand(16, 16).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = TentFilter(3.0)
+    result = bmp.resample(32, 32, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 32, 32, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+def test_gaussian_stddev_effect():
+    """GaussianFilter with non-default stddev should match the numpy reference."""
+    rng = np.random.RandomState(31)
+    data = rng.rand(16, 16).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    for stddev in [0.25, 0.5, 1.0]:
+        filt = GaussianFilter(stddev)
+        result = bmp.resample(32, 32, filt)
+        out = np.array(result, copy=False)
+        ref = reference_resample_2d(data, 32, 32, filt)
+        np.testing.assert_allclose(out, ref, atol=1e-5, err_msg=f"stddev={stddev}")
+
+
+def test_lanczos_lobes_variation():
+    """LanczosFilter with different lobe counts should match the numpy reference."""
+    rng = np.random.RandomState(32)
+    data = rng.rand(16, 16).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    for lobes in [1, 2, 3, 5]:
+        filt = LanczosFilter(lobes)
+        result = bmp.resample(32, 32, filt)
+        out = np.array(result, copy=False)
+        ref = reference_resample_2d(data, 32, 32, filt)
+        np.testing.assert_allclose(out, ref, atol=1e-5, err_msg=f"lobes={lobes}")
+
+
+def test_mitchell_catmull_rom_interpolation():
+    """MitchellFilter with non-default b/c should match the numpy reference."""
+    rng = np.random.RandomState(33)
+    data = rng.rand(16, 16).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    # Catmull-Rom: b=0, c=0.5
+    filt = MitchellFilter(0.0, 0.5)
+    result = bmp.resample(32, 16, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 32, 16, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Channel independence and precision tests
+# ---------------------------------------------------------------------------
+
+
+def test_channel_independence():
+    """Each channel should be resampled independently with no cross-channel leakage."""
+    size = 16
+    data = np.zeros((size, size, 3), dtype=np.float32)
+    # Channel 0: horizontal gradient
+    data[:, :, 0] = np.linspace(0, 1, size, dtype=np.float32).reshape(1, size)
+    # Channel 1: vertical gradient
+    data[:, :, 1] = np.linspace(0, 1, size, dtype=np.float32).reshape(size, 1)
+    # Channel 2: constant
+    data[:, :, 2] = 0.5
+
+    bmp_rgb = Bitmap(data, pixel_format=Bitmap.PixelFormat.rgb, srgb_gamma=False)
+    result_rgb = bmp_rgb.resample(32, 32, LanczosFilter())
+    out_rgb = np.array(result_rgb, copy=False)
+
+    # Resample each channel individually as single-channel bitmaps.
+    for ch in range(3):
+        ch_data = data[:, :, ch : ch + 1].copy()
+        bmp_ch = Bitmap(ch_data, pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+        result_ch = bmp_ch.resample(32, 32, LanczosFilter())
+        out_ch = np.array(result_ch, copy=False)
+        np.testing.assert_allclose(
+            out_rgb[:, :, ch],
+            out_ch,
+            atol=1e-6,
+            err_msg=f"Channel {ch} differs between RGB and single-channel resample",
+        )
+
+
+def test_float16_vs_float32_precision():
+    """float16 resample should be within expected precision of float32 resample."""
+    data32 = np.random.RandomState(42).rand(16, 16, 4).astype(np.float32)
+    data16 = data32.astype(np.float16)
+
+    bmp32 = Bitmap(data32, srgb_gamma=False)
+    bmp16 = Bitmap(data16)
+
+    result32 = bmp32.resample(32, 32, MitchellFilter())
+    result16 = bmp16.resample(32, 32, MitchellFilter())
+
+    out32 = np.array(result32, copy=False)
+    out16 = np.array(result16, copy=False).astype(np.float32)
+
+    # float16 has ~3 decimal digits of precision; after resampling the error
+    # accumulates somewhat, so we allow ~2e-2.
+    np.testing.assert_allclose(out16, out32, atol=2e-2, rtol=5e-2)
+
+
+# ---------------------------------------------------------------------------
+# Small / edge-case resolution tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_pixel_upscale():
+    """Upscaling a 1x1 image should produce uniform output equal to the pixel value."""
+    for filt in ALL_FILTERS:
+        data = np.full((1, 1, 1), 0.42, dtype=np.float32)
+        bmp = Bitmap(data, pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+        result = bmp.resample(16, 16, filt)
+        out = np.array(result, copy=False)
+        np.testing.assert_allclose(
+            out, 0.42, atol=1e-4, err_msg=f"Failed for {type(filt).__name__}"
+        )
+
+
+def test_single_row_resample():
+    """A 1×N image should match the numpy reference (horizontal-only path)."""
+    rng = np.random.RandomState(50)
+    data = rng.rand(1, 32).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+    result = bmp.resample(64, 1, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 64, 1, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+def test_single_column_resample():
+    """An N×1 image should match the numpy reference (vertical-only path)."""
+    rng = np.random.RandomState(51)
+    data = rng.rand(32, 1).astype(np.float32)
+    bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
+    filt = LanczosFilter()
+    result = bmp.resample(1, 64, filt)
+    out = np.array(result, copy=False)
+    ref = reference_resample_2d(data, 1, 64, filt)
+    np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/core/test_bitmap_resampling.py
+++ b/slangpy/tests/core/test_bitmap_resampling.py
@@ -44,6 +44,8 @@ def _bc_lookup(source: np.ndarray, pos: int, n: int, bc: FilterBoundaryCondition
     if bc == FilterBoundaryCondition.repeat:
         return float(source[pos % n])
     if bc == FilterBoundaryCondition.mirror:
+        if n == 1:
+            return float(source[0])
         pos = pos % (2 * n - 2)
         if pos >= n - 1:
             pos = 2 * n - 2 - pos
@@ -215,7 +217,7 @@ def test_resample_rejects_uint8():
     """resample should reject non-float types."""
     data = np.zeros((16, 16, 4), dtype=np.uint8)
     bmp = Bitmap(data)
-    with pytest.raises(Exception, match="float"):
+    with pytest.raises(RuntimeError, match="float"):
         bmp.resample(8, 8)
 
 
@@ -296,16 +298,16 @@ def test_boundary_asymmetric():
 def test_resample_zero_dimensions():
     """resample with zero target dimensions should raise."""
     bmp = make_float32_bitmap(16, 16)
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         bmp.resample(0, 10)
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         bmp.resample(10, 0)
 
 
 def test_resample_empty_bitmap():
     """resample on an empty bitmap should raise."""
     bmp = Bitmap(Bitmap.PixelFormat.rgba, Bitmap.ComponentType.float32, 0, 0)
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         bmp.resample(8, 8)
 
 
@@ -385,7 +387,7 @@ def test_resample_into_target_rejects_format_mismatch():
     """Resample into target with different format should raise an error."""
     src = make_float32_bitmap(32, 32, channels=4)
     target = make_float32_bitmap(16, 16, channels=3)
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         src.resample(target)
 
 

--- a/src/sgl/core/bitmap.cpp
+++ b/src/sgl/core/bitmap.cpp
@@ -2362,4 +2362,157 @@ void Bitmap::write_exr(Stream* stream, int quality) const
 
 #endif // SGL_HAS_OPENEXR
 
+// ---------------------------------------------------------------------------
+// Resample / mipmap generation
+// ---------------------------------------------------------------------------
+
+void Bitmap::resample(
+    Bitmap* target,
+    ReconstructionFilter filter,
+    std::pair<FilterBoundaryCondition, FilterBoundaryCondition> bc,
+    std::pair<float, float> clamp
+) const
+{
+    SGL_CHECK(target != nullptr, "Target bitmap must not be null.");
+    SGL_CHECK(target->width() > 0 && target->height() > 0, "Target dimensions must be positive.");
+    SGL_CHECK(!empty(), "Cannot resample an empty bitmap.");
+    SGL_CHECK(
+        m_component_type == ComponentType::float16 || m_component_type == ComponentType::float32,
+        "resample() only supports float16 and float32 component types. Convert the bitmap first."
+    );
+    SGL_CHECK(
+        m_pixel_format == target->pixel_format() && m_component_type == target->component_type()
+            && channel_count() == target->channel_count(),
+        "resample(): source and target bitmaps must have the same pixel format, component type and channel count."
+    );
+
+    uint32_t src_w = m_width;
+    uint32_t src_h = m_height;
+    uint32_t dst_width = target->width();
+    uint32_t dst_height = target->height();
+    uint32_t channels = channel_count();
+
+    // Short-circuit: if dimensions match, just copy.
+    if (src_w == dst_width && src_h == dst_height) {
+        std::memcpy(target->data(), data(), buffer_size());
+        return;
+    }
+
+    size_t total_src = static_cast<size_t>(src_w) * src_h * channels;
+    size_t total_dst = static_cast<size_t>(dst_width) * dst_height * channels;
+
+    // Work in float32 for precision, even for float16 inputs.
+    const bool is_float16 = m_component_type == ComponentType::float16;
+    std::vector<float> src_float_storage;
+    const float* src_ptr;
+    if (is_float16) {
+        src_float_storage.resize(total_src);
+        const math::float16_t* src = data_as<math::float16_t>();
+        for (size_t i = 0; i < total_src; ++i)
+            src_float_storage[i] = static_cast<float>(src[i]);
+        src_ptr = src_float_storage.data();
+    } else {
+        src_ptr = data_as<float>();
+    }
+
+    const bool needs_h = (src_w != dst_width);
+    const bool needs_v = (src_h != dst_height);
+
+    // Use std::visit to dispatch on the concrete filter type.
+    auto do_resample = [&](const auto& f)
+    {
+        const float* h_input = src_ptr;
+        std::vector<float> intermediate;
+
+        if (needs_h) {
+            // Horizontal pass: resample each row from src_w to dst_width.
+            Resampler<float> h_resampler(f, src_w, dst_width);
+            h_resampler.set_boundary_condition(bc.first);
+            // Apply clamp only if this is the final (or only) pass.
+            if (!needs_v)
+                h_resampler.set_clamp(clamp);
+
+            size_t total_inter = static_cast<size_t>(dst_width) * src_h * channels;
+            intermediate.resize(total_inter);
+            thread::parallel_for(
+                thread::blocked_range<uint32_t>(0, src_h, 100),
+                [&](const thread::blocked_range<uint32_t>& range)
+                {
+                    for (uint32_t y = *range.begin(); y < *range.end(); ++y) {
+                        h_resampler.resample(
+                            &h_input[static_cast<size_t>(y) * src_w * channels],
+                            1,
+                            &intermediate[static_cast<size_t>(y) * dst_width * channels],
+                            1,
+                            channels
+                        );
+                    }
+                }
+            );
+        }
+
+        // Source for vertical pass: intermediate if H was done, otherwise original.
+        const float* v_input = needs_h ? intermediate.data() : src_ptr;
+        uint32_t v_input_width = needs_h ? dst_width : src_w;
+
+        if (needs_v) {
+            // Vertical pass: resample each column from src_h to dst_height.
+            Resampler<float> v_resampler(f, src_h, dst_height);
+            v_resampler.set_boundary_condition(bc.second);
+            v_resampler.set_clamp(clamp);
+
+            std::vector<float> dst_float(total_dst);
+            thread::parallel_for(
+                thread::blocked_range<uint32_t>(0, dst_width, 100),
+                [&](const thread::blocked_range<uint32_t>& range)
+                {
+                    for (uint32_t x = *range.begin(); x < *range.end(); ++x) {
+                        v_resampler.resample(
+                            &v_input[static_cast<size_t>(x) * channels],
+                            v_input_width,
+                            &dst_float[static_cast<size_t>(x) * channels],
+                            dst_width,
+                            channels
+                        );
+                    }
+                }
+            );
+            return dst_float;
+        } else {
+            // Only horizontal pass was needed; intermediate is the final result.
+            return intermediate;
+        }
+    };
+
+    std::vector<float> dst_float = std::visit(do_resample, filter);
+
+    // Write output to target bitmap.
+    if (is_float16) {
+        math::float16_t* dst = target->data_as<math::float16_t>();
+        for (size_t i = 0; i < total_dst; ++i)
+            dst[i] = math::float16_t(dst_float[i]);
+    } else {
+        std::memcpy(target->data(), dst_float.data(), total_dst * sizeof(float));
+    }
+}
+
+ref<Bitmap> Bitmap::resample(
+    uint32_t dst_width,
+    uint32_t dst_height,
+    ReconstructionFilter filter,
+    std::pair<FilterBoundaryCondition, FilterBoundaryCondition> bc,
+    std::pair<float, float> clamp
+) const
+{
+    SGL_CHECK(dst_width > 0 && dst_height > 0, "Target dimensions must be positive.");
+
+    ref<Bitmap> result
+        = make_ref<Bitmap>(m_pixel_format, m_component_type, dst_width, dst_height, channel_count(), channel_names());
+    result->set_srgb_gamma(m_srgb_gamma);
+
+    resample(result.get(), filter, bc, clamp);
+
+    return result;
+}
+
 } // namespace sgl

--- a/src/sgl/core/bitmap.h
+++ b/src/sgl/core/bitmap.h
@@ -51,6 +51,7 @@ derivative works thereof, in binary and source code form.
 #include "sgl/core/enum.h"
 #include "sgl/core/stream.h"
 #include "sgl/core/data_struct.h"
+#include "sgl/core/rfilter.h"
 
 #include <filesystem>
 #include <future>
@@ -242,6 +243,44 @@ public:
     ref<Bitmap> convert(PixelFormat pixel_format, ComponentType component_type, bool srgb_gamma) const;
 
     void convert(Bitmap* target) const;
+
+    /**
+     * \brief Resample into a pre-allocated target bitmap using a separable filter.
+     * Source and target must have the same pixel format, component type and channel count.
+     * Only supports float16 and float32 component types.
+     * \param target Pre-allocated target bitmap.
+     * \param filter Reconstruction filter to use.
+     * \param bc Horizontal and vertical boundary conditions for out-of-bounds lookups.
+     * \param clamp Optional (min, max) range to clamp output values.
+     */
+    void resample(
+        Bitmap* target,
+        ReconstructionFilter filter = BoxFilter{},
+        std::pair<FilterBoundaryCondition, FilterBoundaryCondition> bc
+        = {FilterBoundaryCondition::clamp, FilterBoundaryCondition::clamp},
+        std::pair<float, float> clamp
+        = {-std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()}
+    ) const;
+
+    /**
+     * \brief Resample to arbitrary resolution using a separable filter.
+     * Only supports float16 and float32 component types.
+     * \param width Target width.
+     * \param height Target height.
+     * \param filter Reconstruction filter to use.
+     * \param bc Horizontal and vertical boundary conditions for out-of-bounds lookups.
+     * \param clamp Optional (min, max) range to clamp output values.
+     * \return Returns a new bitmap containing the resampled image.
+     */
+    ref<Bitmap> resample(
+        uint32_t width,
+        uint32_t height,
+        ReconstructionFilter filter = BoxFilter{},
+        std::pair<FilterBoundaryCondition, FilterBoundaryCondition> bc
+        = {FilterBoundaryCondition::clamp, FilterBoundaryCondition::clamp},
+        std::pair<float, float> clamp
+        = {-std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()}
+    ) const;
 
     /// Equality operator.
     bool operator==(const Bitmap& other) const;

--- a/src/sgl/core/maths.h
+++ b/src/sgl/core/maths.h
@@ -28,6 +28,14 @@ constexpr bool is_power_of_two(T a)
     return (a & (a - (T)1)) == 0;
 }
 
+/// Returns always positive modulo value.
+template<std::integral T>
+constexpr T modulo(T a, T b)
+{
+    T result = a - (a / b) * b;
+    return result < 0 ? result + b : result;
+}
+
 /// Divide a by b and round up to the next integer.
 template<std::integral T>
 constexpr T div_round_up(T a, T b)

--- a/src/sgl/core/rfilter.h
+++ b/src/sgl/core/rfilter.h
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "sgl/core/macros.h"
+#include "sgl/core/error.h"
+#include "sgl/core/enum.h"
+#include "sgl/core/maths.h"
+#include "sgl/math/constants.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <variant>
+
+namespace sgl {
+
+/// Filter boundary condition used for resampling images.
+enum class FilterBoundaryCondition {
+    /// Clamp to the outermost sample position.
+    clamp = 0,
+    /// Assume that the input repeats in a periodic fashion.
+    repeat,
+    /// Assume that the input is mirrored along the boundary.
+    mirror,
+    /// Assume that the input function is zero outside of the defined domain.
+    zero,
+    /// Assume that the input function is equal to one outside of the defined domain.
+    one,
+};
+SGL_ENUM_INFO(
+    FilterBoundaryCondition,
+    {
+        {FilterBoundaryCondition::clamp, "clamp"},
+        {FilterBoundaryCondition::repeat, "repeat"},
+        {FilterBoundaryCondition::mirror, "mirror"},
+        {FilterBoundaryCondition::zero, "zero"},
+        {FilterBoundaryCondition::one, "one"},
+    }
+);
+SGL_ENUM_REGISTER(FilterBoundaryCondition);
+
+struct BoxFilter {
+    BoxFilter() = default;
+    float radius() const { return 0.5f; }
+    float eval(float x) const { return (x >= -0.5f && x < 0.5f) ? 1.f : 0.f; }
+};
+
+struct TentFilter {
+    TentFilter(float radius = 1.f)
+        : m_radius(radius)
+        , m_inv_radius(1.f / radius)
+    {
+        SGL_CHECK(radius > 0.f, "TentFilter radius must be positive.");
+    }
+    float radius() const { return m_radius; }
+    float eval(float x) const { return std::max(0.f, 1.f - std::abs(x * m_inv_radius)); }
+
+private:
+    float m_radius;
+    float m_inv_radius;
+};
+
+struct GaussianFilter {
+    GaussianFilter(float stddev = 0.5f)
+        : m_stddev(stddev)
+    {
+        SGL_CHECK(stddev > 0.f, "GaussianFilter stddev must be positive.");
+        m_radius = 4.f * m_stddev;
+        m_alpha = -1.f / (2.f * m_stddev * m_stddev);
+        m_bias = std::exp(m_alpha * m_radius * m_radius);
+    }
+    float radius() const { return m_radius; }
+    float eval(float x) const
+    {
+        const float INV_LOG_TWO = 1.44269504088896340736f;
+        return std::max(0.f, std::exp2((INV_LOG_TWO * m_alpha) * x * x) - m_bias);
+    }
+
+private:
+    float m_stddev;
+    float m_radius;
+    float m_alpha;
+    float m_bias;
+};
+
+struct MitchellFilter {
+    MitchellFilter(float b = 1.f / 3.f, float c = 1.f / 3.f)
+        : m_b(b)
+        , m_c(c)
+    {
+    }
+    float radius() const { return 2.f; }
+    float eval(float x) const
+    {
+        x = std::abs(x);
+        float x2 = x * x;
+        float x3 = x2 * x;
+
+        float a3 = (12.f - 9.f * m_b - 6.f * m_c);
+        float a2 = (-18.f + 12.f * m_b + 6.f * m_c);
+        float a0 = (6.f - 2.f * m_b);
+        float b3 = (-m_b - 6.f * m_c);
+        float b2 = (6.f * m_b + 30.f * m_c);
+        float b1 = (-12.f * m_b - 48.f * m_c);
+        float b0 = (8.f * m_b + 24.f * m_c);
+
+        if (x < 1.f)
+            return (a3 * x3 + (a2 * x2 + a0)) / 6.f;
+        else if (x < 2.f)
+            return (b3 * x3 + (b2 * x2 + (b1 * x + b0))) / 6.f;
+        else
+            return 0.f;
+    }
+
+private:
+    float m_b;
+    float m_c;
+};
+
+struct LanczosFilter {
+    LanczosFilter(int lobes = 3)
+        : m_radius(static_cast<float>(lobes))
+    {
+        SGL_CHECK(lobes > 0, "LanczosFilter lobes must be positive.");
+    }
+    float radius() const { return m_radius; }
+    float eval(float x) const
+    {
+        x = std::abs(x);
+
+        float x1 = static_cast<float>(M_PI) * x;
+        float x2 = x1 / m_radius;
+        if (x < std::numeric_limits<float>::epsilon())
+            return 1.f;
+        else if (x > m_radius)
+            return 0.f;
+        else
+            return std::sin(x1) * std::sin(x2) / (x1 * x2);
+    }
+
+private:
+    float m_radius;
+};
+
+using ReconstructionFilter = std::variant<BoxFilter, TentFilter, GaussianFilter, MitchellFilter, LanczosFilter>;
+
+/// Utility class for efficiently resampling discrete datasets to different resolutions.
+/// \tparam Scalar The underlying floating point data type.
+template<typename Scalar_>
+struct Resampler {
+    using Scalar = Scalar_;
+    using Float = float;
+
+    /**
+     * \brief Create a new Resampler object that transforms between the specified resolutions.
+     *
+     * This constructor precomputes all information needed to efficiently perform the
+     * desired resampling operation. For that reason, it is most efficient if it can
+     * be used repeatedly (e.g. to resample the equal-sized rows of a bitmap)
+     *
+     * \param source_res Source resolution
+     * \param target_res Target resolution
+     */
+    template<typename Filter>
+    Resampler(const Filter& filter, uint32_t source_res, uint32_t target_res)
+        : m_source_res(source_res)
+        , m_target_res(target_res)
+    {
+        if (source_res == 0 || target_res == 0)
+            SGL_THROW("Resampler::Resampler(): source or target resolution == 0!");
+
+        Float filter_radius_orig = filter.radius();
+        Float filter_radius = filter_radius_orig;
+        Float scale = Float(1);
+        Float inv_scale = Float(1);
+
+        /* Low-pass filter: scale reconstruction filters when downsampling */
+        if (target_res < source_res) {
+            scale = (Float)source_res / (Float)target_res;
+            inv_scale = Float(1) / scale;
+            filter_radius *= scale;
+        }
+
+        m_taps = static_cast<uint32_t>(std::ceil(filter_radius * 2));
+        if (source_res == target_res && (m_taps % 2) != 1)
+            --m_taps;
+
+        if (filter_radius_orig < 1)
+            m_taps = std::min(m_taps, source_res);
+
+        if (source_res != target_res) { /* Resampling mode */
+            m_start = std::unique_ptr<int32_t[]>(new int32_t[target_res]);
+            m_weights = std::unique_ptr<Scalar[]>(new Scalar[m_taps * target_res]);
+            m_fast_start = 0;
+            m_fast_end = m_target_res;
+
+            for (uint32_t i = 0; i < target_res; i++) {
+                /* Compute the fractional coordinates of the new sample i
+                   in the original coordinates */
+                Float center = (i + Float(0.5)) / target_res * source_res;
+
+                /* Determine the index of the first original sample
+                   that might contribute */
+                m_start[i] = static_cast<int32_t>(std::floor(center - filter_radius + Float(0.5)));
+
+                /* Determine the size of center region, on which to run
+                   the fast non condition-aware code */
+                if (m_start[i] < 0)
+                    m_fast_start = std::max(m_fast_start, i + 1);
+                else if (m_start[i] + m_taps - 1 >= m_source_res)
+                    m_fast_end = std::min(m_fast_end, i);
+
+                double sum = 0.0;
+                for (uint32_t j = 0; j < m_taps; j++) {
+                    /* Compute the position where the filter should be evaluated */
+                    Float pos = m_start[i] + (int32_t)j + Float(0.5) - center;
+
+                    /* Perform the evaluation and record the weight */
+                    auto weight = filter.eval(pos * inv_scale);
+
+                    /* Handle the (numerical) edge case of the pixel center missing
+                       the filter support when upsampling using the box filter. */
+                    if constexpr (std::is_same_v<std::decay_t<Filter>, BoxFilter>) {
+                        if (target_res > source_res)
+                            weight = Float(1.0);
+                    }
+                    m_weights[i * m_taps + j] = static_cast<Scalar>(weight);
+                    sum += double(weight);
+                }
+
+                SGL_ASSERT(sum != 0);
+
+                /* Normalize the contribution of each sample */
+                double normalization = 1.0 / sum;
+                for (uint32_t j = 0; j < m_taps; j++) {
+                    Scalar& value = m_weights[i * m_taps + j];
+                    value = Scalar(double(value) * normalization);
+                }
+            }
+        } else { /* Filtering mode */
+            uint32_t half_taps = m_taps / 2;
+            m_weights = std::unique_ptr<Scalar[]>(new Scalar[m_taps]);
+
+            double sum = 0.0;
+            for (uint32_t i = 0; i < m_taps; i++) {
+                auto weight = filter.eval(Float(static_cast<int32_t>(i) - static_cast<int32_t>(half_taps)));
+                m_weights[i] = Scalar(weight);
+                sum += double(weight);
+            }
+
+            SGL_ASSERT(sum != 0);
+
+            double normalization = 1.0 / sum;
+            for (uint32_t i = 0; i < m_taps; i++) {
+                Scalar& value = m_weights[i];
+                value = Scalar(double(value) * normalization);
+            }
+            m_fast_start = std::min(half_taps, m_target_res - 1);
+            m_fast_end = static_cast<uint32_t>(
+                std::max(static_cast<int64_t>(m_target_res) - static_cast<int64_t>(half_taps), static_cast<int64_t>(0))
+            );
+        }
+
+        /* Avoid overlapping fast start/end intervals when the
+           target image is very small compared to the source image */
+        m_fast_start = std::min(m_fast_start, m_fast_end);
+    }
+
+    /// Return the reconstruction filter's source resolution
+    uint32_t source_resolution() const { return m_source_res; }
+
+    /// Return the reconstruction filter's target resolution
+    uint32_t target_resolution() const { return m_target_res; }
+
+    /// Return the number of taps used by the reconstruction filter
+    uint32_t taps() const { return m_taps; }
+
+    /// Boundary condition used when looking up samples outside of the defined input domain.
+    FilterBoundaryCondition boundary_condition() const { return m_bc; }
+
+    /// Set the boundary condition used when looking up samples outside of the defined input domain.
+    void set_boundary_condition(FilterBoundaryCondition bc) { m_bc = bc; }
+
+    /// Range to which resampled values will be clamped.
+    const std::pair<Scalar, Scalar>& clamp() { return m_clamp; }
+
+    /// Set the range to which resampled values will be clamped.
+    void set_clamp(const std::pair<Scalar, Scalar>& value) { m_clamp = value; }
+
+    /**
+     * \brief Resample a multi-channel array and clamp the results to a specified valid range
+     *
+     * \param source Source array of samples
+     * \param target Target array of samples
+     * \param source_stride Stride of samples in the source array. A value of '1' implies that they are densely packed.
+     * \param target_stride Stride of samples in the target array. A value of '1' implies that they are densely packed.
+     * \param channels Number of channels to be resampled
+     */
+    void resample(
+        const Scalar* source,
+        uint32_t source_stride,
+        Scalar* target,
+        uint32_t target_stride,
+        uint32_t channels
+    ) const
+    {
+        using ResampleFunctor = void (Resampler::*)(const Scalar*, uint32_t, Scalar*, uint32_t, uint32_t) const;
+
+        ResampleFunctor f;
+
+        if (m_clamp
+            != std::make_pair(-std::numeric_limits<Scalar>::infinity(), std::numeric_limits<Scalar>::infinity())) {
+            if (m_start)
+                f = &Resampler::resample_internal<true /* Clamp */, true /* Resample */>;
+            else
+                f = &Resampler::resample_internal<true /* Clamp */, false /* Resample */>;
+        } else {
+            if (m_start)
+                f = &Resampler::resample_internal<false /* Clamp */, true /* Resample */>;
+            else
+                f = &Resampler::resample_internal<false /* Clamp */, false /* Resample */>;
+        }
+
+        (this->*f)(source, source_stride, target, target_stride, channels);
+    }
+
+    std::string to_string() const
+    {
+        return fmt::format("Resampler[source_res={}, target_res={}]", m_source_res, m_target_res);
+    }
+
+private:
+    template<bool Clamp, bool Resample>
+    void resample_internal(
+        const Scalar* source,
+        uint32_t source_stride,
+        Scalar* target,
+        uint32_t target_stride,
+        uint32_t channels
+    ) const
+    {
+        const uint32_t taps = m_taps, half_taps = m_taps / 2;
+        const Scalar* weights = m_weights.get();
+        const int32_t* start = m_start.get();
+        const Scalar min = std::get<0>(m_clamp);
+        const Scalar max = std::get<1>(m_clamp);
+
+        target_stride = channels * (target_stride - 1);
+        source_stride *= channels;
+
+        // Resample the left border region, while accounting for the boundary conditions.
+        for (uint32_t i = 0; i < m_fast_start; ++i) {
+            const int32_t offset = Resample ? (*start++) : (static_cast<int32_t>(i) - half_taps);
+
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                Scalar result = 0;
+                for (uint32_t j = 0; j < taps; ++j)
+                    result += lookup(source, offset + static_cast<int32_t>(j), source_stride, ch) * weights[j];
+
+                *target++ = Clamp ? std::clamp(result, min, max) : result;
+            }
+
+            target += target_stride;
+
+            if (Resample)
+                weights += taps;
+        }
+
+        // Use a faster branch-free loop for resampling the main portion.
+        for (uint32_t i = m_fast_start; i < m_fast_end; ++i) {
+            const int32_t offset = Resample ? (*start++) : (static_cast<int32_t>(i) - half_taps);
+
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                Scalar result = 0;
+                for (uint32_t j = 0; j < taps; ++j)
+                    result += source[source_stride * (offset + static_cast<int32_t>(j)) + ch] * weights[j];
+
+                *target++ = Clamp ? std::clamp(result, min, max) : result;
+            }
+
+            target += target_stride;
+
+            if (Resample)
+                weights += taps;
+        }
+
+        // Resample the right border region, while accounting for the boundary conditions.
+        for (uint32_t i = m_fast_end; i < m_target_res; ++i) {
+            const int32_t offset = Resample ? (*start++) : (static_cast<int32_t>(i) - half_taps);
+
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                Scalar result = 0;
+                for (uint32_t j = 0; j < taps; ++j)
+                    result += lookup(source, offset + static_cast<int32_t>(j), source_stride, ch) * weights[j];
+
+                *target++ = Clamp ? std::clamp(result, min, max) : result;
+            }
+
+            target += target_stride;
+
+            if (Resample)
+                weights += taps;
+        }
+    }
+
+    Scalar lookup(const Scalar* source, int32_t pos, uint32_t stride, uint32_t ch) const
+    {
+        if (pos < 0 || pos >= static_cast<int32_t>(m_source_res)) [[unlikely]] {
+            switch (m_bc) {
+            case FilterBoundaryCondition::clamp:
+                pos = std::clamp(pos, 0, static_cast<int32_t>(m_source_res) - 1);
+                break;
+
+            case FilterBoundaryCondition::repeat:
+                pos = modulo(pos, static_cast<int32_t>(m_source_res));
+                break;
+
+            case FilterBoundaryCondition::mirror:
+                pos = modulo(pos, 2 * static_cast<int32_t>(m_source_res) - 2);
+                if (pos >= static_cast<int32_t>(m_source_res) - 1)
+                    pos = 2 * m_source_res - 2 - pos;
+                break;
+
+            case FilterBoundaryCondition::one:
+                return Scalar(1);
+
+            case FilterBoundaryCondition::zero:
+                return Scalar(0);
+            }
+        }
+
+        return source[pos * stride + ch];
+    }
+
+private:
+    std::unique_ptr<int32_t[]> m_start;
+    std::unique_ptr<Scalar[]> m_weights;
+    uint32_t m_source_res;
+    uint32_t m_target_res;
+    uint32_t m_fast_start;
+    uint32_t m_fast_end;
+    uint32_t m_taps;
+    FilterBoundaryCondition m_bc = FilterBoundaryCondition::clamp;
+    std::pair<Scalar, Scalar> m_clamp{
+        -std::numeric_limits<Scalar>::infinity(),
+        std::numeric_limits<Scalar>::infinity()
+    };
+};
+
+} // namespace sgl

--- a/src/sgl/core/rfilter.h
+++ b/src/sgl/core/rfilter.h
@@ -418,9 +418,13 @@ private:
                 break;
 
             case FilterBoundaryCondition::mirror:
-                pos = modulo(pos, 2 * static_cast<int32_t>(m_source_res) - 2);
-                if (pos >= static_cast<int32_t>(m_source_res) - 1)
-                    pos = 2 * m_source_res - 2 - pos;
+                if (m_source_res <= 1) {
+                    pos = 0;
+                } else {
+                    pos = modulo(pos, 2 * static_cast<int32_t>(m_source_res) - 2);
+                    if (pos >= static_cast<int32_t>(m_source_res) - 1)
+                        pos = 2 * m_source_res - 2 - pos;
+                }
                 break;
 
             case FilterBoundaryCondition::one:

--- a/src/slangpy_ext/CMakeLists.txt
+++ b/src/slangpy_ext/CMakeLists.txt
@@ -13,6 +13,7 @@ nanobind_add_module(slangpy_ext NB_STATIC LTO
     core/logger.cpp
     core/object.cpp
     core/platform.cpp
+    core/rfilter.cpp
     core/thread.cpp
     core/timer.cpp
     core/window.cpp

--- a/src/slangpy_ext/core/bitmap.cpp
+++ b/src/slangpy_ext/core/bitmap.cpp
@@ -221,6 +221,34 @@ SGL_PY_EXPORT(core_bitmap)
             D(Bitmap, convert)
         )
         .def(
+            "resample",
+            nb::overload_cast<
+                Bitmap*,
+                ReconstructionFilter,
+                std::pair<FilterBoundaryCondition, FilterBoundaryCondition>,
+                std::pair<float, float>>(&Bitmap::resample, nb::const_),
+            "target"_a,
+            "filter"_a = BoxFilter{},
+            "bc"_a = std::make_pair(FilterBoundaryCondition::clamp, FilterBoundaryCondition::clamp),
+            "clamp"_a = std::make_pair(-std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()),
+            D(Bitmap, resample)
+        )
+        .def(
+            "resample",
+            nb::overload_cast<
+                uint32_t,
+                uint32_t,
+                ReconstructionFilter,
+                std::pair<FilterBoundaryCondition, FilterBoundaryCondition>,
+                std::pair<float, float>>(&Bitmap::resample, nb::const_),
+            "width"_a,
+            "height"_a,
+            "filter"_a = BoxFilter{},
+            "bc"_a = std::make_pair(FilterBoundaryCondition::clamp, FilterBoundaryCondition::clamp),
+            "clamp"_a = std::make_pair(-std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()),
+            D_NA(Bitmap, resample)
+        )
+        .def(
             "write",
             nb::overload_cast<const std::filesystem::path&, Bitmap::FileFormat, int>(&Bitmap::write, nb::const_),
             "path"_a,

--- a/src/slangpy_ext/core/rfilter.cpp
+++ b/src/slangpy_ext/core/rfilter.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "nanobind.h"
+
+#include "sgl/core/rfilter.h"
+
+SGL_PY_EXPORT(core_rfilter)
+{
+    using namespace sgl;
+
+    nb::sgl_enum<FilterBoundaryCondition>(m, "FilterBoundaryCondition", D(FilterBoundaryCondition));
+
+    nb::class_<BoxFilter>(m, "BoxFilter", D(BoxFilter))
+        .def(nb::init<>())
+        .def("eval", &BoxFilter::eval, "x"_a)
+        .def_prop_ro("radius", &BoxFilter::radius);
+
+    nb::class_<TentFilter>(m, "TentFilter", D(TentFilter))
+        .def(nb::init<float>(), "radius"_a = 1.f)
+        .def("eval", &TentFilter::eval, "x"_a)
+        .def_prop_ro("radius", &TentFilter::radius);
+
+    nb::class_<GaussianFilter>(m, "GaussianFilter", D(GaussianFilter))
+        .def(nb::init<float>(), "stddev"_a = 0.5f)
+        .def("eval", &GaussianFilter::eval, "x"_a)
+        .def_prop_ro("radius", &GaussianFilter::radius);
+
+    nb::class_<MitchellFilter>(m, "MitchellFilter", D(MitchellFilter))
+        .def(nb::init<float, float>(), "b"_a = 1.f / 3.f, "c"_a = 1.f / 3.f)
+        .def("eval", &MitchellFilter::eval, "x"_a)
+        .def_prop_ro("radius", &MitchellFilter::radius);
+
+    nb::class_<LanczosFilter>(m, "LanczosFilter", D(LanczosFilter))
+        .def(nb::init<int>(), "lobes"_a = 3)
+        .def("eval", &LanczosFilter::eval, "x"_a)
+        .def_prop_ro("radius", &LanczosFilter::radius);
+}

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -721,6 +721,47 @@ static const char *__doc_sgl_Bitmap_read_tga = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_rebuild_pixel_struct = R"doc()doc";
 
+static const char *__doc_sgl_Bitmap_resample =
+R"doc(Resample into a pre-allocated target bitmap using a separable filter.
+Source and target must have the same pixel format, component type and
+channel count. Only supports float16 and float32 component types.
+
+Parameter ``target``:
+    Pre-allocated target bitmap.
+
+Parameter ``filter``:
+    Reconstruction filter to use.
+
+Parameter ``bc``:
+    Horizontal and vertical boundary conditions for out-of-bounds
+    lookups.
+
+Parameter ``clamp``:
+    Optional (min, max) range to clamp output values.)doc";
+
+static const char *__doc_sgl_Bitmap_resample_2 =
+R"doc(Resample to arbitrary resolution using a separable filter. Only
+supports float16 and float32 component types.
+
+Parameter ``width``:
+    Target width.
+
+Parameter ``height``:
+    Target height.
+
+Parameter ``filter``:
+    Reconstruction filter to use.
+
+Parameter ``bc``:
+    Horizontal and vertical boundary conditions for out-of-bounds
+    lookups.
+
+Parameter ``clamp``:
+    Optional (min, max) range to clamp output values.
+
+Returns:
+    Returns a new bitmap containing the resampled image.)doc";
+
 static const char *__doc_sgl_Bitmap_set_srgb_gamma =
 R"doc(Set the sRGB gamma flag. Note that this does not convert the pixel
 values, it only sets the flag and adjusts the pixel struct.)doc";
@@ -1011,6 +1052,14 @@ Returns:
 static const char *__doc_sgl_BlockAllocator_reset =
 R"doc(Reset the allocator, rebuilding the free list from all pages (NOT
 thread safe).)doc";
+
+static const char *__doc_sgl_BoxFilter = R"doc()doc";
+
+static const char *__doc_sgl_BoxFilter_BoxFilter = R"doc()doc";
+
+static const char *__doc_sgl_BoxFilter_eval = R"doc()doc";
+
+static const char *__doc_sgl_BoxFilter_radius = R"doc()doc";
 
 static const char *__doc_sgl_Buffer = R"doc()doc";
 
@@ -2536,6 +2585,8 @@ static const char *__doc_sgl_DescriptorHandleType_undefined = R"doc()doc";
 
 static const char *__doc_sgl_DescriptorHandle_DescriptorHandle = R"doc()doc";
 
+static const char *__doc_sgl_DescriptorHandle_DescriptorHandle_2 = R"doc()doc";
+
 static const char *__doc_sgl_DescriptorHandle_is_valid = R"doc()doc";
 
 static const char *__doc_sgl_DescriptorHandle_operator_bool = R"doc()doc";
@@ -3766,6 +3817,22 @@ static const char *__doc_sgl_FillMode_solid = R"doc()doc";
 
 static const char *__doc_sgl_FillMode_wireframe = R"doc()doc";
 
+static const char *__doc_sgl_FilterBoundaryCondition = R"doc(Filter boundary condition used for resampling images.)doc";
+
+static const char *__doc_sgl_FilterBoundaryCondition_clamp = R"doc(Clamp to the outermost sample position.)doc";
+
+static const char *__doc_sgl_FilterBoundaryCondition_info = R"doc()doc";
+
+static const char *__doc_sgl_FilterBoundaryCondition_mirror = R"doc(Assume that the input is mirrored along the boundary.)doc";
+
+static const char *__doc_sgl_FilterBoundaryCondition_one =
+R"doc(Assume that the input function is equal to one outside of the defined
+domain.)doc";
+
+static const char *__doc_sgl_FilterBoundaryCondition_repeat = R"doc(Assume that the input repeats in a periodic fashion.)doc";
+
+static const char *__doc_sgl_FilterBoundaryCondition_zero = R"doc(Assume that the input function is zero outside of the defined domain.)doc";
+
 static const char *__doc_sgl_Format = R"doc(Resource formats.)doc";
 
 static const char *__doc_sgl_FormatChannels = R"doc()doc";
@@ -4189,6 +4256,22 @@ static const char *__doc_sgl_GamepadState_right_x = R"doc(X-axis of the right an
 static const char *__doc_sgl_GamepadState_right_y = R"doc(Y-axis of the right analog stick.)doc";
 
 static const char *__doc_sgl_GamepadState_to_string = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter_GaussianFilter = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter_eval = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter_m_alpha = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter_m_bias = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter_m_radius = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter_m_stddev = R"doc()doc";
+
+static const char *__doc_sgl_GaussianFilter_radius = R"doc()doc";
 
 static const char *__doc_sgl_HeapReport = R"doc(Report information for a memory heap.)doc";
 
@@ -4842,6 +4925,16 @@ static const char *__doc_sgl_LMDBException_error = R"doc()doc";
 
 static const char *__doc_sgl_LMDBException_m_error = R"doc()doc";
 
+static const char *__doc_sgl_LanczosFilter = R"doc()doc";
+
+static const char *__doc_sgl_LanczosFilter_LanczosFilter = R"doc()doc";
+
+static const char *__doc_sgl_LanczosFilter_eval = R"doc()doc";
+
+static const char *__doc_sgl_LanczosFilter_m_radius = R"doc()doc";
+
+static const char *__doc_sgl_LanczosFilter_radius = R"doc()doc";
+
 static const char *__doc_sgl_LinearSweptSpheresEndCapsMode = R"doc()doc";
 
 static const char *__doc_sgl_LinearSweptSpheresEndCapsMode_chained = R"doc()doc";
@@ -5226,6 +5319,18 @@ static const char *__doc_sgl_MemoryType_info = R"doc()doc";
 static const char *__doc_sgl_MemoryType_read_back = R"doc()doc";
 
 static const char *__doc_sgl_MemoryType_upload = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter_MitchellFilter = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter_eval = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter_m_b = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter_m_c = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter_radius = R"doc()doc";
 
 static const char *__doc_sgl_ModifierID = R"doc()doc";
 
@@ -6423,6 +6528,91 @@ static const char *__doc_sgl_RenderTargetWriteMask_none = R"doc()doc";
 
 static const char *__doc_sgl_RenderTargetWriteMask_red = R"doc()doc";
 
+static const char *__doc_sgl_Resampler =
+R"doc(Utility class for efficiently resampling discrete datasets to
+different resolutions.
+
+Template parameter ``Scalar``:
+    The underlying floating point data type.)doc";
+
+static const char *__doc_sgl_Resampler_Resampler =
+R"doc(Create a new Resampler object that transforms between the specified
+resolutions.
+
+This constructor precomputes all information needed to efficiently
+perform the desired resampling operation. For that reason, it is most
+efficient if it can be used repeatedly (e.g. to resample the equal-
+sized rows of a bitmap)
+
+Parameter ``source_res``:
+    Source resolution
+
+Parameter ``target_res``:
+    Target resolution)doc";
+
+static const char *__doc_sgl_Resampler_boundary_condition =
+R"doc(Boundary condition used when looking up samples outside of the defined
+input domain.)doc";
+
+static const char *__doc_sgl_Resampler_clamp = R"doc(Range to which resampled values will be clamped.)doc";
+
+static const char *__doc_sgl_Resampler_lookup = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_bc = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_clamp = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_fast_end = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_fast_start = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_source_res = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_start = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_taps = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_target_res = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_m_weights = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_resample =
+R"doc(Resample a multi-channel array and clamp the results to a specified
+valid range
+
+Parameter ``source``:
+    Source array of samples
+
+Parameter ``target``:
+    Target array of samples
+
+Parameter ``source_stride``:
+    Stride of samples in the source array. A value of '1' implies that
+    they are densely packed.
+
+Parameter ``target_stride``:
+    Stride of samples in the target array. A value of '1' implies that
+    they are densely packed.
+
+Parameter ``channels``:
+    Number of channels to be resampled)doc";
+
+static const char *__doc_sgl_Resampler_resample_internal = R"doc()doc";
+
+static const char *__doc_sgl_Resampler_set_boundary_condition =
+R"doc(Set the boundary condition used when looking up samples outside of the
+defined input domain.)doc";
+
+static const char *__doc_sgl_Resampler_set_clamp = R"doc(Set the range to which resampled values will be clamped.)doc";
+
+static const char *__doc_sgl_Resampler_source_resolution = R"doc(Return the reconstruction filter's source resolution)doc";
+
+static const char *__doc_sgl_Resampler_taps = R"doc(Return the number of taps used by the reconstruction filter)doc";
+
+static const char *__doc_sgl_Resampler_target_resolution = R"doc(Return the reconstruction filter's target resolution)doc";
+
+static const char *__doc_sgl_Resampler_to_string = R"doc()doc";
+
 static const char *__doc_sgl_Resolver = R"doc()doc";
 
 static const char *__doc_sgl_Resolver_resolve = R"doc()doc";
@@ -7059,11 +7249,11 @@ static const char *__doc_sgl_SlangDebugInfoLevel = R"doc(Slang debug info levels
 
 static const char *__doc_sgl_SlangDebugInfoLevel_info = R"doc()doc";
 
-static const char *__doc_sgl_SlangDebugInfoLevel_maximal = R"doc(Emit as much debug infromation as possible for each target.)doc";
+static const char *__doc_sgl_SlangDebugInfoLevel_maximal = R"doc(Emit as much debug information as possible for each target.)doc";
 
 static const char *__doc_sgl_SlangDebugInfoLevel_minimal =
 R"doc(Emit as little debug information as possible, while still supporting
-stack trackes.)doc";
+stack traces.)doc";
 
 static const char *__doc_sgl_SlangDebugInfoLevel_none = R"doc(No debug information.)doc";
 
@@ -7095,9 +7285,16 @@ static const char *__doc_sgl_SlangEntryPointDesc_specialization_args = R"doc(Spe
 
 static const char *__doc_sgl_SlangEntryPointDesc_type_conformances = R"doc()doc";
 
+static const char *__doc_sgl_SlangEntryPointDesc_type_lookup_module =
+R"doc(Module to use for type lookups (type conformances, specialization
+args). When entry point is from a composed module, this contains the
+composed module.)doc";
+
 static const char *__doc_sgl_SlangEntryPoint_SlangEntryPoint = R"doc()doc";
 
 static const char *__doc_sgl_SlangEntryPoint_class_name = R"doc()doc";
+
+static const char *__doc_sgl_SlangEntryPoint_create_build_context = R"doc(Helper to create a build context for entry point operations.)doc";
 
 static const char *__doc_sgl_SlangEntryPoint_desc = R"doc()doc";
 
@@ -7198,6 +7395,8 @@ static const char *__doc_sgl_SlangModuleData_slang_component_type = R"doc(The un
 static const char *__doc_sgl_SlangModuleData_slang_module = R"doc(The underlying slang module (null for composed modules).)doc";
 
 static const char *__doc_sgl_SlangModuleDesc = R"doc()doc";
+
+static const char *__doc_sgl_SlangModuleDesc_2 = R"doc()doc";
 
 static const char *__doc_sgl_SlangModuleDesc_is_composed = R"doc(Returns true if this is a composed module (has source modules).)doc";
 
@@ -7371,6 +7570,8 @@ static const char *__doc_sgl_SlangSession_compose_modules =
 R"doc(Compose multiple modules into a single composed module. The composed
 module provides a unified layout and entry point access across all
 source modules.)doc";
+
+static const char *__doc_sgl_SlangSession_create_module = R"doc(Helper to create a module, updating cache afterwards.)doc";
 
 static const char *__doc_sgl_SlangSession_create_session = R"doc()doc";
 
@@ -7630,6 +7831,18 @@ static const char *__doc_sgl_Surface_m_rhi_surface = R"doc()doc";
 static const char *__doc_sgl_Surface_present = R"doc(Present the previously acquire image.)doc";
 
 static const char *__doc_sgl_Surface_unconfigure = R"doc(Unconfigure the surface.)doc";
+
+static const char *__doc_sgl_TentFilter = R"doc()doc";
+
+static const char *__doc_sgl_TentFilter_TentFilter = R"doc()doc";
+
+static const char *__doc_sgl_TentFilter_eval = R"doc()doc";
+
+static const char *__doc_sgl_TentFilter_m_inv_radius = R"doc()doc";
+
+static const char *__doc_sgl_TentFilter_m_radius = R"doc()doc";
+
+static const char *__doc_sgl_TentFilter_radius = R"doc()doc";
 
 static const char *__doc_sgl_Texture = R"doc()doc";
 
@@ -8969,7 +9182,9 @@ static const char *__doc_sgl_detail_from_slang_9 = R"doc()doc";
 
 static const char *__doc_sgl_detail_get_slang_rhi_message_count = R"doc()doc";
 
-static const char *__doc_sgl_detail_invalidate_reflection_data_for_device = R"doc()doc";
+static const char *__doc_sgl_detail_invalidate_reflection_data =
+R"doc(Invalidate reflection data. If device is set, only reflection data
+owned by that device is invalidated.)doc";
 
 static const char *__doc_sgl_detail_on_slang_wrapper_destroyed = R"doc()doc";
 
@@ -9142,6 +9357,8 @@ static const char *__doc_sgl_find_enum_info_adl_73 = R"doc()doc";
 static const char *__doc_sgl_find_enum_info_adl_74 = R"doc()doc";
 
 static const char *__doc_sgl_find_enum_info_adl_75 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_76 = R"doc()doc";
 
 static const char *__doc_sgl_flags_to_string_list = R"doc(Convert an flags enum value to a list of strings.)doc";
 
@@ -10308,6 +10525,8 @@ Template parameter ``N``:
 
 static const char *__doc_sgl_math_yaw = R"doc(Returns yaw value of euler angles expressed in radians.)doc";
 
+static const char *__doc_sgl_modulo = R"doc(Returns always positive modulo value.)doc";
+
 static const char *__doc_sgl_narrow_cast = R"doc()doc";
 
 static const char *__doc_sgl_object_init_py =
@@ -10903,6 +11122,8 @@ static const char *__doc_sgl_slangpy_CallContext_call_shape = R"doc()doc";
 static const char *__doc_sgl_slangpy_CallContext_cuda_stream = R"doc()doc";
 
 static const char *__doc_sgl_slangpy_CallContext_device = R"doc()doc";
+
+static const char *__doc_sgl_slangpy_CallContext_init = R"doc(Initialize call shape and CUDA stream (called each dispatch).)doc";
 
 static const char *__doc_sgl_slangpy_CallContext_m_call_mode = R"doc()doc";
 

--- a/src/slangpy_ext/slangpy_ext.cpp
+++ b/src/slangpy_ext/slangpy_ext.cpp
@@ -22,6 +22,7 @@ SGL_PY_DECLARE(core_input);
 SGL_PY_DECLARE(core_logger);
 SGL_PY_DECLARE(core_object);
 SGL_PY_DECLARE(core_platform);
+SGL_PY_DECLARE(core_rfilter);
 SGL_PY_DECLARE(core_thread);
 SGL_PY_DECLARE(core_timer);
 SGL_PY_DECLARE(core_window);
@@ -116,6 +117,7 @@ NB_MODULE(slangpy_ext, m_)
     SGL_PY_IMPORT(core_timer);
     SGL_PY_IMPORT(core_window);
     SGL_PY_IMPORT(core_data_struct);
+    SGL_PY_IMPORT(core_rfilter);
     SGL_PY_IMPORT(core_bitmap);
     SGL_PY_IMPORT(core_crypto);
     SGL_PY_IMPORT(core_data_type);


### PR DESCRIPTION
- Add `Bitmap::resample` function for resampling/resizing an image
- Added a few different reconstruction filters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image resampling: Box, Tent, Gaussian, Mitchell, Lanczos filters; per-axis boundary modes (clamp, repeat, mirror, zero, one); optional output clamping; preserves pixel format, channels and sRGB; supports float16/float32 and in-place or allocate-new targets.

* **Python**
  * Resampling APIs and filter types exposed to Python via new bindings/module.

* **Tests**
  * Comprehensive NumPy-backed resampling test suite.

* **Utilities**
  * Added a modulo utility ensuring non-negative results.

* **Documentation**
  * User docs for resampling APIs, filters and modulo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->