### PR TITLE
Remove dead NativeTorchTensorDiffPair::read_signature override

### DIFF
--- a/src/slangpy_ext/utils/slangpytorchtensor.cpp
+++ b/src/slangpy_ext/utils/slangpytorchtensor.cpp
@@ -159,41 +159,6 @@ namespace {
 
 } // anonymous namespace
 
-// NativeTorchTensorDiffPair implementation
-
-void NativeTorchTensorDiffPair::read_signature(SignatureBuilder* builder) const
-{
-    // Write signature that combines both primal and grad tensor signatures
-    // This ensures that different primal/grad combinations get different cache keys
-    char buffer[128];
-
-    *builder << "TorchDiffPair\n";
-
-    // Add primal signature
-    // get_signature() returns 0 on success, non-zero on failure (does not throw)
-    if (!primal.is_none()) {
-        if (TorchBridge::instance().get_signature(primal.ptr(), buffer, sizeof(buffer)) == 0) {
-            *builder << "primal:" << buffer << "\n";
-        } else {
-            *builder << "primal:none\n";
-        }
-    } else {
-        *builder << "primal:none\n";
-    }
-
-    // Add grad signature
-    if (!grad.is_none()) {
-        if (TorchBridge::instance().get_signature(grad.ptr(), buffer, sizeof(buffer)) == 0) {
-            *builder << "grad:" << buffer << "\n";
-        } else {
-            *builder << "grad:none\n";
-        }
-    } else {
-        *builder << "grad:none\n";
-    }
-}
-
-
 NativeTorchTensorMarshall::NativeTorchTensorMarshall(
     int dims,
     bool writable,

--- a/src/slangpy_ext/utils/slangpytorchtensor.h
+++ b/src/slangpy_ext/utils/slangpytorchtensor.h
@@ -58,9 +58,6 @@ public:
     /// True if this is an input tensor, false if it's an output tensor.
     /// Determines which saved tensor list to index into.
     bool is_input = true;
-
-    /// Read signature for cache key generation
-    void read_signature(SignatureBuilder* builder) const override;
 };
 
 /// Native marshall for torch.Tensor objects.


### PR DESCRIPTION
Fixes #923

The `read_signature(SignatureBuilder*)` override on `NativeTorchTensorDiffPair` was never called from `get_value_signature` because DiffPair objects are created AFTER the cache key signature is built. The call ordering has been this way since the override was first added (`73473aa2`):

1. `get_args_signature(builder, args, kwargs)` — signature built from raw torch tensors
2. `if is_torch_autograd()` → `find_torch_tensors(args, kwargs)` — DiffPairs created here

The cache key from the raw tensor (dtype, shape, strides) is sufficient for kernel selection. DiffPair primal/grad configuration only affects dispatch-time data binding, not which kernel gets compiled.

Removes the dead override (-38 lines).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed signature-based cache key generation functionality for native torch tensor diff pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->