### PR TITLE
Filter unicode in source files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,6 @@ repos:
   - id: check-merge-conflict
   - id: check-yaml
   - id: check-added-large-files
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v20.1.7
-  hooks:
-  - id: clang-format
-- repo: https://github.com/psf/black
-  rev: 24.4.2
-  hooks:
-  - id: black
 - repo: local
   hooks:
     - id: custom-python-hook
@@ -33,6 +25,14 @@ repos:
       entry: python tools/check_ascii_hook.py
       language: python
       files: \.(cpp|hpp|h|c|py|slang|slangh)$
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v20.1.7
+  hooks:
+  - id: clang-format
+- repo: https://github.com/psf/black
+  rev: 24.4.2
+  hooks:
+  - id: black
 
 exclude: |
   (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
       name: slangpy hooks
       entry: python tools/local_precommit.py
       language: python
+- repo: local
+  hooks:
+    - id: check-ascii-source
+      name: check-ascii-source
+      entry: python tools/check_ascii_hook.py
+      language: python
+      files: \.(cpp|hpp|h|c|py|slang|slangh)$
 
 exclude: |
   (?x)^(

--- a/slangpy/benchmarks/test_benchmark_bwd_diff.py
+++ b/slangpy/benchmarks/test_benchmark_bwd_diff.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """
-Benchmark: DiffTensor vs DiffTensorView backward — atomic contention.
+Benchmark: DiffTensor vs DiffTensorView backward - atomic contention.
 
 Two scenarios:
 
 1. Uniform access: y[tid] = w
    All threads load the same weight w. In backward, gradients for w
-   must be accumulated across all threads — atomic contention.
+   must be accumulated across all threads - atomic contention.
 
 2. Per-element access: y[tid] = x[tid] * x[tid]
-   Each thread reads/writes a unique index — no contention.
+   Each thread reads/writes a unique index - no contention.
    loadOnce/storeOnce avoids unnecessary atomics.
 
 GPU time is measured via timestamp query pools (no CPU overhead).
@@ -232,7 +232,7 @@ def test_bwd_dtv_load(
     n: int,
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
-    """Uniform backward using DiffTensorView load() — atomic contention."""
+    """Uniform backward using DiffTensorView load() - atomic contention."""
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("broadcast_dtv")
@@ -248,7 +248,7 @@ def test_bwd_dtv_load_uniform(
     n: int,
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
-    """Uniform backward using DiffTensorView loadUniform() — wave reduction."""
+    """Uniform backward using DiffTensorView loadUniform() - wave reduction."""
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("broadcast_dtv_uniform")

--- a/slangpy/benchmarks/test_benchmark_bwd_diff.slang
+++ b/slangpy/benchmarks/test_benchmark_bwd_diff.slang
@@ -8,11 +8,11 @@ import slangpy;
 // =========================================================================
 // Uniform access: y[tid] = w
 // All threads load the same weight w and write it to their output slot.
-// In backward, gradients for w must be accumulated across all threads —
+// In backward, gradients for w must be accumulated across all threads -
 // this is where contention happens.
 // =========================================================================
 
-// --- DiffTensor: load (atomic backward — contention on w) ---
+// --- DiffTensor: load (atomic backward - contention on w) ---
 [CUDAKernel]
 [Differentiable]
 void broadcast_dt(uint count, DiffTensor<float, 1> w, WDiffTensor<float, 1> output)
@@ -24,7 +24,7 @@ void broadcast_dt(uint count, DiffTensor<float, 1> w, WDiffTensor<float, 1> outp
     output.store(int[1](tid), weight);
 }
 
-// --- DiffTensor: load_uniform (wave-level reduction — correct and fast) ---
+// --- DiffTensor: load_uniform (wave-level reduction - correct and fast) ---
 [CUDAKernel]
 [Differentiable]
 void broadcast_dt_uniform(uint count, DiffTensor<float, 1> w, WDiffTensor<float, 1> output)
@@ -36,7 +36,7 @@ void broadcast_dt_uniform(uint count, DiffTensor<float, 1> w, WDiffTensor<float,
     output.store(int[1](tid), weight);
 }
 
-// --- DiffTensorView: load (atomic backward — contention on w) ---
+// --- DiffTensorView: load (atomic backward - contention on w) ---
 [CUDAKernel]
 [Differentiable]
 void broadcast_dtv(uint count, DiffTensorView<float> w, DiffTensorView<float> output)
@@ -48,7 +48,7 @@ void broadcast_dtv(uint count, DiffTensorView<float> w, DiffTensorView<float> ou
     output.store(tid, weight);
 }
 
-// --- DiffTensorView: loadUniform (wave-level reduction — correct and fast) ---
+// --- DiffTensorView: loadUniform (wave-level reduction - correct and fast) ---
 [CUDAKernel]
 [Differentiable]
 void broadcast_dtv_uniform(uint count, DiffTensorView<float> w, DiffTensorView<float> output)
@@ -62,7 +62,7 @@ void broadcast_dtv_uniform(uint count, DiffTensorView<float> w, DiffTensorView<f
 
 // =========================================================================
 // Per-element access: f(x) = x*x
-// Each thread reads/writes a unique index — no contention.
+// Each thread reads/writes a unique index - no contention.
 // Non-atomic load/store variants avoid unnecessary atomics.
 // =========================================================================
 

--- a/slangpy/benchmarks/test_benchmark_ppisp.py
+++ b/slangpy/benchmarks/test_benchmark_ppisp.py
@@ -38,7 +38,7 @@ RESOLUTION_W = 1920
 RESOLUTION_H = 1080
 BATCH_SIZES = [100_000, 1_000_000]
 
-# Fixture parameters: 10 outer × 100 inner = 1000 total timed calls
+# Fixture parameters: 10 outer x 100 inner = 1000 total timed calls
 ITERATIONS = 10
 SUB_ITERATIONS = 100
 WARMUP_ITERATIONS = 10
@@ -199,7 +199,7 @@ def test_ppisp_correctness_backward(include_pytorch: bool) -> None:
         CORRECTNESS_BATCH, NUM_CAMERAS, NUM_FRAMES, RESOLUTION_W, RESOLUTION_H, torch_device
     )
 
-    # Uniform indices — see comment in test_ppisp_correctness_forward.
+    # Uniform indices - see comment in test_ppisp_correctness_forward.
     cam = 0 if include_pytorch else 2
     frm = 0 if include_pytorch else 5
     camera_idcs = torch.full((CORRECTNESS_BATCH,), cam, device=torch_device, dtype=torch.int16)
@@ -608,7 +608,7 @@ def test_ppisp_backward_slangpy_manual_hook(
 # =============================================================================
 # CPU dispatch overhead benchmarks (tiny batch, no GPU sync, high sub-iterations)
 #
-# Measures pure Python→GPU dispatch overhead by making GPU kernel time negligible
+# Measures pure Python->GPU dispatch overhead by making GPU kernel time negligible
 # (batch_size=32) and removing torch.cuda.synchronize(). The measured time is
 # dominated by argument marshalling, CallData cache lookup, and dispatch.
 # =============================================================================
@@ -654,7 +654,7 @@ def test_ppisp_cpu_overhead_slangpy(
         rgb.grad.zero_()  # type: ignore[union-attr]
         output = model(rgb, pixel_coords, camera_idcs, frame_idcs)
         output.sum().backward()
-        # NO torch.cuda.synchronize() — measure CPU dispatch only
+        # NO torch.cuda.synchronize() - measure CPU dispatch only
 
     benchmark_python_function(
         device,
@@ -694,7 +694,7 @@ def test_ppisp_cpu_overhead_slangtorch(
         rgb.grad.zero_()  # type: ignore[union-attr]
         output = model(rgb, pixel_coords, camera_idcs, frame_idcs)
         output.sum().backward()
-        # NO torch.cuda.synchronize() — measure CPU dispatch only
+        # NO torch.cuda.synchronize() - measure CPU dispatch only
 
     benchmark_python_function(
         device,

--- a/slangpy/builtin/diffpair.py
+++ b/slangpy/builtin/diffpair.py
@@ -34,8 +34,8 @@ def generate_differential_pair(
     assert deriv_storage
     assert primal_target
 
-    # Derivative is writable (RWValueRef) → __slangpy_load backward writes gradients out.
-    # Derivative is readable (ValueType)  → __slangpy_store backward reads gradient seed.
+    # Derivative is writable (RWValueRef) -> __slangpy_load backward writes gradients out.
+    # Derivative is readable (ValueType)  -> __slangpy_store backward reads gradient seed.
     deriv_is_writable = deriv_storage.startswith("RWValueRef")
     deriv_is_readable = deriv_storage.startswith("ValueType") or deriv_is_writable
     needs_diff = deriv_storage != "NoneType"

--- a/slangpy/builtin/value.py
+++ b/slangpy/builtin/value.py
@@ -121,7 +121,7 @@ class ValueMarshall(NativeValueMarshall):
     ) -> bool:
         if not binding.direct_bind:
             return False
-        # ValueMarshall is read-only — suppress the default store
+        # ValueMarshall is read-only - suppress the default store
         return True
 
     # Values just return themselves for raw dispatch

--- a/slangpy/core/callsignature.py
+++ b/slangpy/core/callsignature.py
@@ -173,7 +173,7 @@ def estimate_entrypoint_arguments_size(call: BoundCall, call_dimensionality: int
     total = 0
 
     for node in call.values():
-        # PackedArg types use ParameterBlock — excluded from inline accounting
+        # PackedArg types use ParameterBlock - excluded from inline accounting
         if node.create_param_block:
             continue
         if node.vector_type is not None:
@@ -183,9 +183,9 @@ def estimate_entrypoint_arguments_size(call: BoundCall, call_dimensionality: int
     # _thread_count: uint3 = 12 bytes
     total += 12
 
-    # Shape arrays: _grid_stride, _grid_dim, _call_dim — each is int[call_dimensionality]
+    # Shape arrays: _grid_stride, _grid_dim, _call_dim - each is int[call_dimensionality]
     if call_dimensionality > 0:
-        total += call_dimensionality * 4 * 3  # 3 arrays × N × sizeof(int)
+        total += call_dimensionality * 4 * 3  # 3 arrays x N x sizeof(int)
 
     return total
 

--- a/slangpy/slang/difftensor.slang
+++ b/slangpy/slang/difftensor.slang
@@ -502,7 +502,7 @@ public extension<T: IDifferentiable, let D : int> RWDiffTensor<T, D> where T.Dif
 }
 #endif
 
-// load_uniform for DiffTensor — wave-level gradient reduction.
+// load_uniform for DiffTensor - wave-level gradient reduction.
 // Implemented as an extension rather than a macro inside the struct because
 // WaveActiveSum requires __BuiltinFloatingPointType, but DiffTensor's generic T
 // is only constrained to IDifferentiable. Placing it in the struct body would

--- a/slangpy/tests/core/test_bitmap_resampling.py
+++ b/slangpy/tests/core/test_bitmap_resampling.py
@@ -28,7 +28,7 @@ CHANNEL_FORMAT_PAIRS = [
 ]
 
 # ---------------------------------------------------------------------------
-# Numpy reference resampler — builds weights from native filter.eval(), then
+# Numpy reference resampler - builds weights from native filter.eval(), then
 # applies them with numpy operations.  This is *not* a reimplementation of the
 # C++ resampler; it uses the same filter weights but an independent application
 # path so bugs in the C++ weighted-sum / boundary / separable logic are caught.
@@ -737,7 +737,7 @@ def test_single_pixel_upscale():
 
 
 def test_single_row_resample():
-    """A 1×N image should match the numpy reference (horizontal-only path)."""
+    """A 1xN image should match the numpy reference (horizontal-only path)."""
     rng = np.random.RandomState(50)
     data = rng.rand(1, 32).astype(np.float32)
     bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)
@@ -749,7 +749,7 @@ def test_single_row_resample():
 
 
 def test_single_column_resample():
-    """An N×1 image should match the numpy reference (vertical-only path)."""
+    """An Nx1 image should match the numpy reference (vertical-only path)."""
     rng = np.random.RandomState(51)
     data = rng.rand(32, 1).astype(np.float32)
     bmp = Bitmap(data[:, :, np.newaxis], pixel_format=Bitmap.PixelFormat.y, srgb_gamma=False)

--- a/slangpy/tests/slangpy_tests/test_call_groups.py
+++ b/slangpy/tests/slangpy_tests/test_call_groups.py
@@ -506,14 +506,14 @@ def test_call_group_math_verified_thread_id_patterns(device_type: DeviceType):
     Two key scenarios tested:
 
     1. DEFAULT CASE (no call groups):
-       - Uses default linear dispatch (effectively 1×1 call groups)
+       - Uses default linear dispatch (effectively 1x1 call groups)
        - thread_id.x follows pattern: thread_id = y * width + x
-       - Examples: [0,0]→thread_id=0, [0,1]→thread_id=1, [1,0]→thread_id=64, [1,1]→thread_id=65
+       - Examples: [0,0]->thread_id=0, [0,1]->thread_id=1, [1,0]->thread_id=64, [1,1]->thread_id=65
 
     2. CALL GROUP CASE (4, 8) groups:
-       - Threads arranged in spatial 4×8 groups
+       - Threads arranged in spatial 4x8 groups
        - thread_id assignment depends on group layout and changes from linear pattern
-       - Examples: [0,0]→thread_id=0, [0,1]→thread_id=1, [1,0]→thread_id=8, [1,1]→thread_id=9
+       - Examples: [0,0]->thread_id=0, [0,1]->thread_id=1, [1,0]->thread_id=8, [1,1]->thread_id=9
 
     The key insight: call groups change how thread_id.x is assigned while call_id remains position-based.
     """
@@ -532,7 +532,7 @@ uint3 test_thread_id_patterns(uint2 grid_cell, uint3 thread_id) {
 """
 
     module = helpers.create_module(device, kernel_source)
-    call_shape = (32, 64)  # 32 rows × 64 columns
+    call_shape = (32, 64)  # 32 rows x 64 columns
 
     # Test 1: DEFAULT CASE (no call groups)
     # Expected: Linear thread assignment where thread_id.x = y * width + x
@@ -582,8 +582,8 @@ uint3 test_thread_id_patterns(uint2 grid_cell, uint3 thread_id) {
     )
 
     # With (4, 8) call groups, thread assignment follows group-based pattern:
-    # - Grid divided into 8×8 call groups (32÷4 = 8 rows, 64÷8 = 8 columns of groups)
-    # - Each group contains 4×8 = 32 threads
+    # - Grid divided into 8x8 call groups (32/4 = 8 rows, 64/8 = 8 columns of groups)
+    # - Each group contains 4x8 = 32 threads
     # - thread_id assignment prioritizes spatial locality within groups
 
     # Row 0 positions: early positions should have thread_id = x (same as default)

--- a/slangpy/tests/slangpy_tests/test_code_gen.py
+++ b/slangpy/tests/slangpy_tests/test_code_gen.py
@@ -7,7 +7,7 @@ test calls ``debug_build_call_data`` once and asserts on both ``.code`` and
 ``.debug_only_bindings``.
 
 Negative-gate tests (``test_*_not_direct_bind``, ``test_*_keeps_wrapper``) must
-remain passing — they cover types that are NOT direct-bind eligible.
+remain passing - they cover types that are NOT direct-bind eligible.
 
 Functional dispatch tests are included only for scenarios that are not covered
 by other test files (``test_simple_function_call.py``, ``test_tensor.py``, etc.).
@@ -102,7 +102,7 @@ def build_bwds_call_data_full(
 
 
 # ===========================================================================
-# Codegen + binding flag tests (1–21)
+# Codegen + binding flag tests (1-21)
 # ===========================================================================
 
 
@@ -124,7 +124,7 @@ def test_scalar_direct_bind(device_type: spy.DeviceType):
     # Scalars use raw type directly, no wrapper
     assert_not_contains(code, "ValueType<int>")
     assert_not_contains(code, "typealias _t_a", "typealias _t_b")
-    # Direct assignment — loaded into __tmp_ locals
+    # Direct assignment - loaded into __tmp_ locals
     assert_load_statement(code, "a", "b")
     # _result is auto-created writable RWValueRef
     assert_contains(code, "RWValueRef<int>")
@@ -228,7 +228,7 @@ def test_valueref_read_direct_bind(device_type: spy.DeviceType):
 # 6 -------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_writable_valueref_not_direct_bind(device_type: spy.DeviceType):
-    """Writable ValueRef (inout) must not be direct-bind — needs buffer read/write."""
+    """Writable ValueRef (inout) must not be direct-bind - needs buffer read/write."""
     device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(device, "inc", "void inc(inout int v) { v += 1; }")
     cd = func.debug_build_call_data(ValueRef(5))
@@ -244,7 +244,7 @@ def test_writable_valueref_not_direct_bind(device_type: spy.DeviceType):
 # 7 -------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_struct_all_scalar_direct_bind(device_type: spy.DeviceType):
-    """S{float x, y} via dict — all-scalar, direct-bind.
+    """S{float x, y} via dict - all-scalar, direct-bind.
 
     Merges: test_gate_struct_uses_slangpy_load, test_struct_all_scalars_binding_flag.
     """
@@ -260,7 +260,7 @@ float sum(S s) { return s.x + s.y; }
         device, "sum", src, {"_type": "S", "x": 1.0, "y": 2.0}
     )
 
-    # Direct-bind struct — raw type, no __slangpy_load
+    # Direct-bind struct - raw type, no __slangpy_load
     assert_not_contains(code, "__slangpy_load")
     assert_not_contains(code, "typealias _t_s")
     assert_contains(code, "S __tmp_s;")
@@ -280,7 +280,7 @@ float sum(S s) { return s.x + s.y; }
     ids=["vector_field", "array_field", "matrix_field"],
 )
 def test_struct_composite_fields_direct_bind(device_type: spy.DeviceType, variant: str):
-    """Struct with composite field (vector / array / matrix) all dim-0 → direct-bind."""
+    """Struct with composite field (vector / array / matrix) all dim-0 -> direct-bind."""
     device = helpers.get_device(device_type)
 
     if variant == "vector_field":
@@ -324,7 +324,7 @@ float4x4 apply(S s) { return s.m * s.scale; }
 
     code, bindings = generate_code_and_bindings(device, func_name, src, arg)
 
-    # Struct is direct-bind — raw type, no __slangpy_load
+    # Struct is direct-bind - raw type, no __slangpy_load
     assert_not_contains(code, "__slangpy_load")
     param_name = "foo" if variant == "array_field" else "s"
     assert_not_contains(code, f"typealias _t_{param_name}")
@@ -338,7 +338,7 @@ float4x4 apply(S s) { return s.m * s.scale; }
 # 9 -------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_deeply_nested_struct_direct_bind(device_type: spy.DeviceType):
-    """3-level deep Top{Mid{Bot}} — all-scalar, direct-bind at every level.
+    """3-level deep Top{Mid{Bot}} - all-scalar, direct-bind at every level.
 
     Subsumes 2-level nested struct tests. Merges: test_gate_deeply_nested_struct_codegen,
     test_gate_deeply_nested_struct_binding_flags.
@@ -383,7 +383,7 @@ float compute(Top t) { return t.mid.bot.v * float(t.mid.c) * t.s; }
 # 10 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_struct_mixed_fields(device_type: spy.DeviceType):
-    """S{x(tensor), y(scalar)} — struct NOT direct-bind, scalar child keeps direct-bind.
+    """S{x(tensor), y(scalar)} - struct NOT direct-bind, scalar child keeps direct-bind.
 
     Merges: test_gate_struct_mixed_fields_codegen, test_mixed_children_direct_bind_codegen,
     test_gate_struct_mixed_fields_binding_flags.
@@ -401,20 +401,20 @@ void apply(S s, float scale) {}
         device, "apply", src, {"_type": "S", "x": tensor_x, "y": 1.0}, 2.0
     )
 
-    # Struct NOT direct-bind — inline struct with __slangpy_load
+    # Struct NOT direct-bind - inline struct with __slangpy_load
     assert_contains(code, "__slangpy_load")
     assert_contains(code, "struct _t_s")
     assert_not_contains(code, "typealias _t_s = S;")
-    # Child y direct-bind — type used directly, direct assignment
+    # Child y direct-bind - type used directly, direct assignment
     assert_not_contains(code, "typealias _t_y")
     assert_contains(code, "float y;")
     assert_contains(code, "value.y = y;")
     assert_not_contains(code, "ValueType<float>")
     assert_not_contains(code, "_m_y")
-    # Child x — tensor
+    # Child x - tensor
     assert_contains(code, "Tensor<float, 1>")
     assert_contains(code, "x.__slangpy_load(context.map(_m_x),value.x)")
-    # Independent scalar arg 'scale' — direct-bind
+    # Independent scalar arg 'scale' - direct-bind
     assert_not_contains(code, "typealias _t_scale")
     assert_contains(code, "float __tmp_scale;")
 
@@ -429,7 +429,7 @@ void apply(S s, float scale) {}
 # 11 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_nested_struct_with_tensor_child(device_type: spy.DeviceType):
-    """Outer{Inner{x(tensor),y(scalar)},s} — Outer/Inner NOT direct-bind, scalar leaves are.
+    """Outer{Inner{x(tensor),y(scalar)},s} - Outer/Inner NOT direct-bind, scalar leaves are.
 
     Merges: test_gate_nested_struct_with_tensor_child_codegen,
     test_gate_nested_struct_with_tensor_child_binding_flags.
@@ -477,7 +477,7 @@ float compute(Outer o) { return (o.inner.x + o.inner.y) * o.s; }
 # 12 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_struct_return_not_direct_bind(device_type: spy.DeviceType):
-    """Function returning struct — _result uses wrapper, NOT direct-bind.
+    """Function returning struct - _result uses wrapper, NOT direct-bind.
 
     Merges: test_gate_struct_return_codegen, test_gate_struct_return_binding_flags.
     """
@@ -493,7 +493,7 @@ S make_struct(int a, int b) { return { a, b }; }
 
     # Scalar inputs direct-bind
     assert_not_contains(code, "typealias _t_a", "typealias _t_b")
-    # _result writable — uses wrapper
+    # _result writable - uses wrapper
     assert_contains(code, "__slangpy_store")
     assert_contains(code, "_m__result")
 
@@ -506,7 +506,7 @@ S make_struct(int a, int b) { return { a, b }; }
 # 13 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_struct_vectorized_2d_child(device_type: spy.DeviceType):
-    """S{float3 v (2D tensor→float3), float s (scalar)} — struct NOT direct-bind."""
+    """S{float3 v (2D tensor->float3), float s (scalar)} - struct NOT direct-bind."""
     device = helpers.get_device(device_type)
     src = """
 struct S {
@@ -533,7 +533,7 @@ float3 apply(S st) { return st.v * st.s; }
 # 14 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_mixed_scalar_and_tensor(device_type: spy.DeviceType):
-    """Scalar + tensor args — scalar direct-bind, tensor not.
+    """Scalar + tensor args - scalar direct-bind, tensor not.
 
     Merges: test_gate_mixed_args_scalar_and_tensor, test_gate_mixed_args_direct_bind_flags.
     """
@@ -587,7 +587,7 @@ float tensor_read(Tensor<float,1> t) {
 # 16 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_2d_tensor_to_vector(device_type: spy.DeviceType):
-    """2D Tensor (10,3) → float3: trailing dim consumed by vector, outer dispatched.
+    """2D Tensor (10,3) -> float3: trailing dim consumed by vector, outer dispatched.
 
     Merges: test_gate_2d_tensor_to_vector_codegen, test_gate_2d_tensor_to_vector_binding_flags.
     """
@@ -615,7 +615,7 @@ def test_2d_tensor_to_vector(device_type: spy.DeviceType):
 # 17 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_3d_tensor_to_vector(device_type: spy.DeviceType):
-    """3D Tensor (2,5,3) → float3: two outer dims dispatched (call_dim=2).
+    """3D Tensor (2,5,3) -> float3: two outer dims dispatched (call_dim=2).
 
     Merges: test_gate_3d_tensor_to_vector_codegen, test_gate_3d_tensor_to_vector_binding_flags.
     """
@@ -637,7 +637,7 @@ def test_3d_tensor_to_vector(device_type: spy.DeviceType):
 # 18 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_2d_tensor_to_scalar(device_type: spy.DeviceType):
-    """2D Tensor (4,5) → float: both dims dispatched (call_dim=2).
+    """2D Tensor (4,5) -> float: both dims dispatched (call_dim=2).
 
     Merges: test_gate_2d_tensor_to_scalar_codegen, test_gate_2d_tensor_to_scalar_binding_flags.
     """
@@ -658,7 +658,7 @@ def test_2d_tensor_to_scalar(device_type: spy.DeviceType):
 # 19 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_2d_tensor_to_array(device_type: spy.DeviceType):
-    """2D Tensor (4,8) → half[8]: trailing dim consumed by array, outer dispatched.
+    """2D Tensor (4,8) -> half[8]: trailing dim consumed by array, outer dispatched.
 
     Merges: test_gate_2d_tensor_to_1d_array_codegen, test_gate_2d_tensor_to_1d_array_binding_flags.
     """
@@ -688,7 +688,7 @@ half[NumChannels] tensor_test_channels<let NumChannels : int>(half[NumChannels] 
 # 20 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_mixed_vectorized_dim0_tensor(device_type: spy.DeviceType):
-    """One tensor vectorized (2D→float3) and another at dim-0 (Tensor<float,1> param).
+    """One tensor vectorized (2D->float3) and another at dim-0 (Tensor<float,1> param).
 
     Merges: test_gate_mixed_vectorized_and_dim0_tensor_codegen,
     test_gate_mixed_vectorized_and_dim0_tensor_binding_flags.
@@ -705,7 +705,7 @@ float dot_lookup(float3 v, Tensor<float,1> weights) {
         device, "dot_lookup", src, vec_tensor, weight_tensor
     )
 
-    # v: vectorized dim-1 (2D→float3)
+    # v: vectorized dim-1 (2D->float3)
     assert_contains(code, "_m_v")
     assert_contains(code, "__slangpy_load")
     # weights: dim-0 direct-bind
@@ -739,7 +739,7 @@ def test_long_type_name_typealias(device_type: spy.DeviceType):
     """
     device = helpers.get_device(device_type)
 
-    # --- Long name → typealias emitted ---
+    # --- Long name -> typealias emitted ---
     long_src = f"""
 struct {_LONG_STRUCT_NAME} {{
     float x;
@@ -756,7 +756,7 @@ float sum({_LONG_STRUCT_NAME} s) {{ return s.x + s.y; }}
         "_t_s s;" in code_long or "uniform _t_s s" in code_long
     ), "Expected typealias usage (_t_s s; or uniform _t_s s) not found"
 
-    # --- Short name → no typealias ---
+    # --- Short name -> no typealias ---
     short_src = f"""
 struct {_SHORT_STRUCT_NAME} {{
     float x;
@@ -787,7 +787,7 @@ struct {_LONG_STRUCT_NAME} {{
 
 
 # ===========================================================================
-# Negative gates (22–24) — must remain passing
+# Negative gates (22-24) - must remain passing
 # ===========================================================================
 
 
@@ -829,7 +829,7 @@ float apply(S s) { return float(s.seed.x) * s.scale; }
 # 23 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_vectorized_scalar_keeps_wrapper(device_type: spy.DeviceType):
-    """1D tensor → float: vectorized, keeps __slangpy_load."""
+    """1D tensor -> float: vectorized, keeps __slangpy_load."""
     device = helpers.get_device(device_type)
     tensor = Tensor.from_numpy(device, np.array([1, 2, 3], dtype=np.float32))
     code, _ = generate_code_and_bindings(
@@ -899,7 +899,7 @@ float polynomial(float a, float b) {
 
 
 # ===========================================================================
-# Functional GPU dispatch — novel scenarios only (26–34)
+# Functional GPU dispatch - novel scenarios only (26-34)
 # ===========================================================================
 
 
@@ -955,7 +955,7 @@ float tensor_read(Tensor<float,1> t) {
 # 29 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_dispatch_2d_tensor_to_vector(device_type: spy.DeviceType):
-    """Dispatch 2D tensor → float3 and verify GPU result."""
+    """Dispatch 2D tensor -> float3 and verify GPU result."""
     device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(
         device, "scale", "float3 scale(float3 v, float s) { return v * s; }"
@@ -970,7 +970,7 @@ def test_dispatch_2d_tensor_to_vector(device_type: spy.DeviceType):
 # 30 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_dispatch_2d_tensor_to_array(device_type: spy.DeviceType):
-    """Dispatch 2D tensor → half[8] and verify GPU doubles each element."""
+    """Dispatch 2D tensor -> half[8] and verify GPU doubles each element."""
     device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(
         device,
@@ -1047,7 +1047,7 @@ float compute(Outer o) { return (o.inner.x + o.inner.y) * o.s; }
 # 33 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_dispatch_struct_vectorized_2d_child(device_type: spy.DeviceType):
-    """Dispatch struct with 2D tensor→float3 child and verify GPU result."""
+    """Dispatch struct with 2D tensor->float3 child and verify GPU result."""
     device = helpers.get_device(device_type)
     src = """
 struct S {
@@ -1100,7 +1100,7 @@ int sum_inner(Outer outer) {
 
 
 # ===========================================================================
-# Phase 2 — entry-point params (35–38, 40)
+# Phase 2 - entry-point params (35-38, 40)
 # ===========================================================================
 
 
@@ -1266,9 +1266,9 @@ float polynomial(float a, float b) {
 # 40 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_fallback_calldata_large_params(device_type: spy.DeviceType):
-    """Fallback path: many float4x4 params exceed threshold → ParameterBlock<CallData>.
+    """Fallback path: many float4x4 params exceed threshold -> ParameterBlock<CallData>.
 
-    8 × float4x4 = 512 bytes + 12 bytes _thread_count = 524 bytes.
+    8 x float4x4 = 512 bytes + 12 bytes _thread_count = 524 bytes.
     Exceeds Vulkan (128) and D3D12 (256); CUDA (4096) stays on fast path.
     Asserts codegen patterns match the expected path.
 
@@ -1298,12 +1298,12 @@ float4x4 sum8(float4x4 a, float4x4 b, float4x4 c, float4x4 d,
 
     threshold = device.info.limits.max_entry_point_uniform_size
     if threshold >= 524:
-        # CUDA: fast path — no CallData, individual uniform params
+        # CUDA: fast path - no CallData, individual uniform params
         assert cd.use_entrypoint_args is True
         assert_not_contains(code, "struct CallData")
         assert_contains(code, "uniform uint3 _thread_count")
     else:
-        # Vulkan/D3D12: fallback — struct CallData + ParameterBlock
+        # Vulkan/D3D12: fallback - struct CallData + ParameterBlock
         assert cd.use_entrypoint_args is False
         assert_contains(code, "struct CallData")
         assert_contains(code, "ParameterBlock<CallData> call_data")
@@ -1312,7 +1312,7 @@ float4x4 sum8(float4x4 a, float4x4 b, float4x4 c, float4x4 d,
 
 
 # ===========================================================================
-# Prim-mode trampoline elimination (41–42)
+# Prim-mode trampoline elimination (41-42)
 # ===========================================================================
 
 
@@ -1326,7 +1326,7 @@ def test_prim_no_trampoline(device_type: spy.DeviceType):
     )
     # No trampoline function generated
     assert_not_contains(code, "void _trampoline(")
-    # compute_main does NOT call _trampoline — it inlines the call
+    # compute_main does NOT call _trampoline - it inlines the call
     main_idx = code.index("void compute_main(")
     main_body = code[main_idx:]
     assert "_trampoline(" not in main_body
@@ -1336,7 +1336,7 @@ def test_prim_no_trampoline(device_type: spy.DeviceType):
 # 42 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_struct_array_of_structs_codegen(device_type: spy.DeviceType):
-    """Struct with array-of-structs field: Outer{Inner items[4]} — all dim-0, direct-bind."""
+    """Struct with array-of-structs field: Outer{Inner items[4]} - all dim-0, direct-bind."""
     device = helpers.get_device(device_type)
     src = """
 struct Inner {
@@ -1376,7 +1376,7 @@ int sum_inner(Outer outer) {
 
 
 # ===========================================================================
-# Additional use_entrypoint_args coverage (43–46)
+# Additional use_entrypoint_args coverage (43-46)
 # ===========================================================================
 
 
@@ -1424,7 +1424,7 @@ float sum(S s) { return s.x + s.y; }
 # 46 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_tensor_uses_entrypoint_args(device_type: spy.DeviceType):
-    """Tensor args contribute descriptor-only (0 inline bytes) → entry-point params."""
+    """Tensor args contribute descriptor-only (0 inline bytes) -> entry-point params."""
     if device_type == spy.DeviceType.metal:
         pytest.skip("Metal doesn't support entry point params.")
     device = helpers.get_device(device_type)
@@ -1439,14 +1439,14 @@ def test_tensor_uses_entrypoint_args(device_type: spy.DeviceType):
 
 
 # ===========================================================================
-# Additional functional dispatch tests (47–49)
+# Additional functional dispatch tests (47-49)
 # ===========================================================================
 
 
 # 47 ------------------------------------------------------------------------
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_dispatch_valueref_read(device_type: spy.DeviceType):
-    """Dispatch with a read-only ValueRef input — direct-bind pipeline end-to-end."""
+    """Dispatch with a read-only ValueRef input - direct-bind pipeline end-to-end."""
     device = helpers.get_device(device_type)
     func = helpers.create_function_from_module(
         device, "double_it", "float double_it(float v) { return v * 2; }"

--- a/slangpy/tests/slangpy_tests/test_pytorch_gradient_parity.py
+++ b/slangpy/tests/slangpy_tests/test_pytorch_gradient_parity.py
@@ -948,7 +948,7 @@ def test_scalar_broadcast_no_copyback(device_type: DeviceType):
 
 # =============================================================================
 # Explicit Gradient Copy-back Tests
-# These verify the interop buffer → PyTorch tensor copy-back for gradients
+# These verify the interop buffer -> PyTorch tensor copy-back for gradients
 # =============================================================================
 
 

--- a/slangpy/tests/slangpy_tests/test_torch_autograd_workflows.py
+++ b/slangpy/tests/slangpy_tests/test_torch_autograd_workflows.py
@@ -8,8 +8,8 @@ patterns: optimizer loops, gradient accumulation for broadcast parameters,
 chained kernel calls, vector outputs, and mixed slangpy+PyTorch autograd graphs.
 
 The workflow patterns are inspired by slang-torch examples
-(https://github.com/shader-slang/slang-torch) — bezier curve fitting, MLP
-training, and differentiable rasterization — but these are NOT ports of that
+(https://github.com/shader-slang/slang-torch) - bezier curve fitting, MLP
+training, and differentiable rasterization - but these are NOT ports of that
 code. The slang-torch originals use DiffTensorView, [CUDAKernel],
 [AutoPyBindCUDA], and manual torch.autograd.Function wrappers, none of which
 are used here. These tests use slangpy's own API (scalar/array parameters with
@@ -158,7 +158,7 @@ def test_polynomial_optimization_convergence(device_type: DeviceType):
     x = torch.linspace(-1, 1, 100, device="cuda", dtype=torch.float32)
     y_target = target_a * x**3 + target_b * x**2 + target_c * x + target_d
 
-    # Initialize coefficients at wrong values — these ARE optimized
+    # Initialize coefficients at wrong values - these ARE optimized
     a = torch.tensor([0.0], device="cuda", dtype=torch.float32, requires_grad=True)
     b = torch.tensor([0.0], device="cuda", dtype=torch.float32, requires_grad=True)
     c = torch.tensor([0.0], device="cuda", dtype=torch.float32, requires_grad=True)
@@ -580,7 +580,7 @@ def test_interleaved_slangpy_pytorch_optimization(device_type: DeviceType):
         # slangpy computes the polynomial
         poly_out = module.cubic_poly(a=a, b=b, c=c, d=d, x=x)
 
-        # PyTorch applies sin on top — tests mixed autograd graph
+        # PyTorch applies sin on top - tests mixed autograd graph
         y_pred = torch.sin(poly_out)
 
         loss = ((y_pred - y_target) ** 2).mean()
@@ -652,7 +652,7 @@ def test_retain_graph_accumulates_gradients(device_type: DeviceType):
     y = module.cubic_poly(a=a, b=b, c=c, d=d, x=x)
     loss = y.sum()
 
-    # Two backward calls without zero_grad — gradients should accumulate
+    # Two backward calls without zero_grad - gradients should accumulate
     loss.backward(retain_graph=True)
     loss.backward()
 

--- a/slangpy/tests/utils/test_torch_bridge.py
+++ b/slangpy/tests/utils/test_torch_bridge.py
@@ -248,7 +248,7 @@ class TestTorchBridgeCopy:
         self.mode = torch_bridge_mode
 
     def _make_buffer(self, device: slangpy.Device, byte_size: int) -> slangpy.Buffer:
-        """Create a shared buffer suitable for tensor ↔ buffer copies."""
+        """Create a shared buffer suitable for tensor  buffer copies."""
         return device.create_buffer(
             size=byte_size,
             usage=slangpy.BufferUsage.unordered_access
@@ -341,7 +341,7 @@ class TestTorchBridgeCopy:
 
     @pytest.mark.parametrize("device_type", DEVICE_TYPES)
     def test_roundtrip(self, device_type: DeviceType):
-        """Test data survives tensor → buffer → tensor round-trip."""
+        """Test data survives tensor -> buffer -> tensor round-trip."""
         device = helpers.get_torch_device(device_type)
         src = torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5], dtype=torch.float32, device="cuda")
         buffer = self._make_buffer(device, src.numel() * src.element_size())

--- a/slangpy/torchintegration/autogradhook.py
+++ b/slangpy/torchintegration/autogradhook.py
@@ -62,11 +62,11 @@ class TorchAutoGradHook(torch.autograd.Function):
         ctx.args = args
         ctx.kwargs = kwargs
         ctx.pairs = pairs
-        # Save ALL primals (inputs and outputs) — Slang's backward pass
+        # Save ALL primals (inputs and outputs) - Slang's backward pass
         # replays the forward internally and needs output primals too.
         ctx.save_for_backward(*all_tensors)
 
-        # output_tensors already includes the result tensor (if any) —
+        # output_tensors already includes the result tensor (if any) -
         # autograd_forward appends it when creating the _result pair.
         return tuple(output_tensors)
 

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -418,7 +418,7 @@ nb::object NativeCallData::find_torch_tensors_recurse(nb::object arg, nb::list& 
         // Read access from pre-built list
         if (access_idx >= m_autograd_access_list.size()) {
             throw std::runtime_error(
-                "Autograd access list index out of bounds — "
+                "Autograd access list index out of bounds - "
                 "argument structure doesn't match build-time bindings."
             );
         }

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -676,7 +676,7 @@ private:
 class NativeCallRuntimeOptions : Object {
     SGL_OBJECT(NativeCallRuntimeOptions)
 public:
-    nb::object this_obj; // Default null handle — check with is_valid(), not is_none()
+    nb::object this_obj; // Default null handle - check with is_valid(), not is_none()
     NativeHandle cuda_stream;
     bool is_ray_tracing{false};
     int thread_count{0};
@@ -1023,7 +1023,7 @@ public:
         return nullptr;
     }
 
-    /// Store call data (cache miss only — takes ownership of std::string key).
+    /// Store call data (cache miss only - takes ownership of std::string key).
     void add_call_data(std::string signature, const ref<NativeCallData>& call_data)
     {
         m_cache[std::move(signature)] = call_data;

--- a/src/slangpy_ext/utils/slangpyfunction.cpp
+++ b/src/slangpy_ext/utils/slangpyfunction.cpp
@@ -152,7 +152,7 @@ nb::object NativeFunctionNode::call_bwds(NativeCallData* fwds_call_data, nb::arg
     }
 
     // Gather runtime options (uniforms, cuda_stream, etc.)
-    // Note: we do NOT prepend 'this' to args here — the saved args from the
+    // Note: we do NOT prepend 'this' to args here - the saved args from the
     // forward pass already include it (it was prepended in NativeFunctionNode::call).
     auto& options = cached_options();
     gather_runtime_options(options);
@@ -167,7 +167,7 @@ nb::object NativeFunctionNode::call(nb::args args, nb::kwargs kwargs)
     NativeCallDataCache* cache = resolve_cache();
     SGL_CHECK(cache, "NativeFunctionNode::call: no cache found (was _native_cache set on root?)");
 
-    // Handle _result as type or string → delegate to Python self.return_type(resval).call(...)
+    // Handle _result as type or string -> delegate to Python self.return_type(resval).call(...)
     if (kwargs.contains("_result")) {
         nb::object resval = kwargs["_result"];
         if (nb::isinstance<nb::type_object>(resval) || nb::isinstance<nb::str>(resval)) {
@@ -179,7 +179,7 @@ nb::object NativeFunctionNode::call(nb::args args, nb::kwargs kwargs)
         }
     }
 
-    // Handle _append_to kwarg → delegate to append_to
+    // Handle _append_to kwarg -> delegate to append_to
     if (kwargs.contains("_append_to")) {
         nb::object app_to = kwargs["_append_to"];
         nb::del(kwargs["_append_to"]);

--- a/src/slangpy_ext/utils/slangpytensor.cpp
+++ b/src/slangpy_ext/utils/slangpytensor.cpp
@@ -19,7 +19,7 @@ namespace sgl::slangpy {
 
 namespace {
     /// Helper function to extract shape from PyTorch tensor
-    /// Creates Shape directly and populates it - zero allocations for tensors with ≤8 dimensions
+    /// Creates Shape directly and populates it - zero allocations for tensors with <=8 dimensions
     Shape extract_shape(const nb::ndarray<nb::pytorch, nb::device::cuda>& tensor)
     {
         const size_t ndim = tensor.ndim();
@@ -33,7 +33,7 @@ namespace {
 
     /// Helper function to extract strides from PyTorch tensor
     /// Returns element strides directly (PyTorch stride() already returns element strides for nanobind)
-    /// Creates Shape directly and populates it - zero allocations for tensors with ≤8 dimensions
+    /// Creates Shape directly and populates it - zero allocations for tensors with <=8 dimensions
     Shape extract_strides(const nb::ndarray<nb::pytorch, nb::device::cuda>& tensor)
     {
         const size_t ndim = tensor.ndim();
@@ -54,7 +54,7 @@ namespace {
         const Shape& call_shape
     )
     {
-        Shape result = strides; // Uses copy constructor (inline if ≤8 dims, one allocation if >8)
+        Shape result = strides; // Uses copy constructor (inline if <=8 dims, one allocation if >8)
 
         // Get raw pointers once to avoid per-element m_uses_heap branching
         const int* transform_data = transform.data();

--- a/src/slangpy_ext/utils/slangpytorchtensor.cpp
+++ b/src/slangpy_ext/utils/slangpytorchtensor.cpp
@@ -267,9 +267,9 @@ void NativeTorchTensorMarshall::ensure_binding_info_cached(
         // name here rather than re-deriving from binding access mode or vector type kind.
         //
         // Naming convention:
-        //   "RW" prefix → read-write (primal writable + readable, gradient rw)
-        //   "W"  prefix → write-only primal, read-only gradient
-        //   No prefix   → read-only primal, write-only gradient
+        //   "RW" prefix -> read-write (primal writable + readable, gradient rw)
+        //   "W"  prefix -> write-only primal, read-only gradient
+        //   No prefix   -> read-only primal, write-only gradient
         std::string_view type_name = field.slang_type_layout()->getName();
         bool starts_rw = type_name.size() >= 2 && type_name[0] == 'R' && type_name[1] == 'W';
         bool starts_w = !type_name.empty() && type_name[0] == 'W' && !starts_rw;
@@ -279,9 +279,9 @@ void NativeTorchTensorMarshall::ensure_binding_info_cached(
 
         // Gradient needs copy-back when the gradient is writable (output).
         // This happens when the primal is readable (not write-only):
-        //   DiffTensor   → read primal, write grad → copy back grad
-        //   WDiffTensor  → write primal, read grad → no grad copy-back
-        //   RWDiffTensor → rw primal, rw grad      → copy back grad
+        //   DiffTensor   -> read primal, write grad -> copy back grad
+        //   WDiffTensor  -> write primal, read grad -> no grad copy-back
+        //   RWDiffTensor -> rw primal, rw grad      -> copy back grad
         bool primal_readable = !starts_w;
         m_cached_binding_info.needs_grad_copyback = m_cached_binding_info.has_grad_fields && primal_readable;
     }
@@ -590,7 +590,7 @@ void NativeTorchTensorMarshall::write_shader_cursor_with_interop(
     } else if (m_cached_binding_info.has_grad_fields && primal_info.numel > 0
                && context->device()->supports_cuda_interop()) {
         // Backward pass: output slot has grad but no primal. Shader still needs a valid
-        // primal buffer (DiffTensor layout). Create and zero — we have no tensor to copy from.
+        // primal buffer (DiffTensor layout). Create and zero - we have no tensor to copy from.
         primal_interop_buffer = create_zeroed_interop_buffer(primal_info);
     }
 

--- a/tests/sgl/math/test_matrix.cpp
+++ b/tests/sgl/math/test_matrix.cpp
@@ -816,7 +816,7 @@ TEST_CASE("rotate_2d_direction")
     // Rotate identity matrix by 90 degrees
     float3x3 rotated = rotate_2d(identity, math::radians(90.f));
 
-    // The result should be equivalent to matrix_from_rotation_2d(90°)
+    // The result should be equivalent to matrix_from_rotation_2d(90deg)
     float3x3 expected = math::matrix_from_rotation_2d(math::radians(90.f));
 
     CHECK_ALMOST_EQ(rotated[0], expected[0]);
@@ -952,7 +952,7 @@ TEST_CASE("2d_transform_combinations")
     transform_matrix = mul(transform_matrix, math::matrix_from_rotation_2d(math::radians(90.f)));
     transform_matrix = mul(transform_matrix, math::matrix_from_scaling_2d(float2(2.f, 3.f)));
 
-    // Transform point (1, 1) -> scale to (2, 3) -> rotate 90° to (-3, 2) -> translate to (2, 12)
+    // Transform point (1, 1) -> scale to (2, 3) -> rotate 90deg to (-3, 2) -> translate to (2, 12)
     float3 point(1.f, 1.f, 1.f);
     float3 transformed = mul(transform_matrix, point);
     CHECK_ALMOST_EQ(transformed, float3(2.f, 12.f, 1.f));

--- a/tools/check_ascii_hook.py
+++ b/tools/check_ascii_hook.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import sys
+import unicodedata
+from pathlib import Path
+
+REPLACEMENTS = {
+    # Invisible / zero-width
+    "\ufeff": "",  # BOM (byte order mark)
+    "\u00ad": "",  # soft hyphen
+    "\u200b": "",  # zero-width space
+    "\u200c": "",  # zero-width non-joiner
+    "\u200d": "",  # zero-width joiner
+    # Spaces
+    "\u00a0": " ",  # non-breaking space
+    "\u2000": " ",  # en quad
+    "\u2001": " ",  # em quad
+    "\u2002": " ",  # en space
+    "\u2003": " ",  # em space
+    "\u2004": " ",  # three-per-em space
+    "\u2005": " ",  # four-per-em space
+    "\u2006": " ",  # six-per-em space
+    "\u2007": " ",  # figure space
+    "\u2008": " ",  # punctuation space
+    "\u2009": " ",  # thin space
+    "\u200a": " ",  # hair space
+    "\u202f": " ",  # narrow no-break space
+    # Dashes
+    "\u2010": "-",  # hyphen
+    "\u2011": "-",  # non-breaking hyphen
+    "\u2012": "-",  # figure dash
+    "\u2013": "-",  # en dash
+    "\u2014": "-",  # em dash
+    "\u2015": "-",  # horizontal bar
+    # Quotes
+    "\u2018": "'",  # left single quotation mark
+    "\u2019": "'",  # right single quotation mark
+    "\u201a": "'",  # single low-9 quotation mark
+    "\u201c": '"',  # left double quotation mark
+    "\u201d": '"',  # right double quotation mark
+    "\u201e": '"',  # double low-9 quotation mark
+    "\u2032": "'",  # prime
+    "\u2033": '"',  # double prime
+    "\u00ab": "<<",  # left guillemet
+    "\u00bb": ">>",  # right guillemet
+    "\u2039": "<",  # single left angle quotation mark
+    "\u203a": ">",  # single right angle quotation mark
+    # Symbols
+    "\u2026": "...",  # ellipsis
+    "\u2022": "*",  # bullet
+    "\u00b0": "deg",  # degree sign
+    "\u00b7": ".",  # middle dot
+    "\u00d7": "x",  # multiplication sign
+    "\u00f7": "/",  # division sign
+    "\u00ac": "!",  # not sign
+    "\u00b1": "+/-",  # plus-minus sign
+    "\u00b5": "u",  # micro sign
+    "\u00a9": "(c)",  # copyright
+    "\u00ae": "(R)",  # registered
+    "\u2122": "(TM)",  # trademark
+    "\u2713": "Y",  # check mark
+    "\u2714": "Y",  # heavy check mark
+    "\u2717": "X",  # ballot X
+    "\u2718": "X",  # heavy ballot X
+    # Math / arrows
+    "\u03c0": "pi",  # pi
+    "\u00b9": "1",  # superscript one
+    "\u221a": "sqrt",  # square root
+    "\u221e": "inf",  # infinity
+    "\u2248": "~=",  # approximately equal
+    "\u2260": "!=",  # not equal
+    "\u2264": "<=",  # less-than or equal
+    "\u2265": ">=",  # greater-than or equal
+    "\u2190": "<-",  # left arrow
+    "\u2192": "->",  # right arrow
+}
+
+
+def write_text_preserve_newlines(path: Path, text: str) -> None:
+    with path.open("w", encoding="utf-8", newline="") as f:
+        f.write(text)
+
+
+def main() -> int:
+    had_error = False
+    for raw_path in sys.argv[1:]:
+
+        # Read the file
+        path = Path(raw_path)
+        try:
+            data = path.read_bytes()
+        except UnicodeDecodeError as exc:
+            print(f"{path}: not valid UTF-8 ({exc})", file=sys.stderr)
+            had_error = True
+            continue
+        except OSError as exc:
+            print(f"{path}: failed to read file ({exc})", file=sys.stderr)
+            had_error = True
+            continue
+
+        # If ASCII-only, no decoding or detailed scan.
+        if data.isascii():
+            continue
+
+        # Contains unicode, so decode it
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            print(f"{path}: not valid UTF-8 ({exc})", file=sys.stderr)
+            had_error = True
+            continue
+
+        # Fix each line with explicit replacements first, then Unicode normalization.
+        changed = False
+        unresolved_lines: list[int] = []
+        lines = text.splitlines(keepends=True)
+        fixed_lines: list[str] = []
+        for line_no, line in enumerate(lines, start=1):
+            replaced = line
+            for src, dst in REPLACEMENTS.items():
+                replaced = replaced.replace(src, dst)
+            normalized = unicodedata.normalize("NFKD", replaced)
+            fixed_line = normalized.encode("ascii", "ignore").decode("ascii")
+            if fixed_line != line:
+                changed = True
+                print(
+                    f"{path}:{line_no}: replaced non-ASCII characters with ASCII equivalents",
+                    file=sys.stderr,
+                )
+            if any(ord(ch) > 127 for ch in normalized):
+                unresolved_lines.append(line_no)
+
+            fixed_lines.append(fixed_line)
+
+        # If changes, write out the fixed file
+        if changed:
+            write_text_preserve_newlines(path, "".join(fixed_lines))
+
+        # If any lines still contain non-ASCII after fixing, report them as errors.
+        for line_no in unresolved_lines:
+            print(
+                f"{path}:{line_no}: line still contains non-ASCII characters after automatic fixing",
+                file=sys.stderr,
+            )
+            had_error = True
+
+    return 1 if had_error else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Add `check_ascii_hook.py` script for removing unicode characters from source files
- Add check to pre-commit
- Fix existing files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an ASCII source validation step to the development workflow to enforce ASCII-only characters in source and docs.
  * Standardized punctuation and arrow/multiplication glyphs across comments, docstrings, and test text to ASCII-friendly equivalents for consistent cross-platform rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->