### PR TITLE
Add SGL_ENUM_FLAGS_INFO

### DIFF
--- a/src/sgl/core/data_struct.h
+++ b/src/sgl/core/data_struct.h
@@ -108,7 +108,7 @@ public:
         default_ = 4,
     };
 
-    SGL_ENUM_INFO(
+    SGL_ENUM_FLAGS_INFO(
         Flags,
         {
             {Flags::none, "none"},

--- a/src/sgl/core/enum.h
+++ b/src/sgl/core/enum.h
@@ -23,6 +23,7 @@ template<typename T>
 concept is_enum_info = requires(T v) {
     { v.name } -> std::same_as<const char* const&>;
     { v.items[0] } -> std::same_as<const std::pair<typename T::enum_type, const char*>&>;
+    { T::is_flags } -> std::same_as<const bool&>;
 };
 
 template<typename T>
@@ -165,11 +166,34 @@ namespace detail {
  *     { Foo::B, "B" },
  *     { Foo::C, "C" },
  * })
+ *
+ * For flag enums (bitwise combinable), use SGL_ENUM_FLAGS_INFO instead.
  */
 #define SGL_ENUM_INFO(T, ...)                                                                                          \
     struct T##_info {                                                                                                  \
         using enum_type = T;                                                                                           \
         static constexpr const char* name{#T};                                                                         \
+        static constexpr bool is_flags{false};                                                                         \
+        static constexpr std::array<std::pair<T, const char*>, std::size<std::pair<T, const char*>>(__VA_ARGS__)>      \
+            items{__VA_ARGS__};                                                                                        \
+    };
+
+/**
+ * Define enum information for a flags enum (bitwise combinable values).
+ * Identical to SGL_ENUM_INFO but marks the enum as a flags type.
+ *
+ * enum class FooFlags { A = 1 << 0, B = 1 << 1 };
+ * SGL_ENUM_CLASS_OPERATORS(FooFlags);
+ * SGL_ENUM_FLAGS_INFO(FooFlags, {
+ *     { FooFlags::A, "A" },
+ *     { FooFlags::B, "B" },
+ * })
+ */
+#define SGL_ENUM_FLAGS_INFO(T, ...)                                                                                    \
+    struct T##_info {                                                                                                  \
+        using enum_type = T;                                                                                           \
+        static constexpr const char* name{#T};                                                                         \
+        static constexpr bool is_flags{true};                                                                          \
         static constexpr std::array<std::pair<T, const char*>, std::size<std::pair<T, const char*>>(__VA_ARGS__)>      \
             items{__VA_ARGS__};                                                                                        \
     };

--- a/src/sgl/core/input.h
+++ b/src/sgl/core/input.h
@@ -58,7 +58,7 @@ enum class KeyModifierFlags : uint32_t {
 };
 
 SGL_ENUM_CLASS_OPERATORS(KeyModifierFlags);
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     KeyModifierFlags,
     {
         {KeyModifierFlags::none, "none"},

--- a/src/sgl/device/formats.h
+++ b/src/sgl/device/formats.h
@@ -245,7 +245,7 @@ enum class FormatChannels : uint32_t {
 };
 
 SGL_ENUM_CLASS_OPERATORS(FormatChannels);
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     FormatChannels,
     {
         {FormatChannels::none, "none"},
@@ -364,7 +364,7 @@ enum class FormatSupport : uint32_t {
 };
 SGL_ENUM_CLASS_OPERATORS(FormatSupport);
 
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     FormatSupport,
     {
         {FormatSupport::none, "none"},

--- a/src/sgl/device/raytracing.h
+++ b/src/sgl/device/raytracing.h
@@ -32,7 +32,7 @@ enum class AccelerationStructureGeometryFlags : uint32_t {
 };
 
 SGL_ENUM_CLASS_OPERATORS(AccelerationStructureGeometryFlags);
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     AccelerationStructureGeometryFlags,
     {
         {AccelerationStructureGeometryFlags::none, "none"},
@@ -53,7 +53,7 @@ enum class AccelerationStructureInstanceFlags : uint32_t {
 };
 
 SGL_ENUM_CLASS_OPERATORS(AccelerationStructureInstanceFlags);
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     AccelerationStructureInstanceFlags,
     {
         {AccelerationStructureInstanceFlags::none, "none"},
@@ -212,7 +212,7 @@ enum class AccelerationStructureBuildFlags : uint32_t {
 };
 
 SGL_ENUM_CLASS_OPERATORS(AccelerationStructureBuildFlags);
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     AccelerationStructureBuildFlags,
     {
         {AccelerationStructureBuildFlags::none, "none"},

--- a/src/sgl/device/resource.h
+++ b/src/sgl/device/resource.h
@@ -89,7 +89,7 @@ enum class BufferUsage : uint32_t {
 };
 SGL_ENUM_CLASS_OPERATORS(BufferUsage);
 
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     BufferUsage,
     {
         {BufferUsage::none, "none"},
@@ -125,7 +125,7 @@ enum class TextureUsage : uint32_t {
 };
 SGL_ENUM_CLASS_OPERATORS(TextureUsage);
 
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     TextureUsage,
     {
         {TextureUsage::none, "none"},

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -689,7 +689,7 @@ enum class RenderTargetWriteMask : uint8_t {
 };
 
 SGL_ENUM_CLASS_OPERATORS(RenderTargetWriteMask);
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     RenderTargetWriteMask,
     {
         {RenderTargetWriteMask::none, "none"},
@@ -795,7 +795,7 @@ enum class RayTracingPipelineFlags : uint8_t {
 };
 
 SGL_ENUM_CLASS_OPERATORS(RayTracingPipelineFlags);
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     RayTracingPipelineFlags,
     {
         {RayTracingPipelineFlags::none, "none"},

--- a/src/slangpy_ext/core/input.cpp
+++ b/src/slangpy_ext/core/input.cpp
@@ -10,7 +10,7 @@ SGL_PY_EXPORT(core_input)
 
     nb::sgl_enum<CursorMode>(m, "CursorMode", D(CursorMode));
     nb::sgl_enum<MouseButton>(m, "MouseButton", D(MouseButton));
-    nb::sgl_enum<KeyModifierFlags>(m, "KeyModifierFlags", D(KeyModifierFlags));
+    nb::sgl_enum_flags<KeyModifierFlags>(m, "KeyModifierFlags", D(KeyModifierFlags));
     nb::sgl_enum<KeyModifier>(m, "KeyModifier", D(KeyModifier));
     nb::sgl_enum<KeyCode>(m, "KeyCode", D(KeyCode));
 

--- a/src/slangpy_ext/nanobind.h
+++ b/src/slangpy_ext/nanobind.h
@@ -166,9 +166,10 @@ public:
 template<typename T>
 class sgl_enum_flags : public sgl_enum<T> {
 public:
+    static_assert(::sgl::has_enum_info<T>, "nanobind::sgl_enum_flags<> requires an enumeration type with infos!");
     static_assert(
-        std::is_same_v<T, decltype(std::declval<T>() & std::declval<T>())>,
-        "nanobind::sgl_enum_flags<> requires an enumeration type with bitwise operators!"
+        ::sgl::EnumInfo<T>::is_flags,
+        "nanobind::sgl_enum_flags<> requires an enumeration type registered with SGL_ENUM_FLAGS_INFO!"
     );
 
     using Base = sgl_enum<T>;

--- a/tests/sgl/core/test_enum.cpp
+++ b/tests/sgl/core/test_enum.cpp
@@ -28,7 +28,7 @@ enum class TestFlags {
 };
 SGL_ENUM_CLASS_OPERATORS(TestFlags);
 
-SGL_ENUM_INFO(
+SGL_ENUM_FLAGS_INFO(
     TestFlags,
     {
         {TestFlags::A, "A"},
@@ -59,6 +59,9 @@ SGL_ENUM_REGISTER(TestStruct::TestEnum);
 static_assert(has_enum_info<void> == false);
 static_assert(has_enum_info<::TestEnum> == true);
 static_assert(has_enum_info<TestStruct::TestEnum> == true);
+
+static_assert(!EnumInfo<::TestEnum>::is_flags);
+static_assert(EnumInfo<::TestFlags>::is_flags);
 
 TEST_CASE("enum_has_value")
 {


### PR DESCRIPTION
- Add `is_flags` on enum infos
- Add `SGL_ENUM_FLAGS_INFO` to register enum flag types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal enum metadata handling to improve consistency and type safety across the library's reflection utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->