### PR TITLE
Replace Slang OperatorAddressOf `&` usage with `__getAddress`

### DIFF
--- a/slangpy/tests/slangpy_tests/test_modules.slang
+++ b/slangpy/tests/slangpy_tests/test_modules.slang
@@ -19,8 +19,8 @@ struct Material : IDifferentiable, IAtomicAddable {
 
     static void atomicAdd(This* buf, uint element, This value)
     {
-        float3::atomicAdd(&buf[element].color, 0, value.color);
-        float3::atomicAdd(&buf[element].emission, 0, value.emission);
+        float3::atomicAdd(__getAddress(buf[element].color), 0, value.color);
+        float3::atomicAdd(__getAddress(buf[element].emission), 0, value.emission);
     }
 };
 
@@ -75,10 +75,10 @@ struct Particle : IDifferentiable, IAtomicAddable {
 
     static void atomicAdd(This* buf, uint element, This value)
     {
-        float2::atomicAdd(&buf[element].position, 0, value.position);
-        float2::atomicAdd(&buf[element].velocity, 0, value.velocity);
-        float::atomicAdd(&buf[element].size, 0, value.size);
-        Material::atomicAdd(&buf[element].material, 0, value.material);
+        float2::atomicAdd(__getAddress(buf[element].position), 0, value.position);
+        float2::atomicAdd(__getAddress(buf[element].velocity), 0, value.velocity);
+        float::atomicAdd(__getAddress(buf[element].size), 0, value.size);
+        Material::atomicAdd(__getAddress(buf[element].material), 0, value.material);
     }
 }
 

--- a/slangpy/tests/slangpy_tests/test_pointers.py
+++ b/slangpy/tests/slangpy_tests/test_pointers.py
@@ -604,7 +604,7 @@ struct Test {
     int intvalue2;
 }
 void test_atomic_float_in_struct_access(int call_id, Test* buffer) {
-    Atomic<float>* cur = (Atomic<float>*) &buffer[call_id%10].value;
+    Atomic<float>* cur = (Atomic<float>*) __getAddress(buffer[call_id%10].value);
     cur.add(1.0f);
 }
 """,


### PR DESCRIPTION
For https://github.com/shader-slang/slang/issues/9148

This change replaces uses of `&` for getting addresses with `__getAddress`, in Slang code in the test files, since that use of `&` will be deprecated. This mirrors the similar replacements in Slang in https://github.com/shader-slang/slang/pull/10280, where the abilities of `__getAddress` were expanded to compensate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test cases for atomic operations to use refined address handling techniques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->