### PR TITLE
Add ASTC format support to the format enumeration and info table

### DIFF
--- a/src/sgl/device/formats.cpp
+++ b/src/sgl/device/formats.cpp
@@ -103,6 +103,13 @@ static const FormatInfo s_format_infos[] = {
     {Format::bc6h_sfloat,           "bc6h_sfloat",              16,     3,      FormatType::float_,         false,  false,  true,       4,  4,      {128, 0, 0, 0  },   DXGI_FORMAT_BC6H_SF16,                  VK_FORMAT_BC6H_SFLOAT_BLOCK,        nullptr},
     {Format::bc7_unorm,             "bc7_unorm",                16,     4,      FormatType::unorm,          false,  false,  true,       4,  4,      {128, 0, 0, 0  },   DXGI_FORMAT_BC7_UNORM,                  VK_FORMAT_BC7_UNORM_BLOCK,          nullptr},
     {Format::bc7_unorm_srgb,        "bc7_unorm_srgb",           16,     4,      FormatType::unorm_srgb,     false,  false,  true,       4,  4,      {128, 0, 0, 0  },   DXGI_FORMAT_BC7_UNORM_SRGB,             VK_FORMAT_BC7_SRGB_BLOCK,           nullptr},
+
+    {Format::astc4x4_unorm,         "astc4x4_unorm",            16,     4,      FormatType::unorm,          false,  false,  true,       4,  4,      {128, 0, 0, 0  },   DXGI_FORMAT_UNKNOWN,                    VK_FORMAT_ASTC_4x4_UNORM_BLOCK,     nullptr},
+    {Format::astc4x4_unorm_srgb,    "astc4x4_unorm_srgb",       16,     4,      FormatType::unorm_srgb,     false,  false,  true,       4,  4,      {128, 0, 0, 0  },   DXGI_FORMAT_UNKNOWN,                    VK_FORMAT_ASTC_4x4_SRGB_BLOCK,      nullptr},
+    {Format::astc6x6_unorm,         "astc6x6_unorm",            16,     4,      FormatType::unorm,          false,  false,  true,       6,  6,      {128, 0, 0, 0  },   DXGI_FORMAT_UNKNOWN,                    VK_FORMAT_ASTC_6x6_UNORM_BLOCK,     nullptr},
+    {Format::astc6x6_unorm_srgb,    "astc6x6_unorm_srgb",       16,     4,      FormatType::unorm_srgb,     false,  false,  true,       6,  6,      {128, 0, 0, 0  },   DXGI_FORMAT_UNKNOWN,                    VK_FORMAT_ASTC_6x6_SRGB_BLOCK,      nullptr},
+    {Format::astc8x8_unorm,         "astc8x8_unorm",            16,     4,      FormatType::unorm,          false,  false,  true,       8,  8,      {128, 0, 0, 0  },   DXGI_FORMAT_UNKNOWN,                    VK_FORMAT_ASTC_8x8_UNORM_BLOCK,     nullptr},
+    {Format::astc8x8_unorm_srgb,    "astc8x8_unorm_srgb",       16,     4,      FormatType::unorm_srgb,     false,  false,  true,       8,  8,      {128, 0, 0, 0  },   DXGI_FORMAT_UNKNOWN,                    VK_FORMAT_ASTC_8x8_SRGB_BLOCK,      nullptr},
     // clang-format on
 };
 

--- a/src/sgl/device/formats.h
+++ b/src/sgl/device/formats.h
@@ -102,6 +102,13 @@ enum class Format : uint32_t {
     bc7_unorm = static_cast<uint32_t>(rhi::Format::BC7Unorm),
     bc7_unorm_srgb = static_cast<uint32_t>(rhi::Format::BC7UnormSrgb),
 
+    astc4x4_unorm = static_cast<uint32_t>(rhi::Format::ASTC4x4Unorm),
+    astc4x4_unorm_srgb = static_cast<uint32_t>(rhi::Format::ASTC4x4UnormSrgb),
+    astc6x6_unorm = static_cast<uint32_t>(rhi::Format::ASTC6x6Unorm),
+    astc6x6_unorm_srgb = static_cast<uint32_t>(rhi::Format::ASTC6x6UnormSrgb),
+    astc8x8_unorm = static_cast<uint32_t>(rhi::Format::ASTC8x8Unorm),
+    astc8x8_unorm_srgb = static_cast<uint32_t>(rhi::Format::ASTC8x8UnormSrgb),
+
     count,
 };
 
@@ -196,6 +203,12 @@ SGL_ENUM_INFO(
         {Format::bc7_unorm, "bc7_unorm"},
         {Format::bc7_unorm_srgb, "bc7_unorm_srgb"},
 
+        {Format::astc4x4_unorm, "astc4x4_unorm"},
+        {Format::astc4x4_unorm_srgb, "astc4x4_unorm_srgb"},
+        {Format::astc6x6_unorm, "astc6x6_unorm"},
+        {Format::astc6x6_unorm_srgb, "astc6x6_unorm_srgb"},
+        {Format::astc8x8_unorm, "astc8x8_unorm"},
+        {Format::astc8x8_unorm_srgb, "astc8x8_unorm_srgb"},
     }
 );
 SGL_ENUM_REGISTER(Format);


### PR DESCRIPTION
Add ASTC format enum, slang-rhi already supports it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ASTC compressed texture formats (4x4, 6x6, and 8x8 block sizes) in both standard and sRGB color space variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->