### PR TITLE
Fix CUDA interop buffer race and add targeted CUDA↔graphics sync (#929)

### DIFF
--- a/slangpy/tests/slangpy_tests/test_torchintegration.py
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.py
@@ -727,5 +727,31 @@ def test_zero_size_dispatch(device_type: DeviceType):
     assert result.numel() == 0
 
 
+DIFF_SQUARE_SRC = r"""
+[Differentiable]
+float square(float x) { return x * x; }
+"""
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_diffpair_get_shape_grad_only(device_type: DeviceType):
+    """NativeTorchTensorMarshall::get_shape falls back to grad when primal=None.
+
+    Exercises the create_zeroed_interop_buffer path on non-CUDA devices.
+    Previously this caused a CUDA_ERROR_ILLEGAL_ADDRESS on the second
+    dispatch due to an async memset outliving the interop buffer (#929).
+    """
+    from slangpy.torchintegration import diff_pair
+
+    device = helpers.get_torch_device(device_type)
+    func = helpers.create_function_from_module(device, "square", DIFF_SQUARE_SRC)
+
+    grad = torch.ones(5, device="cuda", dtype=torch.float32)
+    pair = diff_pair(None, grad)
+
+    result = func(pair)
+    assert result is not None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/slangpy_tests/test_torchintegration.py
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.py
@@ -749,8 +749,10 @@ def test_diffpair_get_shape_grad_only(device_type: DeviceType):
     grad = torch.ones(5, device="cuda", dtype=torch.float32)
     pair = diff_pair(None, grad)
 
-    result = func(pair)
-    assert result is not None
+    result_1 = func(pair)
+    result_2 = func(pair)
+    assert result_1 is not None
+    assert result_2 is not None
 
 
 if __name__ == "__main__":

--- a/src/sgl/utils/slangpy.h
+++ b/src/sgl/utils/slangpy.h
@@ -429,7 +429,7 @@ public:
 
     /// Called by marshalls when they perform CUDA work on shared interop buffers
     /// (e.g. copy_to_buffer, memset_device_async). Records the CUDA stream so
-    /// that exec() can pass it to submit_command_buffer for CUDA↔graphics sync.
+    /// that exec() can pass it to submit_command_buffer for CUDA<->graphics sync.
     void mark_interop_cuda_stream(NativeHandle stream)
     {
         if (!m_interop_cuda_stream.is_valid())

--- a/src/sgl/utils/slangpy.h
+++ b/src/sgl/utils/slangpy.h
@@ -419,6 +419,7 @@ public:
     {
         m_call_shape = call_shape;
         m_cuda_stream = cuda_stream;
+        m_interop_cuda_stream = NativeHandle();
     }
 
     Device* device() const { return m_device.get(); }
@@ -426,11 +427,25 @@ public:
     CallMode call_mode() const { return m_call_mode; }
     const NativeHandle& cuda_stream() const { return m_cuda_stream; }
 
+    /// Called by marshalls when they perform CUDA work on shared interop buffers
+    /// (e.g. copy_to_buffer, memset_device_async). Records the CUDA stream so
+    /// that exec() can pass it to submit_command_buffer for CUDA↔graphics sync.
+    void mark_interop_cuda_stream(NativeHandle stream)
+    {
+        if (!m_interop_cuda_stream.is_valid())
+            m_interop_cuda_stream = stream;
+    }
+
+    /// Returns the CUDA stream recorded by a marshall for interop sync, or
+    /// an invalid handle if no interop CUDA work was done this dispatch.
+    const NativeHandle& interop_cuda_stream() const { return m_interop_cuda_stream; }
+
 private:
     ref<Device> m_device;
     Shape m_call_shape;
     CallMode m_call_mode;
     NativeHandle m_cuda_stream;
+    NativeHandle m_interop_cuda_stream;
 };
 
 } // namespace sgl::slangpy

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -975,9 +975,14 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
     }
 
     // If we created a temporary command encoder, we need to submit it.
+    // Use the interop CUDA stream recorded by marshalls (if any) so that
+    // submit_command_buffers enables CUDA↔graphics synchronization.
     uint64_t submit_id = 0;
     if (temp_command_encoder) {
-        submit_id = m_device->submit_command_buffer(temp_command_encoder->finish(), CommandQueueType::graphics, cuda_stream);
+        NativeHandle submit_cuda_stream = cuda_stream;
+        if (!submit_cuda_stream.is_valid())
+            submit_cuda_stream = context->interop_cuda_stream();
+        submit_id = m_device->submit_command_buffer(temp_command_encoder->finish(), CommandQueueType::graphics, submit_cuda_stream);
         command_encoder = nullptr;
     }
 

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -975,8 +975,9 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
     }
 
     // If we created a temporary command encoder, we need to submit it.
+    uint64_t submit_id = 0;
     if (temp_command_encoder) {
-        m_device->submit_command_buffer(temp_command_encoder->finish(), CommandQueueType::graphics, cuda_stream);
+        submit_id = m_device->submit_command_buffer(temp_command_encoder->finish(), CommandQueueType::graphics, cuda_stream);
         command_encoder = nullptr;
     }
 
@@ -993,6 +994,14 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
         auto rb_val = t[1];
         auto rb_data = t[2];
         bvr->python_type()->read_calldata(context, bvr.get(), rb_val, rb_data);
+    }
+
+    // On CUDA devices, temporary buffers in read_back (e.g. zeroed primal for
+    // diff_pair(None, grad)) are referenced by raw device address — the RHI has
+    // no ref to defer their deletion. Wait for the submit to finish so the GPU
+    // dispatch is complete before read_back goes out of scope and frees them.
+    if (submit_id && m_device->type() == DeviceType::cuda && nb::len(read_back) > 0) {
+        m_device->wait_for_submit(submit_id);
     }
 
     // Pack updated 'this' values back (skip if no args needed unpacking).

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -418,7 +418,7 @@ nb::object NativeCallData::find_torch_tensors_recurse(nb::object arg, nb::list& 
         // Read access from pre-built list
         if (access_idx >= m_autograd_access_list.size()) {
             throw std::runtime_error(
-                "Autograd access list index out of bounds — "
+                "Autograd access list index out of bounds - "
                 "argument structure doesn't match build-time bindings."
             );
         }
@@ -976,13 +976,17 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
 
     // If we created a temporary command encoder, we need to submit it.
     // Use the interop CUDA stream recorded by marshalls (if any) so that
-    // submit_command_buffers enables CUDA↔graphics synchronization.
+    // submit_command_buffers enables CUDA<->graphics synchronization.
     uint64_t submit_id = 0;
     if (temp_command_encoder) {
         NativeHandle submit_cuda_stream = cuda_stream;
         if (!submit_cuda_stream.is_valid())
             submit_cuda_stream = context->interop_cuda_stream();
-        submit_id = m_device->submit_command_buffer(temp_command_encoder->finish(), CommandQueueType::graphics, submit_cuda_stream);
+        submit_id = m_device->submit_command_buffer(
+            temp_command_encoder->finish(),
+            CommandQueueType::graphics,
+            submit_cuda_stream
+        );
         command_encoder = nullptr;
     }
 
@@ -1002,7 +1006,7 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
     }
 
     // On CUDA devices, temporary buffers in read_back (e.g. zeroed primal for
-    // diff_pair(None, grad)) are referenced by raw device address — the RHI has
+    // diff_pair(None, grad)) are referenced by raw device address -- the RHI has
     // no ref to defer their deletion. Wait for the submit to finish so the GPU
     // dispatch is complete before read_back goes out of scope and frees them.
     if (submit_id && m_device->type() == DeviceType::cuda && nb::len(read_back) > 0) {

--- a/src/slangpy_ext/utils/slangpytorchtensor.cpp
+++ b/src/slangpy_ext/utils/slangpytorchtensor.cpp
@@ -267,9 +267,9 @@ void NativeTorchTensorMarshall::ensure_binding_info_cached(
         // name here rather than re-deriving from binding access mode or vector type kind.
         //
         // Naming convention:
-        //   "RW" prefix → read-write (primal writable + readable, gradient rw)
-        //   "W"  prefix → write-only primal, read-only gradient
-        //   No prefix   → read-only primal, write-only gradient
+        //   "RW" prefix - read-write (primal writable + readable, gradient rw)
+        //   "W"  prefix - write-only primal, read-only gradient
+        //   No prefix   - read-only primal, write-only gradient
         std::string_view type_name = field.slang_type_layout()->getName();
         bool starts_rw = type_name.size() >= 2 && type_name[0] == 'R' && type_name[1] == 'W';
         bool starts_w = !type_name.empty() && type_name[0] == 'W' && !starts_rw;
@@ -279,9 +279,9 @@ void NativeTorchTensorMarshall::ensure_binding_info_cached(
 
         // Gradient needs copy-back when the gradient is writable (output).
         // This happens when the primal is readable (not write-only):
-        //   DiffTensor   → read primal, write grad → copy back grad
-        //   WDiffTensor  → write primal, read grad → no grad copy-back
-        //   RWDiffTensor → rw primal, rw grad      → copy back grad
+        //   DiffTensor   - read primal, write grad - copy back grad
+        //   WDiffTensor  - write primal, read grad - no grad copy-back
+        //   RWDiffTensor - rw primal, rw grad      - copy back grad
         bool primal_readable = !starts_w;
         m_cached_binding_info.needs_grad_copyback = m_cached_binding_info.has_grad_fields && primal_readable;
     }
@@ -401,8 +401,7 @@ void NativeTorchTensorMarshall::write_shader_cursor_pre_dispatch(
         // is complete before the buffer is freed.
         ref<Buffer> primal_zeroed_buffer;
         if (primal_info.data_ptr == nullptr && primal_info.numel > 0) {
-            size_t buffer_size
-                = static_cast<size_t>(primal_info.numel) * static_cast<size_t>(primal_info.element_size);
+            size_t buffer_size = static_cast<size_t>(primal_info.numel) * static_cast<size_t>(primal_info.element_size);
             if (buffer_size == 0)
                 buffer_size = static_cast<size_t>(primal_info.element_size);
 
@@ -496,8 +495,12 @@ void NativeTorchTensorMarshall::write_torch_tensor_fields(
             tvd.data = static_cast<uint64_t>(interop_buffer->device_address());
             // Recalculate strides as contiguous for the interop buffer copy
             Shape contiguous_strides = make_contiguous_strides(shape, info.element_size);
-            contiguous_strides
-                = apply_broadcast_stride_zeroing(contiguous_strides, shape, binding->transform(), context->call_shape());
+            contiguous_strides = apply_broadcast_stride_zeroing(
+                contiguous_strides,
+                shape,
+                binding->transform(),
+                context->call_shape()
+            );
             for (int i = 0; i < info.ndim && i < kSlangPyTensorViewMaxDim; i++)
                 tvd.strides[i] = static_cast<uint32_t>(contiguous_strides[i] * info.element_size);
         }
@@ -577,9 +580,9 @@ void NativeTorchTensorMarshall::write_shader_cursor_with_interop(
 ) const
 {
     // Record PyTorch's current CUDA stream on the context so that exec() can
-    // pass it to submit_command_buffer for CUDA↔graphics synchronization.
+    // pass it to submit_command_buffer for CUDA<->graphics synchronization.
     // Called after any CUDA work on shared interop buffers (copy_to_buffer,
-    // memset_device_async). Only needed once per dispatch — subsequent calls
+    // memset_device_async). Only needed once per dispatch -- subsequent calls
     // are no-ops if the stream is already recorded.
     auto mark_interop_stream = [&](int32_t device_index)
     {
@@ -641,7 +644,7 @@ void NativeTorchTensorMarshall::write_shader_cursor_with_interop(
     } else if (m_cached_binding_info.has_grad_fields && primal_info.numel > 0
                && context->device()->supports_cuda_interop()) {
         // Backward pass: output slot has grad but no primal. Shader still needs a valid
-        // primal buffer (DiffTensor layout). Create and zero — we have no tensor to copy from.
+        // primal buffer (DiffTensor layout). Create and zero -- we have no tensor to copy from.
         primal_interop_buffer = create_zeroed_interop_buffer(primal_info);
     }
 

--- a/src/slangpy_ext/utils/slangpytorchtensor.cpp
+++ b/src/slangpy_ext/utils/slangpytorchtensor.cpp
@@ -393,9 +393,35 @@ void NativeTorchTensorMarshall::write_shader_cursor_pre_dispatch(
             read_back
         );
     } else {
-        // CUDA device - direct pointer access
+        // CUDA device - direct pointer access.
+        // When primal is None (backward pass, grad-only diff_pair), allocate a
+        // zeroed buffer so the shader has a valid device address instead of null.
+        // The buffer is stored in read_back; exec() will wait_for_submit on CUDA
+        // devices before read_back goes out of scope, ensuring the GPU dispatch
+        // is complete before the buffer is freed.
+        ref<Buffer> primal_zeroed_buffer;
+        if (primal_info.data_ptr == nullptr && primal_info.numel > 0) {
+            size_t buffer_size
+                = static_cast<size_t>(primal_info.numel) * static_cast<size_t>(primal_info.element_size);
+            if (buffer_size == 0)
+                buffer_size = static_cast<size_t>(primal_info.element_size);
+
+            primal_zeroed_buffer = context->device()->create_buffer({
+                .size = buffer_size,
+                .struct_size = static_cast<size_t>(primal_info.element_size),
+                .usage = BufferUsage::unordered_access | BufferUsage::shader_resource,
+                .default_state = ResourceState::shader_resource,
+            });
+            DeviceAddress addr = primal_zeroed_buffer->device_address();
+            if (addr && buffer_size > 0) {
+                CUstream stream = context->cuda_stream().is_valid()
+                    ? reinterpret_cast<CUstream>(context->cuda_stream().value())
+                    : nullptr;
+                cuda::memset_device_async(reinterpret_cast<uint8_t*>(addr), 0, buffer_size, stream);
+            }
+        }
+
         if (!m_cached_binding_info.has_grad_fields) {
-            // Flat structure - write directly to primal offsets
             write_torch_tensor_fields(
                 context,
                 binding,
@@ -403,10 +429,9 @@ void NativeTorchTensorMarshall::write_shader_cursor_pre_dispatch(
                 base_address,
                 m_cached_binding_info.primal,
                 primal_info,
-                nullptr
+                primal_zeroed_buffer.get()
             );
         } else {
-            // Differentiated structure - write primal, then gradients
             write_torch_tensor_fields(
                 context,
                 binding,
@@ -414,10 +439,9 @@ void NativeTorchTensorMarshall::write_shader_cursor_pre_dispatch(
                 base_address,
                 m_cached_binding_info.primal,
                 primal_info,
-                nullptr
+                primal_zeroed_buffer.get()
             );
 
-            // Write gradient tensors if present
             if (has_grad && m_d_in && m_cached_binding_info.grad_in.is_valid) {
                 write_torch_tensor_fields(
                     context,
@@ -441,6 +465,12 @@ void NativeTorchTensorMarshall::write_shader_cursor_pre_dispatch(
                 );
             }
         }
+
+        if (primal_zeroed_buffer) {
+            nb::dict calldata;
+            calldata["_primal_interop_keepalive"] = nb::cast(primal_zeroed_buffer);
+            store_readback(binding, read_back, primal_value, calldata);
+        }
     }
 }
 
@@ -461,8 +491,16 @@ void NativeTorchTensorMarshall::write_torch_tensor_fields(
     strides = apply_broadcast_stride_zeroing(strides, shape, binding->transform(), context->call_shape());
 
     if (offsets.is_tensorview) {
-        // TensorView path: build TensorViewData struct and write via set_data()
         TensorViewData tvd = populate_tensorview_data(info, shape, strides);
+        if (interop_buffer) {
+            tvd.data = static_cast<uint64_t>(interop_buffer->device_address());
+            // Recalculate strides as contiguous for the interop buffer copy
+            Shape contiguous_strides = make_contiguous_strides(shape, info.element_size);
+            contiguous_strides
+                = apply_broadcast_stride_zeroing(contiguous_strides, shape, binding->transform(), context->call_shape());
+            for (int i = 0; i < info.ndim && i < kSlangPyTensorViewMaxDim; i++)
+                tvd.strides[i] = static_cast<uint32_t>(contiguous_strides[i] * info.element_size);
+        }
         shader_object->set_data(offsets.tensorview_offset, &tvd, sizeof(TensorViewData));
         return;
     }
@@ -649,35 +687,38 @@ void NativeTorchTensorMarshall::write_shader_cursor_with_interop(
         }
     }
 
-    // Store interop info for post-dispatch copy-back
+    // Always store interop buffers in read_back to extend their lifetime past the
+    // dispatch. Async CUDA operations (memset_device_async, copy_to_buffer) reference
+    // the buffer's CUDA-mapped memory. If the buffer is destroyed before the stream
+    // drains, cuMemFree tears down the mapping while work is in flight, corrupting
+    // the CUDA context. Storing refs in read_back keeps buffers alive until after
+    // submit_command_buffers and the read_back loop complete.
     size_t primal_buffer_size = static_cast<size_t>(primal_info.numel) * static_cast<size_t>(primal_info.element_size);
     size_t grad_buffer_size = static_cast<size_t>(grad_info.numel) * static_cast<size_t>(grad_info.element_size);
 
-    // Primal: use cached flag and only copy back when we have a real tensor (primal_info.data_ptr).
-    // When we created a zeroed buffer for backward output slot (no primal), do not copy back.
     bool needs_primal_copyback = m_cached_binding_info.needs_primal_copyback && primal_info.numel > 0
         && primal_interop_buffer && primal_info.data_ptr != nullptr;
     bool needs_grad_copyback
         = m_cached_binding_info.needs_grad_copyback && has_grad && grad_info.numel > 0 && grad_interop_buffer;
 
-    if (needs_primal_copyback || needs_grad_copyback) {
+    if (primal_interop_buffer || grad_interop_buffer) {
         nb::dict calldata;
 
-        // Store primal interop info if needed
         if (needs_primal_copyback) {
             calldata["_interop_buffer"] = nb::cast(primal_interop_buffer);
             calldata["_buffer_size"] = primal_buffer_size;
+        } else if (primal_interop_buffer) {
+            calldata["_primal_interop_keepalive"] = nb::cast(primal_interop_buffer);
         }
 
-        // Store grad interop info if needed
         if (needs_grad_copyback) {
             calldata["_grad_interop_buffer"] = nb::cast(grad_interop_buffer);
             calldata["_grad_buffer_size"] = grad_buffer_size;
             calldata["_grad_value"] = grad_value;
+        } else if (grad_interop_buffer) {
+            calldata["_grad_interop_keepalive"] = nb::cast(grad_interop_buffer);
         }
 
-        // Store using standard read_back format: (binding, value, calldata)
-        // Use primal_value as the main value (for backward compatibility)
         store_readback(binding, read_back, primal_value, calldata);
     }
 }

--- a/src/slangpy_ext/utils/slangpytorchtensor.cpp
+++ b/src/slangpy_ext/utils/slangpytorchtensor.cpp
@@ -576,8 +576,21 @@ void NativeTorchTensorMarshall::write_shader_cursor_with_interop(
     nb::list read_back
 ) const
 {
-    // Helper: create interop buffer with given info. If tensor_value has data, copy from it;
-    // otherwise (e.g. backward pass output slot, primal is None) leave buffer uninitialized.
+    // Record PyTorch's current CUDA stream on the context so that exec() can
+    // pass it to submit_command_buffer for CUDA↔graphics synchronization.
+    // Called after any CUDA work on shared interop buffers (copy_to_buffer,
+    // memset_device_async). Only needed once per dispatch — subsequent calls
+    // are no-ops if the stream is already recorded.
+    auto mark_interop_stream = [&](int32_t device_index)
+    {
+        if (context->interop_cuda_stream().is_valid())
+            return;
+        void* stream_ptr = TorchBridge::instance().get_current_cuda_stream(device_index);
+        context->mark_interop_cuda_stream(
+            NativeHandle(rhi::NativeHandle(rhi::NativeHandleType::CUstream, reinterpret_cast<uint64_t>(stream_ptr)))
+        );
+    };
+
     auto create_interop_buffer_from_tensor
         = [&](nb::object tensor_value, const TensorBridgeInfo& info, bool writable) -> ref<Buffer>
     {
@@ -593,12 +606,11 @@ void NativeTorchTensorMarshall::write_shader_cursor_with_interop(
         });
         if (info.numel > 0 && info.data_ptr != nullptr) {
             TorchBridge::instance().copy_to_buffer(tensor_value, interop_buffer->cuda_memory(), buffer_size);
+            mark_interop_stream(info.device_index);
         }
         return interop_buffer;
     };
 
-    // Helper: create interop buffer from shape/size only and zero it. Used when there is no
-    // tensor to copy from (e.g. backward pass output slot has grad but no primal).
     auto create_zeroed_interop_buffer = [&](const TensorBridgeInfo& info) -> ref<Buffer>
     {
         size_t buffer_size = static_cast<size_t>(info.numel) * static_cast<size_t>(info.element_size);
@@ -617,6 +629,7 @@ void NativeTorchTensorMarshall::write_shader_cursor_with_interop(
                 ? reinterpret_cast<CUstream>(context->cuda_stream().value())
                 : nullptr;
             cuda::memset_device_async(static_cast<uint8_t*>(cuda_ptr), 0, buffer_size, stream);
+            mark_interop_stream(info.device_index);
         }
         return interop_buffer;
     };


### PR DESCRIPTION
## Summary

- **Fix interop buffer lifetime race**: `diff_pair(None, grad)` caused `CUDA_ERROR_ILLEGAL_ADDRESS` because zeroed interop buffers were destroyed before async CUDA work completed. Now always store interop buffer refs in `read_back` to extend lifetime past the dispatch.
- **Fix CUDA direct path null-pointer crash**: On CUDA devices, `diff_pair(None, grad)` wrote a null device address into the shader. Now allocates a zeroed buffer and waits on the submit fence before freeing it.
- **Add targeted CUDA↔graphics synchronization**: Marshalls that perform CUDA work on shared interop buffers (via `copy_to_buffer` / `memset_device_async`) now record PyTorch's current CUDA stream on the `CallContext`. `exec()` passes this stream to `submit_command_buffer`, activating the existing `sync_to_cuda` / `sync_to_device` fence mechanisms only when needed.

Closes #929

## Changes

| File | What |
|------|------|
| `slangpytorchtensor.cpp` | Interop buffer keepalive in `read_back`; zeroed buffer for CUDA direct path; `mark_interop_stream` to record PyTorch's CUDA stream; fix `TensorView` path to use interop buffer address |
| `slangpy.cpp` | Capture `submit_id`; `wait_for_submit` on CUDA when `read_back` non-empty; pass interop CUDA stream to `submit_command_buffer` |
| `slangpy.h` | Add `mark_interop_cuda_stream()` / `interop_cuda_stream()` to `CallContext` |
| `test_torchintegration.py` | Add `test_diffpair_get_shape_grad_only` reproducer |

## Test plan

- [x] `test_diffpair_get_shape_grad_only` — all 4 variants (native/fallback x vulkan/cuda) pass
- [x] Full torch integration suite — 334 passed, 84 skipped, 0 failed
- [x] No runtime regression (625s, same as baseline)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled gradient-only differentiation support for PyTorch–Slang interop.

* **Bug Fixes**
  * Prevented premature deallocation of temporary CUDA/graphics buffers during queued GPU work.
  * Improved CUDA stream selection and fallback for command submissions.
  * Ensured temporary buffer lifetimes cover async dispatch and read-back flows.

* **Tests**
  * Added tests validating gradient-only computation behavior across device types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->