### PR TITLE
Use ptrs for tensor storage (vulkan/metal)

### DIFF
--- a/slangpy/slang/atomics.slang
+++ b/slangpy/slang/atomics.slang
@@ -103,7 +103,7 @@ public extension<S : IAtomicAddable, T : ISizedArray<S, D>, let D : int> T : IAt
 // store a buffer of atomics, and where appropriate uses IAtomicAddable to define the atomic add operation.
 public extension<T: IAtomicAddable> StorageTraits<T>
 {
-#ifdef __TARGET_CUDA__
+#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__) && !defined(__TARGET_METAL__)
     public typealias AtomicBufferType = T*;
     // Stride-aware versions (stride parameter ignored on CUDA since it uses element indexing)
     public static void atomicAddWithStride(AtomicBufferType buffer, uint idx, uint byte_stride, T value) { T::atomicAdd(buffer, idx, value); }

--- a/slangpy/slang/atomics.slang
+++ b/slangpy/slang/atomics.slang
@@ -103,7 +103,7 @@ public extension<S : IAtomicAddable, T : ISizedArray<S, D>, let D : int> T : IAt
 // store a buffer of atomics, and where appropriate uses IAtomicAddable to define the atomic add operation.
 public extension<T: IAtomicAddable> StorageTraits<T>
 {
-#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__) && !defined(__TARGET_METAL__)
+#if defined(__TARGET_CUDA__) || defined(__TARGET_VULKAN__) || defined(__TARGET_METAL__)
     public typealias AtomicBufferType = T*;
     // Stride-aware versions (stride parameter ignored on CUDA since it uses element indexing)
     public static void atomicAddWithStride(AtomicBufferType buffer, uint idx, uint byte_stride, T value) { T::atomicAdd(buffer, idx, value); }

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -78,7 +78,7 @@ int _idx_vec<let N : int>(vector<int,N> index, int[N] stride) {
 
 public struct StorageTraits<T>
 {
-#if defined(__TARGET_CUDA__) || defined(__TARGET_VULKAN__)
+#if defined(__TARGET_CUDA__) || defined(__TARGET_VULKAN__) || defined(__TARGET_METAL__)
     public typealias BufferType = T*;
     public typealias RWBufferType = T*;
 #else

--- a/slangpy/slang/core.slang
+++ b/slangpy/slang/core.slang
@@ -78,7 +78,7 @@ int _idx_vec<let N : int>(vector<int,N> index, int[N] stride) {
 
 public struct StorageTraits<T>
 {
-#ifdef __TARGET_CUDA__
+#if defined(__TARGET_CUDA__) || defined(__TARGET_VULKAN__)
     public typealias BufferType = T*;
     public typealias RWBufferType = T*;
 #else

--- a/slangpy/slang/difftensor.slang
+++ b/slangpy/slang/difftensor.slang
@@ -478,7 +478,7 @@ public struct RWDiffTensor<T : IDifferentiable, let D : int> : IRWDiffTensor<T, 
 }
 
 // Bespoke loads for directly reading underlying structured buffers from tensor
-#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__)
+#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__) && !defined(__TARGET_METAL__)
 public extension<T: IDifferentiable, let D : int> DiffTensor<T, D> where T.Differential : IAtomicAddable
 {
     public void __slangpy_load(Context0D context, out StructuredBuffer<T> value)

--- a/slangpy/slang/difftensor.slang
+++ b/slangpy/slang/difftensor.slang
@@ -478,7 +478,7 @@ public struct RWDiffTensor<T : IDifferentiable, let D : int> : IRWDiffTensor<T, 
 }
 
 // Bespoke loads for directly reading underlying structured buffers from tensor
-#ifndef __TARGET_CUDA__
+#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__)
 public extension<T: IDifferentiable, let D : int> DiffTensor<T, D> where T.Differential : IAtomicAddable
 {
     public void __slangpy_load(Context0D context, out StructuredBuffer<T> value)

--- a/slangpy/slang/primaltensor.slang
+++ b/slangpy/slang/primaltensor.slang
@@ -342,7 +342,7 @@ public struct RWPrimalTensor<T : IDifferentiable, let D : int> : IRWDiffTensor<T
 }
 
 // Bespoke loads for directly reading underlying structured buffers from tensor
-#ifndef __TARGET_CUDA__
+#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__)
 public extension<T : IDifferentiable, let D : int> PrimalTensor<T, D> where T.Differential : IAtomicAddable
 {
     public void __slangpy_load(Context0D context, out StructuredBuffer<T> value)

--- a/slangpy/slang/primaltensor.slang
+++ b/slangpy/slang/primaltensor.slang
@@ -342,7 +342,7 @@ public struct RWPrimalTensor<T : IDifferentiable, let D : int> : IRWDiffTensor<T
 }
 
 // Bespoke loads for directly reading underlying structured buffers from tensor
-#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__)
+#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__) && !defined(__TARGET_METAL__)
 public extension<T : IDifferentiable, let D : int> PrimalTensor<T, D> where T.Differential : IAtomicAddable
 {
     public void __slangpy_load(Context0D context, out StructuredBuffer<T> value)

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -512,7 +512,7 @@ public extension<let D : int, TensorType : IWTensor<uint64_t, D>> TensorType
 }
 
 // Bespoke loads for directly reading underlying structured buffers from tensor
-#ifndef __TARGET_CUDA__
+#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__)
 public extension<T, let D: int> Tensor<T, D>
 {
     public void __slangpy_load(Context0D context, out StructuredBuffer<T> value)

--- a/slangpy/slang/tensor.slang
+++ b/slangpy/slang/tensor.slang
@@ -512,7 +512,7 @@ public extension<let D : int, TensorType : IWTensor<uint64_t, D>> TensorType
 }
 
 // Bespoke loads for directly reading underlying structured buffers from tensor
-#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__)
+#if !defined(__TARGET_CUDA__) && !defined(__TARGET_VULKAN__) && !defined(__TARGET_METAL__)
 public extension<T, let D: int> Tensor<T, D>
 {
     public void __slangpy_load(Context0D context, out StructuredBuffer<T> value)


### PR DESCRIPTION
Update the internal storage of tensors to use pointers for the Vulkan/Metal backends. This change allows tensors to be packed, enabling them for dynamic dispatch for the Vulkan/Metal backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified buffer/tensor handling across GPU backends (CUDA, Vulkan, Metal) for more consistent behavior.
  * Atomic operations on GPU backends now use byte-addressing stride handling for consistent cross-backend semantics.

* **Refactor**
  * Adjusted compile-time inclusion of bespoke tensor load extensions so Vulkan and Metal follow the same loading behavior as CUDA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->