### PR TITLE
Change missing slangpy-torch warning to error with opt-in fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ Repository = "https://github.com/shader-slang/slangpy"
 Issues = "https://github.com/shader-slang/slangpy/issues"
 Changelog = "https://slangpy.shader-slang.org/en/latest/changelog.html"
 
+[project.optional-dependencies]
+torch = ["slangpy-torch>=0.7.0"]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -23,6 +23,7 @@ from slangpy import (
     DeviceType,
     TypeConformance,
     is_torch_bridge_using_fallback,
+    get_torch_bridge_fallback_reason,
 )
 from slangpy.bindings import (
     BindContext,
@@ -160,20 +161,39 @@ class CallData(NativeCallData):
                 import torch
                 import slangpy.torchintegration.torchtensormarshall  # type: ignore (Registers torch.Tensor handler)
 
-                # Warn once if the slangpy_torch bridge is not installed (using Python fallback)
-                global _torch_bridge_warned
-                if not _torch_bridge_warned:
-                    if is_torch_bridge_using_fallback():
-                        import warnings
+                # Error if slangpy-torch native bridge is not available (unless fallback opted in)
+                if is_torch_bridge_using_fallback():
+                    allow_fallback = os.environ.get("SLANGPY_ALLOW_TORCH_FALLBACK", "").lower() in (
+                        "true",
+                        "1",
+                    )
 
-                        warnings.warn(
-                            "PyTorch tensors detected but slangpy_torch is not installed. "
-                            "Using slower Python fallback for tensor metadata extraction. "
-                            "Install slangpy_torch for better performance: pip install slangpy_torch",
-                            UserWarning,
-                            stacklevel=6,  # Point to user's call site
-                        )
-                    _torch_bridge_warned = True
+                    if allow_fallback:
+                        global _torch_bridge_warned
+                        if not _torch_bridge_warned:
+                            import warnings
+
+                            warnings.warn(
+                                "slangpy-torch native bridge not available. Using slower Python fallback. "
+                                "Install slangpy-torch for better performance: pip install slangpy[torch]",
+                                UserWarning,
+                                stacklevel=6,
+                            )
+                            _torch_bridge_warned = True
+                    else:
+                        reason = get_torch_bridge_fallback_reason()
+                        if reason == "incompatible":
+                            raise RuntimeError(
+                                "slangpy-torch is installed but has an incompatible version.\n"
+                                "Upgrade with: pip install --upgrade slangpy-torch --no-build-isolation\n"
+                                "To use the slower Python fallback, set SLANGPY_ALLOW_TORCH_FALLBACK=1"
+                            )
+                        else:
+                            raise RuntimeError(
+                                "PyTorch tensors detected but slangpy-torch is not installed.\n"
+                                "Install with: pip install slangpy[torch]\n"
+                                "To use the slower Python fallback, set SLANGPY_ALLOW_TORCH_FALLBACK=1"
+                            )
 
                 self.torch_integration = True
                 self.torch_autograd = autograd

--- a/slangpy/testing/plugin.py
+++ b/slangpy/testing/plugin.py
@@ -142,10 +142,11 @@ def torch_bridge_mode(request: pytest.FixtureRequest):
     try:
         if mode == "fallback":
             spy.set_torch_bridge_python_fallback(True)
+            os.environ["SLANGPY_ALLOW_TORCH_FALLBACK"] = "1"
         else:
             spy.set_torch_bridge_python_fallback(False)
 
         yield mode
     finally:
-        # Always restore the original state
         spy.set_torch_bridge_python_fallback(was_fallback)
+        os.environ.pop("SLANGPY_ALLOW_TORCH_FALLBACK", None)

--- a/src/slangpy_ext/utils/torch_bridge.cpp
+++ b/src/slangpy_ext/utils/torch_bridge.cpp
@@ -126,6 +126,13 @@ bool is_torch_bridge_using_fallback()
     return TorchBridge::instance().is_using_fallback();
 }
 
+/// Get the reason the native bridge is not available.
+/// @return "missing" (not installed), "incompatible" (wrong version), or "" (available).
+std::string get_torch_bridge_fallback_reason()
+{
+    return TorchBridge::instance().fallback_reason();
+}
+
 /// Force use of Python fallback for torch bridge operations.
 /// @param force If true, force Python fallback mode.
 void set_torch_bridge_python_fallback(bool force)
@@ -275,6 +282,12 @@ SGL_PY_EXPORT(utils_torch_bridge)
     m.def("is_torch_bridge_available", &is_torch_bridge_available, D_NA(is_torch_bridge_available));
 
     m.def("is_torch_bridge_using_fallback", &is_torch_bridge_using_fallback, D_NA(is_torch_bridge_using_fallback));
+
+    m.def(
+        "get_torch_bridge_fallback_reason",
+        &get_torch_bridge_fallback_reason,
+        D_NA(get_torch_bridge_fallback_reason)
+    );
 
     m.def(
         "set_torch_bridge_python_fallback",

--- a/src/slangpy_ext/utils/torch_bridge.h
+++ b/src/slangpy_ext/utils/torch_bridge.h
@@ -110,10 +110,12 @@ public:
                 if (m_api->api_version != TENSOR_BRIDGE_API_VERSION
                     || m_api->info_struct_size != sizeof(TensorBridgeInfo)) {
                     m_api = nullptr;
+                    m_fallback_reason = "incompatible";
                 }
             } catch (...) {
                 // slangpy_torch not available, will use Python fallback lazily
                 m_api = nullptr;
+                m_fallback_reason = "missing";
             }
 
             // Note: Python fallback is now initialized lazily on first use,
@@ -142,6 +144,9 @@ public:
     /// Check if using Python fallback mode.
     /// @return True if using Python fallback instead of native API.
     bool is_using_fallback() const { return m_force_python_fallback || (m_api == nullptr && m_torch_available); }
+
+    /// Why the native bridge is not available: "missing", "incompatible", or "" (available/forced).
+    const std::string& fallback_reason() const { return m_fallback_reason; }
 
     /// Force use of Python fallback even if native is available.
     /// @param force If true, force Python fallback mode.
@@ -616,6 +621,7 @@ private:
 
     // Fallback state (mutable for lazy initialization in const methods)
     bool m_force_python_fallback = false;
+    std::string m_fallback_reason; // "missing", "incompatible", or "" (native available)
     mutable bool m_fallback_initialized = false;
 
     // Cached Python objects (module and function handles)


### PR DESCRIPTION
Fixes #900
- Raise `RuntimeError` when torch tensors are used without `slangpy-torch` installed (was a `UserWarning` that was easy to miss)
- Differentiate between "missing" and "incompatible" `slangpy-torch` with tailored error messages
- Set `SLANGPY_ALLOW_TORCH_FALLBACK=1` to opt into the slower Python fallback
- Add `slangpy[torch]` optional dependency group in `pyproject.toml` (installs `slangpy-torch>=0.7.0`)
- Expose `get_torch_bridge_fallback_reason()` from the native layer to Python