### PR TITLE
Added <=> for quat, matrix, and vector

### DIFF
--- a/slangpy/tests/math/test_matrix.py
+++ b/slangpy/tests/math/test_matrix.py
@@ -47,6 +47,31 @@ def test_hashing():
     assert len({spy.float4x4.identity(): 0, spy.float4x4.zeros(): 0}) == 2
 
 
+def test_equality_comparison():
+    assert spy.float2x2([1, 2, 3, 4]) == spy.float2x2([1, 2, 3, 4])
+    assert not spy.float2x2([1, 2, 3, 4]) == spy.float2x2([1, 2, 3, 5])
+    assert not spy.float2x2([1, 2, 3, 4]) != spy.float2x2([1, 2, 3, 4])
+    assert spy.float2x2([1, 2, 3, 4]) != spy.float2x2([1, 2, 4, 4])
+
+
+def test_lexicographic_comparison():
+    assert spy.float2x2([1, 2, 3, 4]) < spy.float2x2([1, 2, 3, 5])
+    assert spy.float2x2([1, 2, 3, 4]) < spy.float2x2([1, 3, 0, 0])
+    assert not spy.float2x2([1, 2, 3, 4]) < spy.float2x2([1, 2, 3, 4])
+    assert not spy.float2x2([1, 3, 0, 0]) < spy.float2x2([1, 2, 9, 9])
+
+    assert spy.float2x2([1, 2, 3, 5]) > spy.float2x2([1, 2, 3, 4])
+    assert not spy.float2x2([1, 2, 3, 4]) > spy.float2x2([1, 2, 3, 4])
+
+    assert spy.float2x2([1, 2, 3, 4]) <= spy.float2x2([1, 2, 3, 4])
+    assert spy.float2x2([1, 2, 3, 4]) <= spy.float2x2([1, 2, 3, 5])
+    assert not spy.float2x2([1, 2, 3, 5]) <= spy.float2x2([1, 2, 3, 4])
+
+    assert spy.float2x2([1, 2, 3, 4]) >= spy.float2x2([1, 2, 3, 4])
+    assert spy.float2x2([1, 2, 3, 5]) >= spy.float2x2([1, 2, 3, 4])
+    assert not spy.float2x2([1, 2, 3, 4]) >= spy.float2x2([1, 2, 3, 5])
+
+
 class TestMatrixMulFunction:
     """Test spy.math.mul() function for all valid matrix-matrix combinations."""
 

--- a/slangpy/tests/math/test_quaternion.py
+++ b/slangpy/tests/math/test_quaternion.py
@@ -25,5 +25,30 @@ def test_hashing():
     assert len({spy.quatf(1, 0, 0, 0): 0, spy.quatf(0, 1, 0, 0): 0}) == 2
 
 
+def test_equality_comparison():
+    assert spy.quatf(1, 2, 3, 4) == spy.quatf(1, 2, 3, 4)
+    assert not spy.quatf(1, 2, 3, 4) == spy.quatf(1, 2, 3, 5)
+    assert not spy.quatf(1, 2, 3, 4) != spy.quatf(1, 2, 3, 4)
+    assert spy.quatf(1, 2, 3, 4) != spy.quatf(1, 2, 4, 4)
+
+
+def test_lexicographic_comparison():
+    assert spy.quatf(1, 2, 3, 4) < spy.quatf(1, 2, 3, 5)
+    assert spy.quatf(1, 2, 3, 4) < spy.quatf(1, 3, 0, 0)
+    assert not spy.quatf(1, 2, 3, 4) < spy.quatf(1, 2, 3, 4)
+    assert not spy.quatf(1, 3, 0, 0) < spy.quatf(1, 2, 9, 9)
+
+    assert spy.quatf(1, 2, 3, 5) > spy.quatf(1, 2, 3, 4)
+    assert not spy.quatf(1, 2, 3, 4) > spy.quatf(1, 2, 3, 4)
+
+    assert spy.quatf(1, 2, 3, 4) <= spy.quatf(1, 2, 3, 4)
+    assert spy.quatf(1, 2, 3, 4) <= spy.quatf(1, 2, 3, 5)
+    assert not spy.quatf(1, 2, 3, 5) <= spy.quatf(1, 2, 3, 4)
+
+    assert spy.quatf(1, 2, 3, 4) >= spy.quatf(1, 2, 3, 4)
+    assert spy.quatf(1, 2, 3, 5) >= spy.quatf(1, 2, 3, 4)
+    assert not spy.quatf(1, 2, 3, 4) >= spy.quatf(1, 2, 3, 5)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/src/sgl/math/matrix_math.h
+++ b/src/sgl/math/matrix_math.h
@@ -806,17 +806,6 @@ template<typename T, int R, int C>
     return ::fmt::format("{}", m);
 }
 
-template<int R, int C, typename T>
-bool lex_lt(const matrix<T, R, C>& lhs, const matrix<T, R, C>& rhs)
-{
-    for (int r = 0; r < R; ++r) {
-        for (int c = 0; c < C; ++c) {
-            if (lhs[r][c] != rhs[r][c])
-                return lhs[r][c] < rhs[r][c];
-        }
-    }
-    return false;
-}
 } // namespace sgl::math
 
 template<typename T, int R, int C>

--- a/src/sgl/math/matrix_types.h
+++ b/src/sgl/math/matrix_types.h
@@ -7,6 +7,7 @@
 #include "sgl/core/error.h"
 
 #include <array>
+#include <compare>
 #include <initializer_list>
 #include <limits>
 
@@ -151,9 +152,6 @@ public:
             m_rows[r][col] = v[r];
     }
 
-    bool operator==(const matrix& rhs) const { return std::memcmp(this, &rhs, sizeof(*this)) == 0; }
-    bool operator!=(const matrix& rhs) const { return !(*this == rhs); }
-
 private:
     enum class Form {
         Undefined,
@@ -183,6 +181,31 @@ private:
 
     row_type m_rows[RowCount];
 };
+
+/// Equality operator.
+template<typename T, int RowCount, int ColCount>
+[[nodiscard]] bool operator==(const matrix<T, RowCount, ColCount>& lhs, const matrix<T, RowCount, ColCount>& rhs)
+{
+    for (int r = 0; r < RowCount; ++r)
+        for (int c = 0; c < ColCount; ++c)
+            if (lhs[r][c] != rhs[r][c])
+                return false;
+    return true;
+}
+
+/// Lexicographic three-way operator.
+template<typename T, int RowCount, int ColCount>
+[[nodiscard]] auto operator<=>(const matrix<T, RowCount, ColCount>& lhs, const matrix<T, RowCount, ColCount>& rhs)
+{
+    for (int r = 0; r < RowCount; ++r) {
+        for (int c = 0; c < ColCount; ++c) {
+            auto cmp = lhs[r][c] <=> rhs[r][c];
+            if (cmp != 0)
+                return cmp;
+        }
+    }
+    return lhs[0][0] <=> rhs[0][0];
+}
 
 using float2x2 = matrix<float, 2, 2>;
 using float2x3 = matrix<float, 2, 3>;

--- a/src/sgl/math/matrix_types.h
+++ b/src/sgl/math/matrix_types.h
@@ -197,14 +197,15 @@ template<typename T, int RowCount, int ColCount>
 template<typename T, int RowCount, int ColCount>
 [[nodiscard]] auto operator<=>(const matrix<T, RowCount, ColCount>& lhs, const matrix<T, RowCount, ColCount>& rhs)
 {
-    for (int r = 0; r < RowCount; ++r) {
-        for (int c = 0; c < ColCount; ++c) {
-            auto cmp = lhs[r][c] <=> rhs[r][c];
-            if (cmp != 0)
-                return cmp;
-        }
+    constexpr int element_count = RowCount * ColCount;
+    const T* lhs_data = lhs.data();
+    const T* rhs_data = rhs.data();
+    for (int i = 0; i < element_count - 1; ++i) {
+        auto cmp = lhs_data[i] <=> rhs_data[i];
+        if (cmp != 0)
+            return cmp;
     }
-    return lhs[0][0] <=> rhs[0][0];
+    return lhs_data[element_count - 1] <=> rhs_data[element_count - 1];
 }
 
 using float2x2 = matrix<float, 2, 2>;

--- a/src/sgl/math/quaternion_types.h
+++ b/src/sgl/math/quaternion_types.h
@@ -89,15 +89,15 @@ template<typename T>
 template<typename T>
 [[nodiscard]] constexpr auto operator<=>(const quat<T>& lhs, const quat<T>& rhs)
 {
-    auto x_cmp = lhs.x <=> rhs.x;
-    if (x_cmp != 0)
-        return x_cmp;
-    auto y_cmp = lhs.y <=> rhs.y;
-    if (y_cmp != 0)
-        return y_cmp;
-    auto z_cmp = lhs.z <=> rhs.z;
-    if (z_cmp != 0)
-        return z_cmp;
+    auto cmp = lhs.x <=> rhs.x;
+    if (cmp != 0)
+        return cmp;
+    cmp = lhs.y <=> rhs.y;
+    if (cmp != 0)
+        return cmp;
+    cmp = lhs.z <=> rhs.z;
+    if (cmp != 0)
+        return cmp;
     return lhs.w <=> rhs.w;
 }
 

--- a/src/sgl/math/quaternion_types.h
+++ b/src/sgl/math/quaternion_types.h
@@ -6,6 +6,7 @@
 #include "sgl/math/vector_types.h"
 
 #include <array>
+#include <compare>
 #include <type_traits>
 
 namespace sgl::math {
@@ -84,11 +85,20 @@ template<typename T>
     return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z && lhs.w == rhs.w;
 }
 
-/// Inequality operator.
+/// Lexicographic three-way operator.
 template<typename T>
-[[nodiscard]] constexpr bool operator!=(const quat<T>& lhs, const quat<T>& rhs)
+[[nodiscard]] constexpr auto operator<=>(const quat<T>& lhs, const quat<T>& rhs)
 {
-    return !(lhs == rhs);
+    auto x_cmp = lhs.x <=> rhs.x;
+    if (x_cmp != 0)
+        return x_cmp;
+    auto y_cmp = lhs.y <=> rhs.y;
+    if (y_cmp != 0)
+        return y_cmp;
+    auto z_cmp = lhs.z <=> rhs.z;
+    if (z_cmp != 0)
+        return z_cmp;
+    return lhs.w <=> rhs.w;
 }
 
 using quatf = quat<float>;

--- a/src/sgl/math/vector_types.h
+++ b/src/sgl/math/vector_types.h
@@ -5,6 +5,8 @@
 #include "sgl/math/scalar_types.h"
 #include "sgl/core/error.h"
 
+#include <compare>
+
 namespace sgl::math {
 
 // ----------------------------------------------------------------------------
@@ -300,45 +302,16 @@ template<typename T, int N>
     return true;
 }
 
-/// Inequality operator.
-template<typename T, int N>
-[[nodiscard]] constexpr bool operator!=(const vector<T, N>& lhs, const vector<T, N>& rhs)
-{
-    return !(lhs == rhs);
-}
-
-/// Lexicographic less-than operator.
+/// Lexicographic three-way operator.
 template<arithmetic T, int N>
-[[nodiscard]] constexpr bool operator<(const vector<T, N>& lhs, const vector<T, N>& rhs)
+[[nodiscard]] constexpr auto operator<=>(const vector<T, N>& lhs, const vector<T, N>& rhs)
 {
     for (int i = 0; i < N; ++i) {
-        if (lhs[i] < rhs[i])
-            return true;
-        if (rhs[i] < lhs[i])
-            return false;
+        auto cmp = lhs[i] <=> rhs[i];
+        if (cmp != 0)
+            return cmp;
     }
-    return false;
-}
-
-/// Lexicographic greater-than operator.
-template<arithmetic T, int N>
-[[nodiscard]] constexpr bool operator>(const vector<T, N>& lhs, const vector<T, N>& rhs)
-{
-    return rhs < lhs;
-}
-
-/// Lexicographic less-or-equal operator.
-template<arithmetic T, int N>
-[[nodiscard]] constexpr bool operator<=(const vector<T, N>& lhs, const vector<T, N>& rhs)
-{
-    return !(rhs < lhs);
-}
-
-/// Lexicographic greater-or-equal operator.
-template<arithmetic T, int N>
-[[nodiscard]] constexpr bool operator>=(const vector<T, N>& lhs, const vector<T, N>& rhs)
-{
-    return !(lhs < rhs);
+    return lhs[0] <=> rhs[0];
 }
 
 using bool1 = vector<bool, 1>;

--- a/src/sgl/math/vector_types.h
+++ b/src/sgl/math/vector_types.h
@@ -306,12 +306,12 @@ template<typename T, int N>
 template<arithmetic T, int N>
 [[nodiscard]] constexpr auto operator<=>(const vector<T, N>& lhs, const vector<T, N>& rhs)
 {
-    for (int i = 0; i < N; ++i) {
+    for (int i = 0; i < N - 1; ++i) {
         auto cmp = lhs[i] <=> rhs[i];
         if (cmp != 0)
             return cmp;
     }
-    return lhs[0] <=> rhs[0];
+    return lhs[N - 1] <=> rhs[N - 1];
 }
 
 using bool1 = vector<bool, 1>;

--- a/src/slangpy_ext/math/matrix.cpp
+++ b/src/slangpy_ext/math/matrix.cpp
@@ -189,6 +189,10 @@ void bind_matrix_type(nb::module_& m, const char* name)
 
     mat.def(nb::self == nb::self);
     mat.def(nb::self != nb::self);
+    mat.def(nb::self < nb::self);
+    mat.def(nb::self > nb::self);
+    mat.def(nb::self <= nb::self);
+    mat.def(nb::self >= nb::self);
 
     // Intrinsics
 

--- a/src/slangpy_ext/math/quaternion.cpp
+++ b/src/slangpy_ext/math/quaternion.cpp
@@ -89,6 +89,10 @@ void bind_quaternion_type(nb::module_& m, const char* name)
 
     quat.def(nb::self == nb::self);
     quat.def(nb::self != nb::self);
+    quat.def(nb::self < nb::self);
+    quat.def(nb::self > nb::self);
+    quat.def(nb::self <= nb::self);
+    quat.def(nb::self >= nb::self);
 
     quat.def(+nb::self);
     quat.def(-nb::self);

--- a/tests/sgl/math/test_matrix.cpp
+++ b/tests/sgl/math/test_matrix.cpp
@@ -3,6 +3,8 @@
 #include "testing.h"
 #include "sgl/math/matrix.h"
 
+#include <compare>
+
 using namespace sgl;
 
 TEST_SUITE_BEGIN("matrix");
@@ -61,6 +63,44 @@ TEST_CASE("constructors")
         CHECK(m[2] == float4(0, 0, 0, 0));
         CHECK(m[3] == float4(0, 0, 0, 0));
     }
+}
+
+TEST_CASE("equality_comparison")
+{
+    CHECK(float2x2({1, 2, 3, 4}) == float2x2({1, 2, 3, 4}));
+    CHECK_FALSE(float2x2({1, 2, 3, 4}) == float2x2({1, 2, 3, 5}));
+    CHECK_FALSE(float2x2({1, 2, 3, 4}) != float2x2({1, 2, 3, 4}));
+    CHECK(float2x2({1, 2, 3, 4}) != float2x2({1, 2, 4, 4}));
+}
+
+TEST_CASE("lexicographic_comparison")
+{
+    CHECK(float2x2({1, 2, 3, 4}) < float2x2({1, 2, 3, 5}));
+    CHECK(float2x2({1, 2, 3, 4}) < float2x2({1, 3, 0, 0}));
+    CHECK_FALSE(float2x2({1, 2, 3, 4}) < float2x2({1, 2, 3, 4}));
+    CHECK_FALSE(float2x2({1, 3, 0, 0}) < float2x2({1, 2, 9, 9}));
+
+    CHECK(float2x2({1, 2, 3, 5}) > float2x2({1, 2, 3, 4}));
+    CHECK_FALSE(float2x2({1, 2, 3, 4}) > float2x2({1, 2, 3, 4}));
+
+    CHECK(float2x2({1, 2, 3, 4}) <= float2x2({1, 2, 3, 4}));
+    CHECK(float2x2({1, 2, 3, 4}) <= float2x2({1, 2, 3, 5}));
+    CHECK_FALSE(float2x2({1, 2, 3, 5}) <= float2x2({1, 2, 3, 4}));
+
+    CHECK(float2x2({1, 2, 3, 4}) >= float2x2({1, 2, 3, 4}));
+    CHECK(float2x2({1, 2, 3, 5}) >= float2x2({1, 2, 3, 4}));
+    CHECK_FALSE(float2x2({1, 2, 3, 4}) >= float2x2({1, 2, 3, 5}));
+}
+
+TEST_CASE("three_way_comparison")
+{
+    auto c0 = float2x2({1, 2, 3, 4}) <=> float2x2({1, 2, 3, 4});
+    auto c1 = float2x2({1, 2, 3, 4}) <=> float2x2({1, 2, 3, 5});
+    auto c2 = float2x2({1, 2, 3, 5}) <=> float2x2({1, 2, 3, 4});
+
+    CHECK(std::is_eq(c0));
+    CHECK(std::is_lt(c1));
+    CHECK(std::is_gt(c2));
 }
 
 TEST_CASE("multilply")

--- a/tests/sgl/math/test_quaternion.cpp
+++ b/tests/sgl/math/test_quaternion.cpp
@@ -4,6 +4,8 @@
 #include "sgl/math/quaternion.h"
 #include "sgl/math/matrix.h"
 
+#include <compare>
+
 using namespace sgl;
 
 TEST_SUITE_BEGIN("quaternion");
@@ -172,6 +174,44 @@ TEST_CASE("operators")
         CHECK(ne(q1, q2) == bool4(false, false, false, false));
         CHECK(ne(q1, q3) == bool4(false, false, false, true));
     }
+}
+
+TEST_CASE("equality_comparison")
+{
+    CHECK(quatf(1, 2, 3, 4) == quatf(1, 2, 3, 4));
+    CHECK_FALSE(quatf(1, 2, 3, 4) == quatf(1, 2, 3, 5));
+    CHECK_FALSE(quatf(1, 2, 3, 4) != quatf(1, 2, 3, 4));
+    CHECK(quatf(1, 2, 3, 4) != quatf(1, 2, 4, 4));
+}
+
+TEST_CASE("lexicographic_comparison")
+{
+    CHECK(quatf(1, 2, 3, 4) < quatf(1, 2, 3, 5));
+    CHECK(quatf(1, 2, 3, 4) < quatf(1, 3, 0, 0));
+    CHECK_FALSE(quatf(1, 2, 3, 4) < quatf(1, 2, 3, 4));
+    CHECK_FALSE(quatf(1, 3, 0, 0) < quatf(1, 2, 9, 9));
+
+    CHECK(quatf(1, 2, 3, 5) > quatf(1, 2, 3, 4));
+    CHECK_FALSE(quatf(1, 2, 3, 4) > quatf(1, 2, 3, 4));
+
+    CHECK(quatf(1, 2, 3, 4) <= quatf(1, 2, 3, 4));
+    CHECK(quatf(1, 2, 3, 4) <= quatf(1, 2, 3, 5));
+    CHECK_FALSE(quatf(1, 2, 3, 5) <= quatf(1, 2, 3, 4));
+
+    CHECK(quatf(1, 2, 3, 4) >= quatf(1, 2, 3, 4));
+    CHECK(quatf(1, 2, 3, 5) >= quatf(1, 2, 3, 4));
+    CHECK_FALSE(quatf(1, 2, 3, 4) >= quatf(1, 2, 3, 5));
+}
+
+TEST_CASE("three_way_comparison")
+{
+    auto c0 = quatf(1, 2, 3, 4) <=> quatf(1, 2, 3, 4);
+    auto c1 = quatf(1, 2, 3, 4) <=> quatf(1, 2, 3, 5);
+    auto c2 = quatf(1, 2, 3, 5) <=> quatf(1, 2, 3, 4);
+
+    CHECK(std::is_eq(c0));
+    CHECK(std::is_lt(c1));
+    CHECK(std::is_gt(c2));
 }
 
 TEST_CASE("multiply")

--- a/tests/sgl/math/test_vector.cpp
+++ b/tests/sgl/math/test_vector.cpp
@@ -4,6 +4,7 @@
 #include "sgl/math/vector.h"
 
 #include <algorithm>
+#include <compare>
 #include <random>
 
 using namespace sgl;
@@ -73,6 +74,17 @@ TEST_CASE("lexicographic_comparison")
     CHECK(float3(1, 2, 3) >= float3(1, 2, 3));
     CHECK(float3(1, 2, 4) >= float3(1, 2, 3));
     CHECK_FALSE(float3(1, 2, 3) >= float3(1, 2, 4));
+}
+
+TEST_CASE("three_way_comparison")
+{
+    auto c0 = float3(1, 2, 3) <=> float3(1, 2, 3);
+    auto c1 = float3(1, 2, 3) <=> float3(1, 2, 4);
+    auto c2 = float3(1, 2, 4) <=> float3(1, 2, 3);
+
+    CHECK(std::is_eq(c0));
+    CHECK(std::is_lt(c1));
+    CHECK(std::is_gt(c2));
 }
 
 TEST_CASE("component_wise_comparisons")


### PR DESCRIPTION
Added `<=>` operator for matrix, vector, and quaternions. Without an explicit `<=>`, types containing these cannot have default generated `<=>` of their own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Math types (vectors, matrices, quaternions) now support lexicographic three-way and relational comparisons, enabling ordering operations (<, >, <=, >=, <=>).

* **Tests**
  * Added comprehensive unit tests validating equality, inequality, lexicographic ordering, and three-way comparison behavior for vectors, matrices, and quaternions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->