### PR TITLE
Fix aarch64 wheel build: override nanothread -march=native under QEMU

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,16 +44,11 @@ jobs:
         include:
           # Specify runners
           - { os: windows, runs-on: [windows-latest] }
-          - { os: linux, runs-on: [ubuntu-latest] }
+          - { os: linux, platform: x86_64, runs-on: [ubuntu-latest] }
+          - { os: linux, platform: aarch64, runs-on: [ubuntu-24.04-arm] }
           - { os: macos, runs-on: [macos-latest] }
 
     steps:
-      - name: Set up QEMU
-        if: matrix.os == 'linux' && matrix.platform == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -53,6 +53,12 @@ endif()
 # nanothread
 
 set(NANOTHREAD_STATIC ON)
+# Override nanothread's default -march=native on Linux aarch64 to avoid assembler
+# errors when building under QEMU emulation (the host CPU may report extensions
+# that the container's toolchain doesn't support).
+if(SGL_LINUX AND SGL_ARCHITECTURE MATCHES "aarch64|arm64")
+    set(NANOTHREAD_NATIVE_FLAGS "-march=armv8-a" CACHE STRING "" FORCE)
+endif()
 add_subdirectory(nanothread)
 # Disable LTO for nanothread as this causes problems when linking with sgl.
 set_target_properties(nanothread PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE FALSE)


### PR DESCRIPTION
nanothread's cmake-defaults uses -march=native, which under QEMU aarch64 emulation expands to an architecture string with extensions (lse128, gcs) that the container toolchain's assembler doesn't support. Override with -march=armv8-a for portable aarch64 wheels.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized compilation settings for ARM64 Linux builds to ensure consistent native flags during build.
  * Updated CI to run Linux ARM64 wheel builds on a native ARM runner instead of using QEMU emulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->