### PR TITLE
Add free-standing device API

### DIFF
--- a/slangpy/tests/device/test_device_api.py
+++ b/slangpy/tests/device/test_device_api.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+
+import slangpy as spy
+from slangpy.testing import helpers
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_push_pop_device(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    spy.push_device(device)
+    assert spy.current_device() is device
+    spy.pop_device()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_current_device_throws_when_empty(device_type: spy.DeviceType):
+    with pytest.raises(Exception, match="No current device"):
+        spy.current_device()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_pop_device_throws_when_empty(device_type: spy.DeviceType):
+    with pytest.raises(Exception, match="No device to pop"):
+        spy.pop_device()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_context_manager(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        assert spy.current_device() is device
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_context_manager_pops_on_exit(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        pass
+    with pytest.raises(Exception, match="No current device"):
+        spy.current_device()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_context_manager_pops_on_exception(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with pytest.raises(RuntimeError):
+        with device:
+            raise RuntimeError("test")
+    with pytest.raises(Exception, match="No current device"):
+        spy.current_device()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_nested_context_managers(device_type: spy.DeviceType):
+    device1 = helpers.get_device(device_type)
+    device2 = helpers.get_device(device_type, use_cache=False)
+    with device1:
+        assert spy.current_device() is device1
+        with device2:
+            assert spy.current_device() is device2
+        assert spy.current_device() is device1
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_create_buffer_with_context(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    if device_type == spy.DeviceType.cuda:
+        pytest.skip("CUDA does not support create_buffer with size")
+    with device:
+        buffer = spy.current_device().create_buffer(size=256)
+        assert buffer is not None
+        assert buffer.size == 256
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_context_manager_returns_device(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device as d:
+        assert d is device
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_free_create_buffer(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        # Test desc overload.
+        desc = spy.BufferDesc()
+        desc.size = 256
+        desc.usage = spy.BufferUsage.shader_resource
+        buffer = spy.create_buffer(desc)
+        assert buffer is not None
+        assert buffer.size == 256
+
+        # Test kwargs overload.
+        buffer2 = spy.create_buffer(size=512, usage=spy.BufferUsage.shader_resource)
+        assert buffer2 is not None
+        assert buffer2.size == 512
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_free_create_texture(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        # Test desc overload.
+        desc = spy.TextureDesc()
+        desc.type = spy.TextureType.texture_2d
+        desc.format = spy.Format.rgba8_unorm
+        desc.width = 64
+        desc.height = 64
+        desc.usage = spy.TextureUsage.shader_resource
+        texture = spy.create_texture(desc)
+        assert texture is not None
+        assert texture.width == 64
+        assert texture.height == 64
+
+        # Test kwargs overload.
+        texture2 = spy.create_texture(
+            type=spy.TextureType.texture_2d,
+            format=spy.Format.rgba8_unorm,
+            width=32,
+            height=32,
+            usage=spy.TextureUsage.shader_resource,
+        )
+        assert texture2 is not None
+        assert texture2.width == 32
+        assert texture2.height == 32
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_free_create_sampler(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        # Test desc overload.
+        sampler = spy.create_sampler(spy.SamplerDesc())
+        assert sampler is not None
+
+        # Test kwargs overload.
+        sampler2 = spy.create_sampler(
+            min_filter=spy.TextureFilteringMode.linear,
+            mag_filter=spy.TextureFilteringMode.linear,
+        )
+        assert sampler2 is not None
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_free_create_fence(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        # Test desc overload.
+        fence = spy.create_fence(spy.FenceDesc())
+        assert fence is not None
+
+        # Test kwargs overload.
+        fence2 = spy.create_fence(initial_value=0, shared=False)
+        assert fence2 is not None
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_free_create_command_encoder(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        encoder = spy.create_command_encoder()
+        assert encoder is not None
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_free_load_program(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+    with device:
+        program = spy.load_program(
+            module_name="test_device_api",
+            entry_point_names=["main"],
+        )
+        assert program is not None

--- a/slangpy/tests/device/test_device_api.py
+++ b/slangpy/tests/device/test_device_api.py
@@ -12,15 +12,13 @@ def empty_device_stack():
     saved = []
     while True:
         try:
-            saved.append(spy.current_device())
-            spy.pop_device()
+            saved.append(spy.pop_device())
         except Exception:
             break
     yield
     # Clean up anything the test left on the stack.
     while True:
         try:
-            spy.current_device()
             spy.pop_device()
         except Exception:
             break
@@ -30,7 +28,7 @@ def empty_device_stack():
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_push_pop_device(device_type: spy.DeviceType):
+def test_push_pop_device(device_type: spy.DeviceType, empty_device_stack: None):
     device = helpers.get_device(device_type)
     spy.push_device(device)
     assert spy.current_device() is device
@@ -113,7 +111,7 @@ def test_create_buffer_with_context(device_type: spy.DeviceType):
     if device_type == spy.DeviceType.cuda:
         pytest.skip("CUDA does not support create_buffer with size")
     with device:
-        buffer = spy.current_device().create_buffer(size=256)
+        buffer = spy.create_buffer(size=256)
         assert buffer is not None
         assert buffer.size == 256
 
@@ -227,7 +225,7 @@ def test_free_load_program(device_type: spy.DeviceType):
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_auto_push_on_create(device_type: spy.DeviceType):
-    """Device constructor auto-pushes onto thread-local stack (like cuCtxCreate)."""
+    """Device constructor auto-pushes onto thread-local stack."""
     device = helpers.get_device(device_type, use_cache=False)
     assert spy.current_device() is device
     device.close()
@@ -248,7 +246,7 @@ def test_auto_push_stacks(device_type: spy.DeviceType):
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_close_pops_if_on_top(device_type: spy.DeviceType, empty_device_stack: None):
-    """close() pops the device if it is current (like cuCtxDestroy)."""
+    """close() pops the device if it is current."""
     device = helpers.get_device(device_type, use_cache=False)
     assert spy.current_device() is device
     device.close()
@@ -257,8 +255,8 @@ def test_close_pops_if_on_top(device_type: spy.DeviceType, empty_device_stack: N
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_close_does_not_pop_if_not_on_top(device_type: spy.DeviceType):
-    """close() does NOT pop if device is not current (like cuCtxDestroy)."""
+def test_close_does_not_pop_if_not_on_top(device_type: spy.DeviceType, empty_device_stack: None):
+    """close() does NOT pop if device is not current."""
     device_a = helpers.get_device(device_type, use_cache=False)
     device_b = helpers.get_device(device_type, use_cache=False)
     # Stack = [A, B], current = B.
@@ -273,7 +271,7 @@ def test_close_does_not_pop_if_not_on_top(device_type: spy.DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_auto_push_with_context_manager(device_type: spy.DeviceType):
+def test_auto_push_with_context_manager(device_type: spy.DeviceType, empty_device_stack: None):
     """Auto-push + context manager stack correctly."""
     device = helpers.get_device(device_type, use_cache=False)
     # Stack = [device] from auto-push.

--- a/slangpy/tests/device/test_device_api.py
+++ b/slangpy/tests/device/test_device_api.py
@@ -12,27 +12,27 @@ def empty_device_stack():
     saved = []
     while True:
         try:
-            saved.append(spy.pop_device())
+            saved.append(spy.pop_current_device())
         except Exception:
             break
     yield
     # Clean up anything the test left on the stack.
     while True:
         try:
-            spy.pop_device()
+            spy.pop_current_device()
         except Exception:
             break
     # Restore original stack.
     for dev in reversed(saved):
-        spy.push_device(dev)
+        spy.push_current_device(dev)
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_push_pop_device(device_type: spy.DeviceType, empty_device_stack: None):
+def test_push_pop_current_device(device_type: spy.DeviceType, empty_device_stack: None):
     device = helpers.get_device(device_type)
-    spy.push_device(device)
+    spy.push_current_device(device)
     assert spy.current_device() is device
-    spy.pop_device()
+    spy.pop_current_device()
 
 
 def test_current_device_throws_when_empty(empty_device_stack: None):
@@ -40,9 +40,9 @@ def test_current_device_throws_when_empty(empty_device_stack: None):
         spy.current_device()
 
 
-def test_pop_device_throws_when_empty(empty_device_stack: None):
+def test_pop_current_device_throws_when_empty(empty_device_stack: None):
     with pytest.raises(Exception, match="No device to pop"):
-        spy.pop_device()
+        spy.pop_current_device()
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
@@ -53,7 +53,7 @@ def test_context_manager(device_type: spy.DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_context_manager_pops_on_exit(device_type: spy.DeviceType):
+def test_context_manager_pops_current_on_exit(device_type: spy.DeviceType):
     device = helpers.get_device(device_type)
     # Record stack state before with block.
     before_device = None
@@ -73,7 +73,7 @@ def test_context_manager_pops_on_exit(device_type: spy.DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_context_manager_pops_on_exception(device_type: spy.DeviceType):
+def test_context_manager_pops_current_on_exception(device_type: spy.DeviceType):
     device = helpers.get_device(device_type)
     # Record stack state before with block.
     before_device = None
@@ -103,17 +103,6 @@ def test_nested_context_managers(device_type: spy.DeviceType):
             assert spy.current_device() is device2
         assert spy.current_device() is device1
     device2.close()
-
-
-@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_create_buffer_with_context(device_type: spy.DeviceType):
-    device = helpers.get_device(device_type)
-    if device_type == spy.DeviceType.cuda:
-        pytest.skip("CUDA does not support create_buffer with size")
-    with device:
-        buffer = spy.create_buffer(size=256)
-        assert buffer is not None
-        assert buffer.size == 256
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
@@ -224,7 +213,7 @@ def test_free_load_program(device_type: spy.DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_auto_push_on_create(device_type: spy.DeviceType):
+def test_auto_push_current_on_create(device_type: spy.DeviceType):
     """Device constructor auto-pushes onto thread-local stack."""
     device = helpers.get_device(device_type, use_cache=False)
     assert spy.current_device() is device
@@ -232,20 +221,20 @@ def test_auto_push_on_create(device_type: spy.DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_auto_push_stacks(device_type: spy.DeviceType):
+def test_auto_push_current_stacks(device_type: spy.DeviceType):
     """Creating multiple devices stacks them; most recent is current."""
     device_a = helpers.get_device(device_type, use_cache=False)
     device_b = helpers.get_device(device_type, use_cache=False)
     assert spy.current_device() is device_b
-    spy.pop_device()
+    spy.pop_current_device()
     assert spy.current_device() is device_a
-    spy.pop_device()
+    spy.pop_current_device()
     device_b.close()
     device_a.close()
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_close_pops_if_on_top(device_type: spy.DeviceType, empty_device_stack: None):
+def test_close_pops_current_if_on_top(device_type: spy.DeviceType, empty_device_stack: None):
     """close() pops the device if it is current."""
     device = helpers.get_device(device_type, use_cache=False)
     assert spy.current_device() is device
@@ -255,7 +244,7 @@ def test_close_pops_if_on_top(device_type: spy.DeviceType, empty_device_stack: N
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_close_does_not_pop_if_not_on_top(device_type: spy.DeviceType, empty_device_stack: None):
+def test_close_does_not_pop_current_if_not_on_top(device_type: spy.DeviceType, empty_device_stack: None):
     """close() does NOT pop if device is not current."""
     device_a = helpers.get_device(device_type, use_cache=False)
     device_b = helpers.get_device(device_type, use_cache=False)
@@ -263,15 +252,15 @@ def test_close_does_not_pop_if_not_on_top(device_type: spy.DeviceType, empty_dev
     device_a.close()
     # A is not on top, so it stays in the stack (stale, matches CUDA).
     assert spy.current_device() is device_b
-    spy.pop_device()
+    spy.pop_current_device()
     # Now A (closed) is on top - same as CUDA stale context behavior.
     assert spy.current_device() is device_a
-    spy.pop_device()
+    spy.pop_current_device()
     device_b.close()
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_auto_push_with_context_manager(device_type: spy.DeviceType, empty_device_stack: None):
+def test_auto_push_current_with_context_manager(device_type: spy.DeviceType, empty_device_stack: None):
     """Auto-push + context manager stack correctly."""
     device = helpers.get_device(device_type, use_cache=False)
     # Stack = [device] from auto-push.

--- a/slangpy/tests/device/test_device_api.py
+++ b/slangpy/tests/device/test_device_api.py
@@ -244,7 +244,9 @@ def test_close_pops_current_if_on_top(device_type: spy.DeviceType, empty_device_
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_close_does_not_pop_current_if_not_on_top(device_type: spy.DeviceType, empty_device_stack: None):
+def test_close_does_not_pop_current_if_not_on_top(
+    device_type: spy.DeviceType, empty_device_stack: None
+):
     """close() does NOT pop if device is not current."""
     device_a = helpers.get_device(device_type, use_cache=False)
     device_b = helpers.get_device(device_type, use_cache=False)
@@ -260,7 +262,9 @@ def test_close_does_not_pop_current_if_not_on_top(device_type: spy.DeviceType, e
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_auto_push_current_with_context_manager(device_type: spy.DeviceType, empty_device_stack: None):
+def test_auto_push_current_with_context_manager(
+    device_type: spy.DeviceType, empty_device_stack: None
+):
     """Auto-push + context manager stack correctly."""
     device = helpers.get_device(device_type, use_cache=False)
     # Stack = [device] from auto-push.

--- a/slangpy/tests/device/test_device_api.py
+++ b/slangpy/tests/device/test_device_api.py
@@ -6,6 +6,29 @@ import slangpy as spy
 from slangpy.testing import helpers
 
 
+@pytest.fixture
+def empty_device_stack():
+    """Save and restore the device stack, providing an empty stack for the test."""
+    saved = []
+    while True:
+        try:
+            saved.append(spy.current_device())
+            spy.pop_device()
+        except Exception:
+            break
+    yield
+    # Clean up anything the test left on the stack.
+    while True:
+        try:
+            spy.current_device()
+            spy.pop_device()
+        except Exception:
+            break
+    # Restore original stack.
+    for dev in reversed(saved):
+        spy.push_device(dev)
+
+
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_push_pop_device(device_type: spy.DeviceType):
     device = helpers.get_device(device_type)
@@ -14,14 +37,12 @@ def test_push_pop_device(device_type: spy.DeviceType):
     spy.pop_device()
 
 
-@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_current_device_throws_when_empty(device_type: spy.DeviceType):
+def test_current_device_throws_when_empty(empty_device_stack: None):
     with pytest.raises(Exception, match="No current device"):
         spy.current_device()
 
 
-@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_pop_device_throws_when_empty(device_type: spy.DeviceType):
+def test_pop_device_throws_when_empty(empty_device_stack: None):
     with pytest.raises(Exception, match="No device to pop"):
         spy.pop_device()
 
@@ -36,20 +57,42 @@ def test_context_manager(device_type: spy.DeviceType):
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_context_manager_pops_on_exit(device_type: spy.DeviceType):
     device = helpers.get_device(device_type)
+    # Record stack state before with block.
+    before_device = None
+    try:
+        before_device = spy.current_device()
+    except Exception:
+        pass
     with device:
         pass
-    with pytest.raises(Exception, match="No current device"):
-        spy.current_device()
+    # Stack should be restored to pre-with state.
+    after_device = None
+    try:
+        after_device = spy.current_device()
+    except Exception:
+        pass
+    assert after_device is before_device
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_context_manager_pops_on_exception(device_type: spy.DeviceType):
     device = helpers.get_device(device_type)
+    # Record stack state before with block.
+    before_device = None
+    try:
+        before_device = spy.current_device()
+    except Exception:
+        pass
     with pytest.raises(RuntimeError):
         with device:
             raise RuntimeError("test")
-    with pytest.raises(Exception, match="No current device"):
-        spy.current_device()
+    # Stack should be restored to pre-with state.
+    after_device = None
+    try:
+        after_device = spy.current_device()
+    except Exception:
+        pass
+    assert after_device is before_device
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
@@ -61,6 +104,7 @@ def test_nested_context_managers(device_type: spy.DeviceType):
         with device2:
             assert spy.current_device() is device2
         assert spy.current_device() is device1
+    device2.close()
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
@@ -174,3 +218,83 @@ def test_free_load_program(device_type: spy.DeviceType):
             entry_point_names=["main"],
         )
         assert program is not None
+
+
+# ---------------------------------------------------------------------------
+# Device auto-push/pop tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_auto_push_on_create(device_type: spy.DeviceType):
+    """Device constructor auto-pushes onto thread-local stack (like cuCtxCreate)."""
+    device = helpers.get_device(device_type, use_cache=False)
+    assert spy.current_device() is device
+    device.close()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_auto_push_stacks(device_type: spy.DeviceType):
+    """Creating multiple devices stacks them; most recent is current."""
+    device_a = helpers.get_device(device_type, use_cache=False)
+    device_b = helpers.get_device(device_type, use_cache=False)
+    assert spy.current_device() is device_b
+    spy.pop_device()
+    assert spy.current_device() is device_a
+    spy.pop_device()
+    device_b.close()
+    device_a.close()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_close_pops_if_on_top(device_type: spy.DeviceType, empty_device_stack: None):
+    """close() pops the device if it is current (like cuCtxDestroy)."""
+    device = helpers.get_device(device_type, use_cache=False)
+    assert spy.current_device() is device
+    device.close()
+    with pytest.raises(Exception, match="No current device"):
+        spy.current_device()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_close_does_not_pop_if_not_on_top(device_type: spy.DeviceType):
+    """close() does NOT pop if device is not current (like cuCtxDestroy)."""
+    device_a = helpers.get_device(device_type, use_cache=False)
+    device_b = helpers.get_device(device_type, use_cache=False)
+    # Stack = [A, B], current = B.
+    device_a.close()
+    # A is not on top, so it stays in the stack (stale, matches CUDA).
+    assert spy.current_device() is device_b
+    spy.pop_device()
+    # Now A (closed) is on top - same as CUDA stale context behavior.
+    assert spy.current_device() is device_a
+    spy.pop_device()
+    device_b.close()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_auto_push_with_context_manager(device_type: spy.DeviceType):
+    """Auto-push + context manager stack correctly."""
+    device = helpers.get_device(device_type, use_cache=False)
+    # Stack = [device] from auto-push.
+    with device:
+        # Stack = [device, device].
+        assert spy.current_device() is device
+    # Stack = [device] after context manager pop.
+    assert spy.current_device() is device
+    device.close()
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_create_after_close(device_type: spy.DeviceType):
+    """After closing a device, creating a new one makes it current."""
+    device_a = helpers.get_device(device_type, use_cache=False)
+    assert spy.current_device() is device_a
+    device_a.close()
+    device_b = helpers.get_device(device_type, use_cache=False)
+    assert spy.current_device() is device_b
+    device_b.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/slangpy/tests/device/test_device_api.slang
+++ b/slangpy/tests/device/test_device_api.slang
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint3 tid: SV_DispatchThreadID)
+{
+}

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -43,6 +43,7 @@ namespace sgl {
 
 static std::vector<Device*> s_devices;
 static std::mutex s_devices_mutex;
+static thread_local std::vector<Device*> tls_device_stack;
 
 inline AdapterLUID from_rhi(const rhi::AdapterLUID& rhi_luid)
 {
@@ -391,6 +392,9 @@ Device::Device(const DeviceDesc& desc)
         std::lock_guard lock(s_devices_mutex);
         s_devices.push_back(this);
     }
+
+    // Auto-push device onto thread-local device stack (matches cuCtxCreate behavior).
+    push_device(this);
 }
 
 Device::~Device()
@@ -451,6 +455,10 @@ void Device::close()
 {
     if (m_closed)
         return;
+
+    // Pop device from thread-local stack if it's the current device (matches cuCtxDestroy behavior).
+    if (!tls_device_stack.empty() && tls_device_stack.back() == this)
+        pop_device();
 
     log_debug("Closing device {}", fmt::ptr(this));
 
@@ -1325,24 +1333,22 @@ std::array<NativeHandle, 3> get_cuda_current_context_native_handles()
 // Thread-local device stack
 // ---------------------------------------------------------------------------
 
-static thread_local std::vector<Device*> t_device_stack;
-
 void push_device(Device* device)
 {
     SGL_CHECK(device != nullptr, "Cannot push a null device.");
-    t_device_stack.push_back(device);
+    tls_device_stack.push_back(device);
 }
 
 void pop_device()
 {
-    SGL_CHECK(!t_device_stack.empty(), "No device to pop. push_device()/pop_device() mismatch.");
-    t_device_stack.pop_back();
+    SGL_CHECK(!tls_device_stack.empty(), "No device to pop. push_device()/pop_device() mismatch.");
+    tls_device_stack.pop_back();
 }
 
 Device* current_device()
 {
-    SGL_CHECK(!t_device_stack.empty(), "No current device. Use push_device() or DeviceScope to set one.");
-    return t_device_stack.back();
+    SGL_CHECK(!tls_device_stack.empty(), "No current device. Use push_device() or DeviceScope to set one.");
+    return tls_device_stack.back();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -1341,7 +1341,10 @@ void push_current_device(Device* device)
 
 Device* pop_current_device()
 {
-    SGL_CHECK(!s_tls_current_device_stack.empty(), "No device to pop. push_current_device()/pop_current_device() mismatch.");
+    SGL_CHECK(
+        !s_tls_current_device_stack.empty(),
+        "No device to pop. push_current_device()/pop_current_device() mismatch."
+    );
     Device* device = s_tls_current_device_stack.back();
     s_tls_current_device_stack.pop_back();
     return device;
@@ -1349,7 +1352,10 @@ Device* pop_current_device()
 
 Device* current_device()
 {
-    SGL_CHECK(!s_tls_current_device_stack.empty(), "No current device. Use push_current_device() or DeviceScope to set one.");
+    SGL_CHECK(
+        !s_tls_current_device_stack.empty(),
+        "No current device. Use push_current_device() or DeviceScope to set one."
+    );
     return s_tls_current_device_stack.back();
 }
 

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -43,7 +43,7 @@ namespace sgl {
 
 static std::vector<Device*> s_devices;
 static std::mutex s_devices_mutex;
-static thread_local std::vector<Device*> tls_device_stack;
+static thread_local std::vector<Device*> s_tls_device_stack;
 
 inline AdapterLUID from_rhi(const rhi::AdapterLUID& rhi_luid)
 {
@@ -393,7 +393,7 @@ Device::Device(const DeviceDesc& desc)
         s_devices.push_back(this);
     }
 
-    // Auto-push device onto thread-local device stack (matches cuCtxCreate behavior).
+    // Auto-push device onto thread-local device stack.
     push_device(this);
 }
 
@@ -456,8 +456,8 @@ void Device::close()
     if (m_closed)
         return;
 
-    // Pop device from thread-local stack if it's the current device (matches cuCtxDestroy behavior).
-    if (!tls_device_stack.empty() && tls_device_stack.back() == this)
+    // Pop device from thread-local stack if it's the current device.
+    if (!s_tls_device_stack.empty() && s_tls_device_stack.back() == this)
         pop_device();
 
     log_debug("Closing device {}", fmt::ptr(this));
@@ -1336,19 +1336,21 @@ std::array<NativeHandle, 3> get_cuda_current_context_native_handles()
 void push_device(Device* device)
 {
     SGL_CHECK(device != nullptr, "Cannot push a null device.");
-    tls_device_stack.push_back(device);
+    s_tls_device_stack.push_back(device);
 }
 
-void pop_device()
+Device* pop_device()
 {
-    SGL_CHECK(!tls_device_stack.empty(), "No device to pop. push_device()/pop_device() mismatch.");
-    tls_device_stack.pop_back();
+    SGL_CHECK(!s_tls_device_stack.empty(), "No device to pop. push_device()/pop_device() mismatch.");
+    Device* device = s_tls_device_stack.back();
+    s_tls_device_stack.pop_back();
+    return device;
 }
 
 Device* current_device()
 {
-    SGL_CHECK(!tls_device_stack.empty(), "No current device. Use push_device() or DeviceScope to set one.");
-    return tls_device_stack.back();
+    SGL_CHECK(!s_tls_device_stack.empty(), "No current device. Use push_device() or DeviceScope to set one.");
+    return s_tls_device_stack.back();
 }
 
 // ---------------------------------------------------------------------------
@@ -1356,28 +1358,37 @@ Device* current_device()
 // ---------------------------------------------------------------------------
 
 DeviceScope::DeviceScope(Device* device)
+    : m_device(device)
 {
     push_device(device);
 }
 
 DeviceScope::~DeviceScope()
 {
-    if (m_active)
+    if (m_active) {
+        SGL_ASSERT(current_device() == m_device);
         pop_device();
+    }
 }
 
 DeviceScope::DeviceScope(DeviceScope&& other) noexcept
-    : m_active(other.m_active)
+    : m_device(other.m_device)
+    , m_active(other.m_active)
 {
+    other.m_device = nullptr;
     other.m_active = false;
 }
 
 DeviceScope& DeviceScope::operator=(DeviceScope&& other) noexcept
 {
     if (this != &other) {
-        if (m_active)
+        if (m_active) {
+            SGL_ASSERT(current_device() == m_device);
             pop_device();
+        }
+        m_device = other.m_device;
         m_active = other.m_active;
+        other.m_device = nullptr;
         other.m_active = false;
     }
     return *this;

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -43,7 +43,7 @@ namespace sgl {
 
 static std::vector<Device*> s_devices;
 static std::mutex s_devices_mutex;
-static thread_local std::vector<Device*> s_tls_device_stack;
+static thread_local std::vector<Device*> s_tls_current_device_stack;
 
 inline AdapterLUID from_rhi(const rhi::AdapterLUID& rhi_luid)
 {
@@ -393,8 +393,8 @@ Device::Device(const DeviceDesc& desc)
         s_devices.push_back(this);
     }
 
-    // Auto-push device onto thread-local device stack.
-    push_device(this);
+    // Auto-push device onto thread-local current device stack.
+    push_current_device(this);
 }
 
 Device::~Device()
@@ -456,9 +456,9 @@ void Device::close()
     if (m_closed)
         return;
 
-    // Pop device from thread-local stack if it's the current device.
-    if (!s_tls_device_stack.empty() && s_tls_device_stack.back() == this)
-        pop_device();
+    // Pop device from thread-local current device stack if it's the current device.
+    if (!s_tls_current_device_stack.empty() && s_tls_current_device_stack.back() == this)
+        pop_current_device();
 
     log_debug("Closing device {}", fmt::ptr(this));
 
@@ -1330,27 +1330,27 @@ std::array<NativeHandle, 3> get_cuda_current_context_native_handles()
 }
 
 // ---------------------------------------------------------------------------
-// Thread-local device stack
+// Thread-local current device stack
 // ---------------------------------------------------------------------------
 
-void push_device(Device* device)
+void push_current_device(Device* device)
 {
     SGL_CHECK(device != nullptr, "Cannot push a null device.");
-    s_tls_device_stack.push_back(device);
+    s_tls_current_device_stack.push_back(device);
 }
 
-Device* pop_device()
+Device* pop_current_device()
 {
-    SGL_CHECK(!s_tls_device_stack.empty(), "No device to pop. push_device()/pop_device() mismatch.");
-    Device* device = s_tls_device_stack.back();
-    s_tls_device_stack.pop_back();
+    SGL_CHECK(!s_tls_current_device_stack.empty(), "No device to pop. push_current_device()/pop_current_device() mismatch.");
+    Device* device = s_tls_current_device_stack.back();
+    s_tls_current_device_stack.pop_back();
     return device;
 }
 
 Device* current_device()
 {
-    SGL_CHECK(!s_tls_device_stack.empty(), "No current device. Use push_device() or DeviceScope to set one.");
-    return s_tls_device_stack.back();
+    SGL_CHECK(!s_tls_current_device_stack.empty(), "No current device. Use push_current_device() or DeviceScope to set one.");
+    return s_tls_current_device_stack.back();
 }
 
 // ---------------------------------------------------------------------------
@@ -1360,14 +1360,14 @@ Device* current_device()
 DeviceScope::DeviceScope(Device* device)
     : m_device(device)
 {
-    push_device(device);
+    push_current_device(device);
 }
 
 DeviceScope::~DeviceScope()
 {
     if (m_active) {
         SGL_ASSERT(current_device() == m_device);
-        pop_device();
+        pop_current_device();
     }
 }
 
@@ -1384,7 +1384,7 @@ DeviceScope& DeviceScope::operator=(DeviceScope&& other) noexcept
     if (this != &other) {
         if (m_active) {
             SGL_ASSERT(current_device() == m_device);
-            pop_device();
+            pop_current_device();
         }
         m_device = other.m_device;
         m_active = other.m_active;

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -1321,5 +1321,275 @@ std::array<NativeHandle, 3> get_cuda_current_context_native_handles()
     return handles;
 }
 
+// ---------------------------------------------------------------------------
+// Thread-local device stack
+// ---------------------------------------------------------------------------
+
+static thread_local std::vector<Device*> t_device_stack;
+
+void push_device(Device* device)
+{
+    SGL_CHECK(device != nullptr, "Cannot push a null device.");
+    t_device_stack.push_back(device);
+}
+
+void pop_device()
+{
+    SGL_CHECK(!t_device_stack.empty(), "No device to pop. push_device()/pop_device() mismatch.");
+    t_device_stack.pop_back();
+}
+
+Device* current_device()
+{
+    SGL_CHECK(!t_device_stack.empty(), "No current device. Use push_device() or DeviceScope to set one.");
+    return t_device_stack.back();
+}
+
+// ---------------------------------------------------------------------------
+// DeviceScope
+// ---------------------------------------------------------------------------
+
+DeviceScope::DeviceScope(Device* device)
+{
+    push_device(device);
+}
+
+DeviceScope::~DeviceScope()
+{
+    if (m_active)
+        pop_device();
+}
+
+DeviceScope::DeviceScope(DeviceScope&& other) noexcept
+    : m_active(other.m_active)
+{
+    other.m_active = false;
+}
+
+DeviceScope& DeviceScope::operator=(DeviceScope&& other) noexcept
+{
+    if (this != &other) {
+        if (m_active)
+            pop_device();
+        m_active = other.m_active;
+        other.m_active = false;
+    }
+    return *this;
+}
+
+// ---------------------------------------------------------------------------
+// Free-standing device API functions.
+// ---------------------------------------------------------------------------
+
+ref<Surface> create_surface(Window* window)
+{
+    return current_device()->create_surface(window);
+}
+
+ref<Surface> create_surface(WindowHandle window_handle)
+{
+    return current_device()->create_surface(window_handle);
+}
+
+ref<Buffer> create_buffer(BufferDesc desc)
+{
+    return current_device()->create_buffer(std::move(desc));
+}
+
+ref<BufferView> create_buffer_view(Buffer* buffer, BufferViewDesc desc)
+{
+    return current_device()->create_buffer_view(buffer, std::move(desc));
+}
+
+ref<Texture> create_texture(TextureDesc desc)
+{
+    return current_device()->create_texture(std::move(desc));
+}
+
+ref<Texture> create_texture_from_resource(TextureDesc desc, rhi::ITexture* resource)
+{
+    return current_device()->create_texture_from_resource(std::move(desc), resource);
+}
+
+ref<TextureView> create_texture_view(Texture* texture, TextureViewDesc desc)
+{
+    return current_device()->create_texture_view(texture, std::move(desc));
+}
+
+ref<Sampler> create_sampler(SamplerDesc desc)
+{
+    return current_device()->create_sampler(std::move(desc));
+}
+
+ref<Fence> create_fence(FenceDesc desc)
+{
+    return current_device()->create_fence(std::move(desc));
+}
+
+ref<QueryPool> create_query_pool(QueryPoolDesc desc)
+{
+    return current_device()->create_query_pool(std::move(desc));
+}
+
+ref<InputLayout> create_input_layout(InputLayoutDesc desc)
+{
+    return current_device()->create_input_layout(std::move(desc));
+}
+
+AccelerationStructureSizes get_acceleration_structure_sizes(const AccelerationStructureBuildDesc& desc)
+{
+    return current_device()->get_acceleration_structure_sizes(desc);
+}
+
+ref<AccelerationStructure> create_acceleration_structure(AccelerationStructureDesc desc)
+{
+    return current_device()->create_acceleration_structure(std::move(desc));
+}
+
+ref<AccelerationStructureInstanceList> create_acceleration_structure_instance_list(size_t size)
+{
+    return current_device()->create_acceleration_structure_instance_list(size);
+}
+
+ref<ShaderTable> create_shader_table(ShaderTableDesc desc)
+{
+    return current_device()->create_shader_table(std::move(desc));
+}
+
+size_t get_coop_vec_matrix_size(
+    uint32_t rows,
+    uint32_t cols,
+    CoopVecMatrixLayout layout,
+    DataType element_type,
+    size_t row_col_stride
+)
+{
+    return current_device()->get_coop_vec_matrix_size(rows, cols, layout, element_type, row_col_stride);
+}
+
+CoopVecMatrixDesc create_coop_vec_matrix_desc(
+    uint32_t rows,
+    uint32_t cols,
+    CoopVecMatrixLayout layout,
+    DataType element_type,
+    size_t offset,
+    size_t row_col_stride
+)
+{
+    return current_device()->create_coop_vec_matrix_desc(rows, cols, layout, element_type, offset, row_col_stride);
+}
+
+void convert_coop_vec_matrices(
+    void* dst,
+    size_t dst_size,
+    std::span<const CoopVecMatrixDesc> dst_descs,
+    const void* src,
+    size_t src_size,
+    std::span<const CoopVecMatrixDesc> src_descs
+)
+{
+    current_device()->convert_coop_vec_matrices(dst, dst_size, dst_descs, src, src_size, src_descs);
+}
+
+void convert_coop_vec_matrix(
+    void* dst,
+    size_t dst_size,
+    const CoopVecMatrixDesc& dst_desc,
+    const void* src,
+    size_t src_size,
+    const CoopVecMatrixDesc& src_desc
+)
+{
+    current_device()->convert_coop_vec_matrix(dst, dst_size, dst_desc, src, src_size, src_desc);
+}
+
+ref<SlangSession> create_slang_session(SlangSessionDesc desc)
+{
+    return current_device()->create_slang_session(std::move(desc));
+}
+
+ref<SlangModule> load_module(std::string_view module_name)
+{
+    return current_device()->load_module(module_name);
+}
+
+ref<SlangModule> load_module_from_source(
+    std::string_view module_name,
+    std::string_view source,
+    std::optional<std::filesystem::path> path
+)
+{
+    return current_device()->load_module_from_source(module_name, source, std::move(path));
+}
+
+ref<SlangModule> compose_modules(
+    std::string_view name,
+    std::vector<ref<SlangModule>> modules,
+    std::span<const TypeConformance> type_conformances
+)
+{
+    return current_device()->compose_modules(name, std::move(modules), type_conformances);
+}
+
+ref<ShaderProgram> link_program(
+    std::vector<ref<SlangModule>> modules,
+    std::vector<ref<SlangEntryPoint>> entry_points,
+    std::optional<SlangLinkOptions> link_options
+)
+{
+    return current_device()->link_program(std::move(modules), std::move(entry_points), std::move(link_options));
+}
+
+ref<ShaderProgram> load_program(
+    std::string_view module_name,
+    std::vector<std::string_view> entry_point_names,
+    std::optional<std::string_view> additional_source,
+    std::optional<SlangLinkOptions> link_options
+)
+{
+    return current_device()
+        ->load_program(module_name, std::move(entry_point_names), additional_source, std::move(link_options));
+}
+
+ref<ShaderObject> create_root_shader_object(const ShaderProgram* shader_program)
+{
+    return current_device()->create_root_shader_object(shader_program);
+}
+
+ref<ShaderObject> create_shader_object(const TypeLayoutReflection* type_layout)
+{
+    return current_device()->create_shader_object(type_layout);
+}
+
+ref<ShaderObject> create_shader_object(ReflectionCursor cursor)
+{
+    return current_device()->create_shader_object(std::move(cursor));
+}
+
+ref<ComputePipeline> create_compute_pipeline(ComputePipelineDesc desc)
+{
+    return current_device()->create_compute_pipeline(std::move(desc));
+}
+
+ref<RenderPipeline> create_render_pipeline(RenderPipelineDesc desc)
+{
+    return current_device()->create_render_pipeline(std::move(desc));
+}
+
+ref<RayTracingPipeline> create_ray_tracing_pipeline(RayTracingPipelineDesc desc)
+{
+    return current_device()->create_ray_tracing_pipeline(std::move(desc));
+}
+
+ref<ComputeKernel> create_compute_kernel(ComputeKernelDesc desc)
+{
+    return current_device()->create_compute_kernel(std::move(desc));
+}
+
+ref<CommandEncoder> create_command_encoder(CommandQueueType queue)
+{
+    return current_device()->create_command_encoder(queue);
+}
+
 
 } // namespace sgl

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -346,6 +346,7 @@ public:
      */
     ref<Buffer> create_buffer(BufferDesc desc);
 
+    /// Create a new buffer view.
     ref<BufferView> create_buffer_view(Buffer* buffer, BufferViewDesc desc);
 
     /**
@@ -368,8 +369,10 @@ public:
      */
     ref<Texture> create_texture(TextureDesc desc);
 
+    /// Create a texture from an existing RHI resource.
     ref<Texture> create_texture_from_resource(TextureDesc desc, rhi::ITexture* resource);
 
+    /// Create a new texture view.
     ref<TextureView> create_texture_view(Texture* texture, TextureViewDesc desc);
 
     /**
@@ -428,12 +431,16 @@ public:
      */
     AccelerationStructureSizes get_acceleration_structure_sizes(const AccelerationStructureBuildDesc& desc);
 
+    /// Create a new acceleration structure.
     ref<AccelerationStructure> create_acceleration_structure(AccelerationStructureDesc desc);
 
+    /// Create a new acceleration structure instance list.
     ref<AccelerationStructureInstanceList> create_acceleration_structure_instance_list(size_t size);
 
+    /// Create a new shader table.
     ref<ShaderTable> create_shader_table(ShaderTableDesc desc);
 
+    /// Get the size of a cooperative vector matrix in bytes.
     size_t get_coop_vec_matrix_size(
         uint32_t rows,
         uint32_t cols,
@@ -442,6 +449,7 @@ public:
         size_t row_col_stride = 0
     );
 
+    /// Create a cooperative vector matrix descriptor.
     CoopVecMatrixDesc create_coop_vec_matrix_desc(
         uint32_t rows,
         uint32_t cols,
@@ -451,6 +459,7 @@ public:
         size_t row_col_stride = 0
     );
 
+    /// Convert multiple cooperative vector matrices between formats.
     void convert_coop_vec_matrices(
         void* dst,
         size_t dst_size,
@@ -460,6 +469,7 @@ public:
         std::span<const CoopVecMatrixDesc> src_descs
     );
 
+    /// Convert a single cooperative vector matrix between formats.
     void convert_coop_vec_matrix(
         void* dst,
         size_t dst_size,
@@ -477,26 +487,31 @@ public:
      */
     ref<SlangSession> create_slang_session(SlangSessionDesc desc);
 
+    /// Load a slang module by name.
     ref<SlangModule> load_module(std::string_view module_name);
 
+    /// Load a slang module from source code.
     ref<SlangModule> load_module_from_source(
         std::string_view module_name,
         std::string_view source,
         std::optional<std::filesystem::path> path = {}
     );
 
+    /// Compose multiple slang modules into one.
     ref<SlangModule> compose_modules(
         std::string_view name,
         std::vector<ref<SlangModule>> modules,
         std::span<const TypeConformance> type_conformances = {}
     );
 
+    /// Link modules and entry points into a shader program.
     ref<ShaderProgram> link_program(
         std::vector<ref<SlangModule>> modules,
         std::vector<ref<SlangEntryPoint>> entry_points,
         std::optional<SlangLinkOptions> link_options = {}
     );
 
+    /// Load a module and link a shader program in one step.
     ref<ShaderProgram> load_program(
         std::string_view module_name,
         std::vector<std::string_view> entry_point_names,
@@ -504,22 +519,31 @@ public:
         std::optional<SlangLinkOptions> link_options = {}
     );
 
+    /// Reload all shader programs.
     void reload_all_programs();
 
+    /// Create a root shader object for a shader program.
     ref<ShaderObject> create_root_shader_object(const ShaderProgram* shader_program);
 
+    /// Create a shader object from a type layout.
     ref<ShaderObject> create_shader_object(const TypeLayoutReflection* type_layout);
 
+    /// Create a shader object from a reflection cursor.
     ref<ShaderObject> create_shader_object(ReflectionCursor cursor);
 
+    /// Create a compute pipeline.
     ref<ComputePipeline> create_compute_pipeline(ComputePipelineDesc desc);
 
+    /// Create a render pipeline.
     ref<RenderPipeline> create_render_pipeline(RenderPipelineDesc desc);
 
+    /// Create a ray tracing pipeline.
     ref<RayTracingPipeline> create_ray_tracing_pipeline(RayTracingPipelineDesc desc);
 
+    /// Create a compute kernel.
     ref<ComputeKernel> create_compute_kernel(ComputeKernelDesc desc);
 
+    /// Create a command encoder.
     ref<CommandEncoder> create_command_encoder(CommandQueueType queue = CommandQueueType::graphics);
 
     /**
@@ -812,5 +836,285 @@ private:
 /// to retrieve an existing context (eg from PyTorch) to pass as the existing_device_handles
 /// from which to create a device in the DeviceDesc.
 SGL_API std::array<NativeHandle, 3> get_cuda_current_context_native_handles();
+
+// ---------------------------------------------------------------------------
+// Thread-local device stack.
+// ---------------------------------------------------------------------------
+
+/// Push a device onto the thread-local device stack.
+/// The device must outlive the corresponding pop_device() call.
+/// \param device Device to push (must not be null).
+SGL_API void push_device(Device* device);
+
+/// Pop the top device from the thread-local device stack.
+/// Throws if the stack is empty.
+SGL_API void pop_device();
+
+/// Get the current device from the top of the thread-local device stack.
+/// Throws if the stack is empty.
+/// \return The current device.
+SGL_API Device* current_device();
+
+/// RAII scope that pushes a device on construction and pops it on destruction.
+///
+/// Usage:
+/// \code
+/// {
+///     DeviceScope scope(device);
+///     auto buf = create_buffer(desc);
+/// }
+/// \endcode
+class SGL_API DeviceScope {
+public:
+    explicit DeviceScope(Device* device);
+    ~DeviceScope();
+
+    // Non-copyable.
+    DeviceScope(const DeviceScope&) = delete;
+    DeviceScope& operator=(const DeviceScope&) = delete;
+
+    // Movable.
+    DeviceScope(DeviceScope&& other) noexcept;
+    DeviceScope& operator=(DeviceScope&& other) noexcept;
+
+private:
+    bool m_active{true};
+};
+
+// ---------------------------------------------------------------------------
+// Free-standing device API functions.
+// Each delegates to current_device()->xxx(...).
+// ---------------------------------------------------------------------------
+
+/**
+ * \brief Create a new surface.
+ *
+ * \param window Window to create the surface for.
+ * \return New surface object.
+ */
+SGL_API ref<Surface> create_surface(Window* window);
+
+/**
+ * \brief Create a new surface.
+ *
+ * \param window_handle Native window handle to create the surface for.
+ * \return New surface object.
+ */
+SGL_API ref<Surface> create_surface(WindowHandle window_handle);
+
+/**
+ * \brief Create a new buffer.
+ *
+ * \param size Buffer size in bytes.
+ * \param element_count Buffer size in number of struct elements. Can be used instead of \c size.
+ * \param struct_size Struct size in bytes.
+ * \param resource_type_layout Resource type layout of the buffer. Can be used instead of \c struct_size to specify the size of the struct.
+ * \param format Buffer format. Used when creating typed buffer views.
+ * \param initial_state Initial resource state.
+ * \param usage Resource usage flags.
+ * \param memory_type Memory type.
+ * \param label Debug label.
+ * \param data Initial data to upload to the buffer.
+ * \param data_size Size of the initial data in bytes.
+ * \return New buffer object.
+ */
+SGL_API ref<Buffer> create_buffer(BufferDesc desc);
+
+/// Create a new buffer view.
+SGL_API ref<BufferView> create_buffer_view(Buffer* buffer, BufferViewDesc desc);
+
+/**
+ * \brief Create a new texture.
+ *
+ * \param type Texture type.
+ * \param format Texture format.
+ * \param width Width in pixels.
+ * \param height Height in pixels.
+ * \param depth Depth in pixels.
+ * \param array_length Array length.
+ * \param mip_count Mip level count. Number of mip levels (ALL_MIPS for all mip levels).
+ * \param sample_count Number of samples for multisampled textures.
+ * \param quality Quality level for multisampled textures.
+ * \param usage Resource usage.
+ * \param memory_type Memory type.
+ * \param label Debug label.
+ * \param data Initial data.
+ * \return New texture object.
+ */
+SGL_API ref<Texture> create_texture(TextureDesc desc);
+
+/// Create a texture from an existing RHI resource.
+SGL_API ref<Texture> create_texture_from_resource(TextureDesc desc, rhi::ITexture* resource);
+
+/// Create a new texture view.
+SGL_API ref<TextureView> create_texture_view(Texture* texture, TextureViewDesc desc);
+
+/**
+ * \brief Create a new sampler.
+ *
+ * \param min_filter Minification filter.
+ * \param mag_filter Magnification filter.
+ * \param mip_filter Mip-map filter.
+ * \param reduction_op Reduction operation.
+ * \param address_u Texture addressing mode for the U coordinate.
+ * \param address_v Texture addressing mode for the V coordinate.
+ * \param address_w Texture addressing mode for the W coordinate.
+ * \param mip_lod_bias Mip-map LOD bias.
+ * \param max_anisotropy Maximum anisotropy.
+ * \param comparison_func Comparison function.
+ * \param border_color Border color.
+ * \param min_lod Minimum LOD level.
+ * \param max_lod Maximum LOD level.
+ * \param label Debug label.
+ * \return New sampler object.
+ */
+SGL_API ref<Sampler> create_sampler(SamplerDesc desc);
+
+/**
+ * \brief Create a new fence.
+ *
+ * \param initial_value Initial fence value.
+ * \param shared Create a shared fence.
+ * \return New fence object.
+ */
+SGL_API ref<Fence> create_fence(FenceDesc desc);
+
+/**
+ * \brief Create a new query pool.
+ *
+ * \param type Query type.
+ * \param count Number of queries in the pool.
+ * \return New query pool object.
+ */
+SGL_API ref<QueryPool> create_query_pool(QueryPoolDesc desc);
+
+/**
+ * \brief Create a new input layout.
+ *
+ * \param input_elements List of input elements (see \ref InputElementDesc for details).
+ * \param vertex_streams List of vertex streams (see \ref VertexStreamDesc for details).
+ * \return New input layout object.
+ */
+SGL_API ref<InputLayout> create_input_layout(InputLayoutDesc desc);
+
+/**
+ * \brief Query the device for buffer sizes required for acceleration structure builds.
+ *
+ * \param desc Acceleration structure build description.
+ * \return Acceleration structure sizes.
+ */
+SGL_API AccelerationStructureSizes get_acceleration_structure_sizes(const AccelerationStructureBuildDesc& desc);
+
+/// Create a new acceleration structure.
+SGL_API ref<AccelerationStructure> create_acceleration_structure(AccelerationStructureDesc desc);
+
+/// Create a new acceleration structure instance list.
+SGL_API ref<AccelerationStructureInstanceList> create_acceleration_structure_instance_list(size_t size);
+
+/// Create a new shader table.
+SGL_API ref<ShaderTable> create_shader_table(ShaderTableDesc desc);
+
+/// Get the size of a cooperative vector matrix in bytes.
+SGL_API size_t get_coop_vec_matrix_size(
+    uint32_t rows,
+    uint32_t cols,
+    CoopVecMatrixLayout layout,
+    DataType element_type,
+    size_t row_col_stride = 0
+);
+
+/// Create a cooperative vector matrix descriptor.
+SGL_API CoopVecMatrixDesc create_coop_vec_matrix_desc(
+    uint32_t rows,
+    uint32_t cols,
+    CoopVecMatrixLayout layout,
+    DataType element_type,
+    size_t offset = 0,
+    size_t row_col_stride = 0
+);
+
+/// Convert multiple cooperative vector matrices between formats.
+SGL_API void convert_coop_vec_matrices(
+    void* dst,
+    size_t dst_size,
+    std::span<const CoopVecMatrixDesc> dst_descs,
+    const void* src,
+    size_t src_size,
+    std::span<const CoopVecMatrixDesc> src_descs
+);
+
+/// Convert a single cooperative vector matrix between formats.
+SGL_API void convert_coop_vec_matrix(
+    void* dst,
+    size_t dst_size,
+    const CoopVecMatrixDesc& dst_desc,
+    const void* src,
+    size_t src_size,
+    const CoopVecMatrixDesc& src_desc
+);
+
+/**
+ * \brief Create a new slang session.
+ *
+ * \param compiler_options Compiler options (see \ref SlangCompilerOptions for details).
+ * \return New slang session object.
+ */
+SGL_API ref<SlangSession> create_slang_session(SlangSessionDesc desc);
+
+/// Load a slang module by name.
+SGL_API ref<SlangModule> load_module(std::string_view module_name);
+
+/// Load a slang module from source code.
+SGL_API ref<SlangModule> load_module_from_source(
+    std::string_view module_name,
+    std::string_view source,
+    std::optional<std::filesystem::path> path = {}
+);
+
+/// Compose multiple slang modules into one.
+SGL_API ref<SlangModule> compose_modules(
+    std::string_view name,
+    std::vector<ref<SlangModule>> modules,
+    std::span<const TypeConformance> type_conformances = {}
+);
+
+/// Link modules and entry points into a shader program.
+SGL_API ref<ShaderProgram> link_program(
+    std::vector<ref<SlangModule>> modules,
+    std::vector<ref<SlangEntryPoint>> entry_points,
+    std::optional<SlangLinkOptions> link_options = {}
+);
+
+/// Load a module and link a shader program in one step.
+SGL_API ref<ShaderProgram> load_program(
+    std::string_view module_name,
+    std::vector<std::string_view> entry_point_names,
+    std::optional<std::string_view> additional_source = {},
+    std::optional<SlangLinkOptions> link_options = {}
+);
+
+/// Create a root shader object for a shader program.
+SGL_API ref<ShaderObject> create_root_shader_object(const ShaderProgram* shader_program);
+
+/// Create a shader object from a type layout.
+SGL_API ref<ShaderObject> create_shader_object(const TypeLayoutReflection* type_layout);
+
+/// Create a shader object from a reflection cursor.
+SGL_API ref<ShaderObject> create_shader_object(ReflectionCursor cursor);
+
+/// Create a compute pipeline.
+SGL_API ref<ComputePipeline> create_compute_pipeline(ComputePipelineDesc desc);
+
+/// Create a render pipeline.
+SGL_API ref<RenderPipeline> create_render_pipeline(RenderPipelineDesc desc);
+
+/// Create a ray tracing pipeline.
+SGL_API ref<RayTracingPipeline> create_ray_tracing_pipeline(RayTracingPipelineDesc desc);
+
+/// Create a compute kernel.
+SGL_API ref<ComputeKernel> create_compute_kernel(ComputeKernelDesc desc);
+
+/// Create a command encoder.
+SGL_API ref<CommandEncoder> create_command_encoder(CommandQueueType queue = CommandQueueType::graphics);
 
 } // namespace sgl

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -842,13 +842,22 @@ SGL_API std::array<NativeHandle, 3> get_cuda_current_context_native_handles();
 // ---------------------------------------------------------------------------
 
 /// Push a device onto the thread-local device stack.
-/// The device must outlive the corresponding pop_device() call.
+///
+/// Stores a raw pointer in the thread-local stack. The caller must ensure
+/// that the device (and any devices below it on the stack) outlive their
+/// corresponding pop_device() calls. Device::close() only auto-pops if the
+/// device is on top of the stack; a closed device lower in the stack remains
+/// as a stale pointer - calling current_device() or pop_device() on that
+/// entry is undefined behavior unless the device is kept alive (refcount > 0)
+/// until popped.
+///
 /// \param device Device to push (must not be null).
 SGL_API void push_device(Device* device);
 
 /// Pop the top device from the thread-local device stack.
 /// Throws if the stack is empty.
-SGL_API void pop_device();
+/// \return The popped device.
+SGL_API Device* pop_device();
 
 /// Get the current device from the top of the thread-local device stack.
 /// Throws if the stack is empty.
@@ -856,6 +865,10 @@ SGL_API void pop_device();
 SGL_API Device* current_device();
 
 /// RAII scope that pushes a device on construction and pops it on destruction.
+///
+/// The device stack must not be externally mutated (push/pop) while a
+/// DeviceScope is active; doing so may cause the destructor to pop the
+/// wrong device. In debug builds an assertion checks LIFO ordering.
 ///
 /// Usage:
 /// \code
@@ -878,6 +891,7 @@ public:
     DeviceScope& operator=(DeviceScope&& other) noexcept;
 
 private:
+    Device* m_device{nullptr};
     bool m_active{true};
 };
 

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -838,26 +838,26 @@ private:
 SGL_API std::array<NativeHandle, 3> get_cuda_current_context_native_handles();
 
 // ---------------------------------------------------------------------------
-// Thread-local device stack.
+// Thread-local current device stack.
 // ---------------------------------------------------------------------------
 
-/// Push a device onto the thread-local device stack.
+/// Push a device onto the thread-local current device stack.
 ///
 /// Stores a raw pointer in the thread-local stack. The caller must ensure
 /// that the device (and any devices below it on the stack) outlive their
-/// corresponding pop_device() calls. Device::close() only auto-pops if the
+/// corresponding pop_current_device() calls. Device::close() only auto-pops if the
 /// device is on top of the stack; a closed device lower in the stack remains
-/// as a stale pointer - calling current_device() or pop_device() on that
+/// as a stale pointer - calling current_device() or pop_current_device() on that
 /// entry is undefined behavior unless the device is kept alive (refcount > 0)
 /// until popped.
 ///
 /// \param device Device to push (must not be null).
-SGL_API void push_device(Device* device);
+SGL_API void push_current_device(Device* device);
 
 /// Pop the top device from the thread-local device stack.
 /// Throws if the stack is empty.
 /// \return The popped device.
-SGL_API Device* pop_device();
+SGL_API Device* pop_current_device();
 
 /// Get the current device from the top of the thread-local device stack.
 /// Throws if the stack is empty.

--- a/src/sgl/device/fwd.h
+++ b/src/sgl/device/fwd.h
@@ -10,6 +10,7 @@ namespace sgl {
 
 struct DeviceDesc;
 class Device;
+class DeviceScope;
 
 // surface.h
 

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -572,9 +572,12 @@ SGL_PY_EXPORT(device_device)
     );
     device.def(
         "__exit__",
-        [](Device* /*self*/, nb::object /*exc_type*/, nb::object /*exc_val*/, nb::object /*exc_tb*/)
+        [](Device* self, nb::object /*exc_type*/, nb::object /*exc_val*/, nb::object /*exc_tb*/)
         {
-            pop_device();
+            // Only pop if this device is on top of the stack to avoid
+            // popping the wrong device when the stack was mutated.
+            if (current_device() == self)
+                pop_device();
         },
         "exc_type"_a.none(),
         "exc_val"_a.none(),

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -566,7 +566,7 @@ SGL_PY_EXPORT(device_device)
         "__enter__",
         [](Device* self) -> Device*
         {
-            push_device(self);
+            push_current_device(self);
             return self;
         }
     );
@@ -577,7 +577,7 @@ SGL_PY_EXPORT(device_device)
             // Only pop if this device is on top of the stack to avoid
             // popping the wrong device when the stack was mutated.
             if (current_device() == self)
-                pop_device();
+                pop_current_device();
         },
         "exc_type"_a.none(),
         "exc_val"_a.none(),
@@ -1200,8 +1200,8 @@ SGL_PY_EXPORT(device_device)
         D(get_cuda_current_context_native_handles)
     );
 
-    m.def("push_device", &push_device, "device"_a, D(push_device));
-    m.def("pop_device", &pop_device, D(pop_device));
+    m.def("push_current_device", &push_current_device, "device"_a, D(push_current_device));
+    m.def("pop_current_device", &pop_current_device, D(pop_current_device));
     m.def("current_device", &current_device, nb::rv_policy::reference, D(current_device));
 
     // Free-standing device API functions.

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -122,7 +122,7 @@ coopvec_get_ndarray_matrix_desc(const nb::ndarray<Args...>& array, std::optional
 }
 
 inline void convert_coop_vec_matrix_ndarray(
-    Device* self,
+    Device* device,
     nb::ndarray<nb::device::cpu> dst,
     nb::ndarray<nb::device::cpu> src,
     std::optional<CoopVecMatrixLayout> dst_layout,
@@ -151,7 +151,118 @@ inline void convert_coop_vec_matrix_ndarray(
         SGL_THROW("At least one of src or dst must be a 2D array");
     }
 
-    self->convert_coop_vec_matrix(dst.data(), dst.nbytes(), dst_desc, src.data(), src.nbytes(), src_desc);
+    device->convert_coop_vec_matrix(dst.data(), dst.nbytes(), dst_desc, src.data(), src.nbytes(), src_desc);
+}
+
+/// Helper for create_buffer kwargs binding (shared by Device and free-standing).
+static ref<Buffer> create_buffer_from_kwargs(
+    Device* device,
+    size_t size,
+    size_t element_count,
+    size_t struct_size,
+    nb::object resource_type_layout,
+    Format format,
+    MemoryType memory_type,
+    BufferUsage usage,
+    ResourceState default_state,
+    std::string label,
+    std::optional<nb::ndarray<nb::numpy>> data
+)
+{
+    if (data) {
+        SGL_CHECK(is_ndarray_contiguous(*data), "Data is not contiguous.");
+    }
+
+    ref<const TypeLayoutReflection> resolved_resource_type_layout;
+    if (!resource_type_layout.is_none()) {
+        // Note: nanobind can't try cast to a ref counted pointer, however the reflection
+        // cursor code below needs to ensure it maintains a reference to the type layout if
+        // returned, so we attempt to convert to the raw ptr here, and then immediately
+        // store it in a local ref counted ptr.
+        if (const TypeLayoutReflection* resolved_struct_type_ptr;
+            nb::try_cast(resource_type_layout, resolved_struct_type_ptr)) {
+            resolved_resource_type_layout = ref<const TypeLayoutReflection>(resolved_struct_type_ptr);
+        }
+        // If this is a reflection cursor, get type layout from it
+        else if (ReflectionCursor reflection_cursor; nb::try_cast(resource_type_layout, reflection_cursor)) {
+            resolved_resource_type_layout = reflection_cursor.type_layout();
+        }
+        // Otherwise we got an invalid type
+        else {
+            throw nb::type_error("Expected a TypeLayoutReflection or ReflectionCursor for 'resource_type_layout'");
+        }
+        if (resolved_resource_type_layout->kind() != TypeReflection::Kind::resource
+            || resolved_resource_type_layout->type()->resource_shape()
+                != TypeReflection::ResourceShape::structured_buffer) {
+            throw nb::type_error("Expected a TypeLayoutReflection of a structured buffer for 'resource_type_layout'");
+        }
+    }
+
+    return device->create_buffer({
+        .size = size,
+        .element_count = element_count,
+        .struct_size = struct_size,
+        .resource_type_layout = resolved_resource_type_layout,
+        .format = format,
+        .memory_type = memory_type,
+        .usage = usage,
+        .default_state = default_state,
+        .label = std::move(label),
+        .data = data ? data->data() : nullptr,
+        .data_size = data ? data->nbytes() : 0,
+    });
+}
+
+/// Helper for create_texture kwargs binding (shared by Device and free-standing).
+static ref<Texture> create_texture_from_kwargs(
+    Device* device,
+    TextureType type,
+    Format format,
+    uint32_t width,
+    uint32_t height,
+    uint32_t depth,
+    uint32_t array_length,
+    uint32_t mip_count,
+    uint32_t sample_count,
+    uint32_t sample_quality,
+    MemoryType memory_type,
+    TextureUsage usage,
+    ResourceState default_state,
+    ref<Sampler> sampler,
+    std::string label,
+    std::optional<nb::ndarray<nb::numpy>> data
+)
+{
+    SubresourceData subresourceData[1];
+    if (data) {
+        SGL_CHECK(array_length == 1, "Texture arrays cannot be populated on construction - use upload_texture_data");
+        SGL_CHECK(
+            type != TextureType::texture_cube && type != TextureType::texture_cube_array,
+            "Cube textures cannot be populated on construction - use upload_texture_data"
+        );
+        SGL_CHECK(is_ndarray_contiguous(*data), "Data is not contiguous.");
+        subresourceData[0].data = data->data();
+        subresourceData[0].size = data->nbytes();
+        subresourceData[0].slice_pitch = subresourceData[0].size / depth;
+        subresourceData[0].row_pitch = subresourceData[0].slice_pitch / height;
+    }
+    return device->create_texture({
+        .type = type,
+        .format = format,
+        .width = width,
+        .height = height,
+        .depth = depth,
+        .array_length = array_length,
+        .mip_count = mip_count,
+        .sample_count = sample_count,
+        .sample_quality = sample_quality,
+        .memory_type = memory_type,
+        .usage = usage,
+        .default_state = default_state,
+        .sampler = std::move(sampler),
+        .label = std::move(label),
+        .data = data ? subresourceData : std::span<SubresourceData>(),
+    });
 }
 
 } // namespace sgl
@@ -451,6 +562,25 @@ SGL_PY_EXPORT(device_device)
         "This is useful for multi-GPU scenarios where you need to temporarily\n"
         "switch to a different device's context."
     );
+    device.def(
+        "__enter__",
+        [](Device* self) -> Device*
+        {
+            push_device(self);
+            return self;
+        }
+    );
+    device.def(
+        "__exit__",
+        [](Device* /*self*/, nb::object /*exc_type*/, nb::object /*exc_val*/, nb::object /*exc_tb*/)
+        {
+            pop_device();
+        },
+        "exc_type"_a.none(),
+        "exc_val"_a.none(),
+        "exc_tb"_a.none()
+    );
+
     device.def("has_feature", &Device::has_feature, "feature"_a, D(Device, has_feature));
     device.def("has_capability", &Device::has_capability, "capability"_a, D(Device, has_capability));
     device.def("get_format_support", &Device::get_format_support, "format"_a, D(Device, get_format_support));
@@ -489,53 +619,19 @@ SGL_PY_EXPORT(device_device)
            std::string label,
            std::optional<nb::ndarray<nb::numpy>> data)
         {
-            if (data) {
-                SGL_CHECK(is_ndarray_contiguous(*data), "Data is not contiguous.");
-            }
-
-            ref<const TypeLayoutReflection> resolved_resource_type_layout;
-            if (!resource_type_layout.is_none()) {
-                // Note: nanobind can't try cast to a ref counted pointer, however the reflection
-                // cursor code below needs to ensure it maintains a reference to the type layout if
-                // returned, so we attempt to convert to the raw ptr here, and then immediately
-                // store it in a local ref counted ptr.
-                if (const TypeLayoutReflection* resolved_struct_type_ptr;
-                    nb::try_cast(resource_type_layout, resolved_struct_type_ptr)) {
-                    resolved_resource_type_layout = ref<const TypeLayoutReflection>(resolved_struct_type_ptr);
-                }
-                // If this is a reflection cursor, get type layout from it
-                else if (ReflectionCursor reflection_cursor; nb::try_cast(resource_type_layout, reflection_cursor)) {
-
-                    resolved_resource_type_layout = reflection_cursor.type_layout();
-                }
-                // Otherwise we got an invalid type
-                else {
-                    throw nb::type_error(
-                        "Expected a TypeLayoutReflection or ReflectionCursor for 'resource_type_layout'"
-                    );
-                }
-                if (resolved_resource_type_layout->kind() != TypeReflection::Kind::resource
-                    || resolved_resource_type_layout->type()->resource_shape()
-                        != TypeReflection::ResourceShape::structured_buffer) {
-                    throw nb::type_error(
-                        "Expected a TypeLayoutReflection of a structured buffer for 'resource_type_layout'"
-                    );
-                }
-            }
-
-            return self->create_buffer({
-                .size = size,
-                .element_count = element_count,
-                .struct_size = struct_size,
-                .resource_type_layout = resolved_resource_type_layout,
-                .format = format,
-                .memory_type = memory_type,
-                .usage = usage,
-                .default_state = default_state,
-                .label = std::move(label),
-                .data = data ? data->data() : nullptr,
-                .data_size = data ? data->nbytes() : 0,
-            });
+            return create_buffer_from_kwargs(
+                self,
+                size,
+                element_count,
+                struct_size,
+                std::move(resource_type_layout),
+                format,
+                memory_type,
+                usage,
+                default_state,
+                std::move(label),
+                std::move(data)
+            );
         },
         "size"_a = BufferDesc().size,
         "element_count"_a = BufferDesc().element_count,
@@ -549,15 +645,7 @@ SGL_PY_EXPORT(device_device)
         "data"_a.none() = nb::none(),
         D(Device, create_buffer)
     );
-    device.def(
-        "create_buffer",
-        [](Device* self, const BufferDesc& desc)
-        {
-            return self->create_buffer(desc);
-        },
-        "desc"_a,
-        D(Device, create_buffer)
-    );
+    device.def("create_buffer", &Device::create_buffer, "desc"_a, D(Device, create_buffer));
 
     device.def(
         "create_texture",
@@ -578,39 +666,24 @@ SGL_PY_EXPORT(device_device)
            std::string label,
            std::optional<nb::ndarray<nb::numpy>> data)
         {
-            SubresourceData subresourceData[1];
-            if (data) {
-                SGL_CHECK(
-                    array_length == 1,
-                    "Texture arrays cannot be populated on construction - use upload_texture_data"
-                );
-                SGL_CHECK(
-                    type != TextureType::texture_cube && type != TextureType::texture_cube_array,
-                    "Cube textures cannot be populated on construction - use upload_texture_data"
-                );
-                SGL_CHECK(is_ndarray_contiguous(*data), "Data is not contiguous.");
-                subresourceData[0].data = data->data();
-                subresourceData[0].size = data->nbytes();
-                subresourceData[0].slice_pitch = subresourceData[0].size / depth;
-                subresourceData[0].row_pitch = subresourceData[0].slice_pitch / height;
-            }
-            return self->create_texture({
-                .type = type,
-                .format = format,
-                .width = width,
-                .height = height,
-                .depth = depth,
-                .array_length = array_length,
-                .mip_count = mip_count,
-                .sample_count = sample_count,
-                .sample_quality = sample_quality,
-                .memory_type = memory_type,
-                .usage = usage,
-                .default_state = default_state,
-                .sampler = std::move(sampler),
-                .label = std::move(label),
-                .data = data ? subresourceData : std::span<SubresourceData>(),
-            });
+            return create_texture_from_kwargs(
+                self,
+                type,
+                format,
+                width,
+                height,
+                depth,
+                array_length,
+                mip_count,
+                sample_count,
+                sample_quality,
+                memory_type,
+                usage,
+                default_state,
+                std::move(sampler),
+                std::move(label),
+                std::move(data)
+            );
         },
         "type"_a = TextureDesc().type,
         "format"_a = TextureDesc().format,
@@ -629,15 +702,7 @@ SGL_PY_EXPORT(device_device)
         "data"_a.none() = nb::none(),
         D(Device, create_texture)
     );
-    device.def(
-        "create_texture",
-        [](Device* self, const TextureDesc& desc)
-        {
-            return self->create_texture(desc);
-        },
-        "desc"_a,
-        D(Device, create_texture)
-    );
+    device.def("create_texture", &Device::create_texture, "desc"_a, D(Device, create_texture));
 
     device.def(
         "create_sampler",
@@ -1130,5 +1195,545 @@ SGL_PY_EXPORT(device_device)
         "get_cuda_current_context_native_handles",
         get_cuda_current_context_native_handles,
         D(get_cuda_current_context_native_handles)
+    );
+
+    m.def("push_device", &push_device, "device"_a, D(push_device));
+    m.def("pop_device", &pop_device, D(pop_device));
+    m.def("current_device", &current_device, nb::rv_policy::reference, D(current_device));
+
+    // Free-standing device API functions.
+
+    m.def(
+        "create_surface",
+        [](ref<Window> window)
+        {
+            return create_surface(window);
+        },
+        "window"_a,
+        D(create_surface)
+    );
+    m.def("create_surface", nb::overload_cast<WindowHandle>(&create_surface), "window_handle"_a, D(create_surface, 2));
+
+    m.def(
+        "create_buffer",
+        [](size_t size,
+           size_t element_count,
+           size_t struct_size,
+           nb::object resource_type_layout,
+           Format format,
+           MemoryType memory_type,
+           BufferUsage usage,
+           ResourceState default_state,
+           std::string label,
+           std::optional<nb::ndarray<nb::numpy>> data)
+        {
+            return create_buffer_from_kwargs(
+                current_device(),
+                size,
+                element_count,
+                struct_size,
+                std::move(resource_type_layout),
+                format,
+                memory_type,
+                usage,
+                default_state,
+                std::move(label),
+                std::move(data)
+            );
+        },
+        "size"_a = BufferDesc().size,
+        "element_count"_a = BufferDesc().element_count,
+        "struct_size"_a = BufferDesc().struct_size,
+        "resource_type_layout"_a.none() = nb::none(),
+        "format"_a = BufferDesc().format,
+        "memory_type"_a = BufferDesc().memory_type,
+        "usage"_a = BufferDesc().usage,
+        "default_state"_a = BufferDesc().default_state,
+        "label"_a = BufferDesc().label,
+        "data"_a.none() = nb::none(),
+        D(create_buffer)
+    );
+    m.def("create_buffer", nb::overload_cast<BufferDesc>(&create_buffer), "desc"_a, D(create_buffer));
+
+    m.def(
+        "create_texture",
+        [](TextureType type,
+           Format format,
+           uint32_t width,
+           uint32_t height,
+           uint32_t depth,
+           uint32_t array_length,
+           uint32_t mip_count,
+           uint32_t sample_count,
+           uint32_t sample_quality,
+           MemoryType memory_type,
+           TextureUsage usage,
+           ResourceState default_state,
+           ref<Sampler> sampler,
+           std::string label,
+           std::optional<nb::ndarray<nb::numpy>> data)
+        {
+            return create_texture_from_kwargs(
+                current_device(),
+                type,
+                format,
+                width,
+                height,
+                depth,
+                array_length,
+                mip_count,
+                sample_count,
+                sample_quality,
+                memory_type,
+                usage,
+                default_state,
+                std::move(sampler),
+                std::move(label),
+                std::move(data)
+            );
+        },
+        "type"_a = TextureDesc().type,
+        "format"_a = TextureDesc().format,
+        "width"_a = TextureDesc().width,
+        "height"_a = TextureDesc().height,
+        "depth"_a = TextureDesc().depth,
+        "array_length"_a = TextureDesc().array_length,
+        "mip_count"_a = TextureDesc().mip_count,
+        "sample_count"_a = TextureDesc().sample_count,
+        "sample_quality"_a = TextureDesc().sample_quality,
+        "memory_type"_a = TextureDesc().memory_type,
+        "usage"_a = TextureDesc().usage,
+        "default_state"_a = TextureDesc().default_state,
+        "sampler"_a.none() = nb::none(),
+        "label"_a = TextureDesc().label,
+        "data"_a.none() = nb::none(),
+        D(create_texture)
+    );
+    m.def("create_texture", nb::overload_cast<TextureDesc>(&create_texture), "desc"_a, D(create_texture));
+
+    m.def(
+        "create_sampler",
+        [](TextureFilteringMode min_filter,
+           TextureFilteringMode mag_filter,
+           TextureFilteringMode mip_filter,
+           TextureReductionOp reduction_op,
+           TextureAddressingMode address_u,
+           TextureAddressingMode address_v,
+           TextureAddressingMode address_w,
+           float mip_lod_bias,
+           uint32_t max_anisotropy,
+           ComparisonFunc comparison_func,
+           float4 border_color,
+           float min_lod,
+           float max_lod,
+           std::string label)
+        {
+            return create_sampler({
+                .min_filter = min_filter,
+                .mag_filter = mag_filter,
+                .mip_filter = mip_filter,
+                .reduction_op = reduction_op,
+                .address_u = address_u,
+                .address_v = address_v,
+                .address_w = address_w,
+                .mip_lod_bias = mip_lod_bias,
+                .max_anisotropy = max_anisotropy,
+                .comparison_func = comparison_func,
+                .border_color = border_color,
+                .min_lod = min_lod,
+                .max_lod = max_lod,
+                .label = std::move(label),
+            });
+        },
+        "min_filter"_a = SamplerDesc().min_filter,
+        "mag_filter"_a = SamplerDesc().mag_filter,
+        "mip_filter"_a = SamplerDesc().mip_filter,
+        "reduction_op"_a = SamplerDesc().reduction_op,
+        "address_u"_a = SamplerDesc().address_u,
+        "address_v"_a = SamplerDesc().address_v,
+        "address_w"_a = SamplerDesc().address_w,
+        "mip_lod_bias"_a = SamplerDesc().mip_lod_bias,
+        "max_anisotropy"_a = SamplerDesc().max_anisotropy,
+        "comparison_func"_a = SamplerDesc().comparison_func,
+        "border_color"_a = SamplerDesc().border_color,
+        "min_lod"_a = SamplerDesc().min_lod,
+        "max_lod"_a = SamplerDesc().max_lod,
+        "label"_a = SamplerDesc().label,
+        D(create_sampler)
+    );
+    m.def("create_sampler", nb::overload_cast<SamplerDesc>(&create_sampler), "desc"_a, D(create_sampler));
+
+    m.def(
+        "create_fence",
+        [](uint64_t initial_value, bool shared)
+        {
+            return create_fence({.initial_value = initial_value, .shared = shared});
+        },
+        "initial_value"_a = FenceDesc().initial_value,
+        "shared"_a = FenceDesc().shared,
+        D(create_fence)
+    );
+    m.def("create_fence", nb::overload_cast<FenceDesc>(&create_fence), "desc"_a, D(create_fence));
+
+    m.def(
+        "create_query_pool",
+        [](QueryType type, uint32_t count)
+        {
+            return create_query_pool({.type = type, .count = count});
+        },
+        "type"_a,
+        "count"_a,
+        D(create_query_pool)
+    );
+    m.def("create_query_pool", nb::overload_cast<QueryPoolDesc>(&create_query_pool), "desc"_a, D(create_query_pool));
+
+    m.def(
+        "create_input_layout",
+        [](std::vector<InputElementDesc> input_elements, std::vector<VertexStreamDesc> vertex_streams)
+        {
+            return create_input_layout({
+                .input_elements = std::move(input_elements),
+                .vertex_streams = std::move(vertex_streams),
+            });
+        },
+        "input_elements"_a,
+        "vertex_streams"_a,
+        D(create_input_layout)
+    );
+    m.def(
+        "create_input_layout",
+        nb::overload_cast<InputLayoutDesc>(&create_input_layout),
+        "desc"_a,
+        D(create_input_layout)
+    );
+
+    m.def(
+        "create_command_encoder",
+        &create_command_encoder,
+        "queue"_a = CommandQueueType::graphics,
+        D(create_command_encoder)
+    );
+
+    m.def(
+        "get_acceleration_structure_sizes",
+        &get_acceleration_structure_sizes,
+        "desc"_a,
+        D(get_acceleration_structure_sizes)
+    );
+    m.def(
+        "create_acceleration_structure",
+        [](AccelerationStructureKind kind, size_t size, std::string label)
+        {
+            return create_acceleration_structure({
+                .kind = kind,
+                .size = size,
+                .label = std::move(label),
+            });
+        },
+        "kind"_a = AccelerationStructureDesc().kind,
+        "size"_a = AccelerationStructureDesc().size,
+        "label"_a = AccelerationStructureDesc().label,
+        D(create_acceleration_structure)
+    );
+    m.def(
+        "create_acceleration_structure",
+        nb::overload_cast<AccelerationStructureDesc>(&create_acceleration_structure),
+        "desc"_a,
+        D(create_acceleration_structure)
+    );
+    m.def(
+        "create_acceleration_structure_instance_list",
+        nb::overload_cast<size_t>(&create_acceleration_structure_instance_list),
+        "size"_a,
+        D(create_acceleration_structure_instance_list)
+    );
+    m.def(
+        "create_shader_table",
+        [](ref<ShaderProgram> program,
+           std::vector<std::string> ray_gen_entry_points,
+           std::vector<std::string> miss_entry_points,
+           std::vector<std::string> hit_group_names,
+           std::vector<std::string> callable_entry_points)
+        {
+            return create_shader_table({
+                .program = std::move(program),
+                .ray_gen_entry_points = std::move(ray_gen_entry_points),
+                .miss_entry_points = std::move(miss_entry_points),
+                .hit_group_names = std::move(hit_group_names),
+                .callable_entry_points = std::move(callable_entry_points),
+            });
+        },
+        "program"_a,
+        "ray_gen_entry_points"_a = std::vector<std::string>{},
+        "miss_entry_points"_a = std::vector<std::string>{},
+        "hit_group_names"_a = std::vector<std::string>{},
+        "callable_entry_points"_a = std::vector<std::string>{},
+        D(create_shader_table)
+    );
+    m.def(
+        "create_shader_table",
+        nb::overload_cast<ShaderTableDesc>(&create_shader_table),
+        "desc"_a,
+        D(create_shader_table)
+    );
+
+    m.def(
+        "get_coop_vec_matrix_size",
+        &get_coop_vec_matrix_size,
+        "rows"_a,
+        "cols"_a,
+        "layout"_a,
+        "element_type"_a,
+        "row_col_stride"_a = 0,
+        D(get_coop_vec_matrix_size)
+    );
+    m.def(
+        "create_coop_vec_matrix_desc",
+        &create_coop_vec_matrix_desc,
+        "rows"_a,
+        "cols"_a,
+        "layout"_a,
+        "element_type"_a,
+        "offset"_a = 0,
+        "row_col_stride"_a = 0,
+        D(create_coop_vec_matrix_desc)
+    );
+    m.def(
+        "convert_coop_vec_matrices",
+        [](nb::bytearray dst,
+           std::span<CoopVecMatrixDesc> dst_descs,
+           nb::bytes src,
+           std::span<CoopVecMatrixDesc> src_descs)
+        {
+            convert_coop_vec_matrices(dst.data(), dst.size(), dst_descs, src.data(), src.size(), src_descs);
+        },
+        "dst"_a,
+        "dst_descs"_a,
+        "src"_a,
+        "src_descs"_a,
+        D(convert_coop_vec_matrices)
+    );
+    m.def(
+        "convert_coop_vec_matrix",
+        [](nb::bytearray dst, const CoopVecMatrixDesc& dst_desc, nb::bytes src, const CoopVecMatrixDesc& src_desc)
+        {
+            convert_coop_vec_matrix(dst.data(), dst.size(), dst_desc, src.data(), src.size(), src_desc);
+        },
+        "dst"_a,
+        "dst_desc"_a,
+        "src"_a,
+        "src_desc"_a,
+        D(convert_coop_vec_matrix)
+    );
+    m.def(
+        "convert_coop_vec_matrix",
+        [](nb::ndarray<nb::device::cpu> dst,
+           nb::ndarray<nb::device::cpu> src,
+           std::optional<CoopVecMatrixLayout> dst_layout,
+           std::optional<CoopVecMatrixLayout> src_layout)
+        {
+            convert_coop_vec_matrix_ndarray(current_device(), dst, src, dst_layout, src_layout);
+        },
+        "dst"_a,
+        "src"_a,
+        "dst_layout"_a = nb::none(),
+        "src_layout"_a = nb::none(),
+        D(convert_coop_vec_matrix)
+    );
+
+    m.def(
+        "create_slang_session",
+        [](std::optional<SlangCompilerOptions> compiler_options,
+           bool add_default_include_paths,
+           std::optional<std::filesystem::path> cache_path)
+        {
+            return create_slang_session(
+                SlangSessionDesc{
+                    .compiler_options = compiler_options.value_or(SlangCompilerOptions{}),
+                    .add_default_include_paths = add_default_include_paths,
+                    .cache_path = cache_path,
+                }
+            );
+        },
+        "compiler_options"_a.none() = nb::none(),
+        "add_default_include_paths"_a = SlangSessionDesc().add_default_include_paths,
+        "cache_path"_a.none() = nb::none(),
+        D(create_slang_session)
+    );
+    m.def(
+        "create_slang_session",
+        nb::overload_cast<SlangSessionDesc>(&create_slang_session),
+        "desc"_a,
+        D(create_slang_session)
+    );
+    m.def("load_module", nb::overload_cast<std::string_view>(&load_module), "module_name"_a, D(load_module));
+    m.def(
+        "load_module_from_source",
+        &load_module_from_source,
+        "module_name"_a,
+        "source"_a,
+        "path"_a.none() = nb::none(),
+        D(load_module_from_source)
+    );
+    m.def(
+        "compose_modules",
+        &compose_modules,
+        "name"_a,
+        "modules"_a,
+        "type_conformances"_a = std::span<const TypeConformance>{},
+        D(compose_modules)
+    );
+    m.def(
+        "link_program",
+        &link_program,
+        "modules"_a,
+        "entry_points"_a,
+        "link_options"_a.none() = nb::none(),
+        D(link_program)
+    );
+    m.def(
+        "load_program",
+        &load_program,
+        "module_name"_a,
+        "entry_point_names"_a,
+        "additional_source"_a.none() = nb::none(),
+        "link_options"_a.none() = nb::none(),
+        D(load_program)
+    );
+
+    m.def("create_root_shader_object", &create_root_shader_object, "shader_program"_a, D(create_root_shader_object));
+    m.def(
+        "create_shader_object",
+        [](ref<TypeLayoutReflection> type_layout)
+        {
+            return create_shader_object(type_layout.get());
+        },
+        "type_layout"_a,
+        D(create_shader_object)
+    );
+    m.def(
+        "create_shader_object",
+        nb::overload_cast<ReflectionCursor>(&create_shader_object),
+        "cursor"_a,
+        D(create_shader_object, 2)
+    );
+
+    m.def(
+        "create_compute_pipeline",
+        [](ref<ShaderProgram> program, bool defer_target_compilation, std::optional<std::string> label)
+        {
+            return create_compute_pipeline({
+                .program = std::move(program),
+                .defer_target_compilation = defer_target_compilation,
+                .label = label.value_or(""),
+            });
+        },
+        "program"_a,
+        "defer_target_compilation"_a = ComputePipelineDesc().defer_target_compilation,
+        "label"_a.none() = nb::none(),
+        D(create_compute_pipeline)
+    );
+    m.def(
+        "create_compute_pipeline",
+        nb::overload_cast<ComputePipelineDesc>(&create_compute_pipeline),
+        "desc"_a,
+        D(create_compute_pipeline)
+    );
+
+    m.def(
+        "create_render_pipeline",
+        [](ref<ShaderProgram> program,
+           ref<InputLayout> input_layout,
+           PrimitiveTopology primitive_topology,
+           std::vector<ColorTargetDesc> targets,
+           std::optional<DepthStencilDesc> depth_stencil,
+           std::optional<RasterizerDesc> rasterizer,
+           std::optional<MultisampleDesc> multisample,
+           bool defer_target_compilation,
+           std::optional<std::string> label)
+        {
+            return create_render_pipeline(
+                {.program = std::move(program),
+                 .input_layout = std::move(input_layout),
+                 .primitive_topology = primitive_topology,
+                 .targets = targets,
+                 .depth_stencil = depth_stencil.value_or(DepthStencilDesc{}),
+                 .rasterizer = rasterizer.value_or(RasterizerDesc{}),
+                 .multisample = multisample.value_or(MultisampleDesc{}),
+                 .defer_target_compilation = defer_target_compilation,
+                 .label = label.value_or("")}
+            );
+        },
+        "program"_a,
+        "input_layout"_a.none(),
+        "primitive_topology"_a = RenderPipelineDesc().primitive_topology,
+        "targets"_a = std::vector<ColorTargetDesc>{},
+        "depth_stencil"_a.none() = nb::none(),
+        "rasterizer"_a.none() = nb::none(),
+        "multisample"_a.none() = nb::none(),
+        "defer_target_compilation"_a = RenderPipelineDesc().defer_target_compilation,
+        "label"_a.none() = nb::none(),
+        D(create_render_pipeline)
+    );
+    m.def(
+        "create_render_pipeline",
+        nb::overload_cast<RenderPipelineDesc>(&create_render_pipeline),
+        "desc"_a,
+        D(create_render_pipeline)
+    );
+
+    m.def(
+        "create_ray_tracing_pipeline",
+        [](ref<ShaderProgram> program,
+           std::vector<HitGroupDesc> hit_groups,
+           uint32_t max_recursion,
+           uint32_t max_ray_payload_size,
+           uint32_t max_attribute_size,
+           RayTracingPipelineFlags flags,
+           bool defer_target_compilation,
+           std::optional<std::string> label)
+        {
+            return create_ray_tracing_pipeline({
+                .program = std::move(program),
+                .hit_groups = std::move(hit_groups),
+                .max_recursion = max_recursion,
+                .max_ray_payload_size = max_ray_payload_size,
+                .max_attribute_size = max_attribute_size,
+                .flags = flags,
+                .defer_target_compilation = defer_target_compilation,
+                .label = label.value_or(""),
+            });
+        },
+        "program"_a,
+        "hit_groups"_a,
+        "max_recursion"_a = RayTracingPipelineDesc().max_recursion,
+        "max_ray_payload_size"_a = RayTracingPipelineDesc().max_ray_payload_size,
+        "max_attribute_size"_a = RayTracingPipelineDesc().max_attribute_size,
+        "flags"_a = RayTracingPipelineDesc().flags,
+        "defer_target_compilation"_a = RayTracingPipelineDesc().defer_target_compilation,
+        "label"_a.none() = nb::none(),
+        D(create_ray_tracing_pipeline)
+    );
+    m.def(
+        "create_ray_tracing_pipeline",
+        nb::overload_cast<RayTracingPipelineDesc>(&create_ray_tracing_pipeline),
+        "desc"_a,
+        D(create_ray_tracing_pipeline)
+    );
+
+    m.def(
+        "create_compute_kernel",
+        [](ref<ShaderProgram> program)
+        {
+            return create_compute_kernel({.program = std::move(program)});
+        },
+        "program"_a,
+        D(create_compute_kernel)
+    );
+    m.def(
+        "create_compute_kernel",
+        nb::overload_cast<ComputeKernelDesc>(&create_compute_kernel),
+        "desc"_a,
+        D(create_compute_kernel)
     );
 }

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -11130,23 +11130,23 @@ static const char *__doc_sgl_platform_static_init = R"doc(Initialize the platfor
 
 static const char *__doc_sgl_platform_static_shutdown = R"doc(Shutdown the platform layer.)doc";
 
-static const char *__doc_sgl_pop_device =
+static const char *__doc_sgl_pop_current_device =
 R"doc(Pop the top device from the thread-local device stack. Throws if the
 stack is empty.
 
 Returns:
     The popped device.)doc";
 
-static const char *__doc_sgl_push_device =
-R"doc(Push a device onto the thread-local device stack.
+static const char *__doc_sgl_push_current_device =
+R"doc(Push a device onto the thread-local current device stack.
 
 Stores a raw pointer in the thread-local stack. The caller must ensure
 that the device (and any devices below it on the stack) outlive their
-corresponding pop_device() calls. Device::close() only auto-pops if
-the device is on top of the stack; a closed device lower in the stack
-remains as a stale pointer - calling current_device() or pop_device()
-on that entry is undefined behavior unless the device is kept alive
-(refcount > 0) until popped.
+corresponding pop_current_device() calls. Device::close() only auto-
+pops if the device is on top of the stack; a closed device lower in
+the stack remains as a stale pointer - calling current_device() or
+pop_current_device() on that entry is undefined behavior unless the
+device is kept alive (refcount > 0) until popped.
 
 Parameter ``device``:
     Device to push (must not be null).)doc";

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -2762,6 +2762,33 @@ static const char *__doc_sgl_DeviceLimits_max_viewport_dimensions = R"doc(Maximu
 
 static const char *__doc_sgl_DeviceLimits_max_viewports = R"doc(Maximum number of viewports per pipeline.)doc";
 
+static const char *__doc_sgl_DeviceScope =
+R"doc(RAII scope that pushes a device on construction and pops it on
+destruction.
+
+Usage:
+
+```
+{
+    DeviceScope scope(device);
+    auto buf = create_buffer(desc);
+}
+```)doc";
+
+static const char *__doc_sgl_DeviceScope_2 = R"doc()doc";
+
+static const char *__doc_sgl_DeviceScope_DeviceScope = R"doc()doc";
+
+static const char *__doc_sgl_DeviceScope_DeviceScope_2 = R"doc()doc";
+
+static const char *__doc_sgl_DeviceScope_DeviceScope_3 = R"doc()doc";
+
+static const char *__doc_sgl_DeviceScope_m_active = R"doc()doc";
+
+static const char *__doc_sgl_DeviceScope_operator_assign = R"doc()doc";
+
+static const char *__doc_sgl_DeviceScope_operator_assign_2 = R"doc()doc";
+
 static const char *__doc_sgl_DeviceType = R"doc()doc";
 
 static const char *__doc_sgl_DeviceType_automatic = R"doc()doc";
@@ -2803,17 +2830,17 @@ device is to be destroyed at runtime, it must be closed explicitly.)doc";
 
 static const char *__doc_sgl_Device_close_all_devices = R"doc(Close all open devices.)doc";
 
-static const char *__doc_sgl_Device_compose_modules = R"doc()doc";
+static const char *__doc_sgl_Device_compose_modules = R"doc(Compose multiple slang modules into one.)doc";
 
-static const char *__doc_sgl_Device_convert_coop_vec_matrices = R"doc()doc";
+static const char *__doc_sgl_Device_convert_coop_vec_matrices = R"doc(Convert multiple cooperative vector matrices between formats.)doc";
 
-static const char *__doc_sgl_Device_convert_coop_vec_matrix = R"doc()doc";
+static const char *__doc_sgl_Device_convert_coop_vec_matrix = R"doc(Convert a single cooperative vector matrix between formats.)doc";
 
 static const char *__doc_sgl_Device_create = R"doc()doc";
 
-static const char *__doc_sgl_Device_create_acceleration_structure = R"doc()doc";
+static const char *__doc_sgl_Device_create_acceleration_structure = R"doc(Create a new acceleration structure.)doc";
 
-static const char *__doc_sgl_Device_create_acceleration_structure_instance_list = R"doc()doc";
+static const char *__doc_sgl_Device_create_acceleration_structure_instance_list = R"doc(Create a new acceleration structure instance list.)doc";
 
 static const char *__doc_sgl_Device_create_buffer =
 R"doc(Create a new buffer.
@@ -2856,15 +2883,15 @@ Parameter ``data_size``:
 Returns:
     New buffer object.)doc";
 
-static const char *__doc_sgl_Device_create_buffer_view = R"doc()doc";
+static const char *__doc_sgl_Device_create_buffer_view = R"doc(Create a new buffer view.)doc";
 
-static const char *__doc_sgl_Device_create_command_encoder = R"doc()doc";
+static const char *__doc_sgl_Device_create_command_encoder = R"doc(Create a command encoder.)doc";
 
-static const char *__doc_sgl_Device_create_compute_kernel = R"doc()doc";
+static const char *__doc_sgl_Device_create_compute_kernel = R"doc(Create a compute kernel.)doc";
 
-static const char *__doc_sgl_Device_create_compute_pipeline = R"doc()doc";
+static const char *__doc_sgl_Device_create_compute_pipeline = R"doc(Create a compute pipeline.)doc";
 
-static const char *__doc_sgl_Device_create_coop_vec_matrix_desc = R"doc()doc";
+static const char *__doc_sgl_Device_create_coop_vec_matrix_desc = R"doc(Create a cooperative vector matrix descriptor.)doc";
 
 static const char *__doc_sgl_Device_create_fence =
 R"doc(Create a new fence.
@@ -2902,11 +2929,11 @@ Parameter ``count``:
 Returns:
     New query pool object.)doc";
 
-static const char *__doc_sgl_Device_create_ray_tracing_pipeline = R"doc()doc";
+static const char *__doc_sgl_Device_create_ray_tracing_pipeline = R"doc(Create a ray tracing pipeline.)doc";
 
-static const char *__doc_sgl_Device_create_render_pipeline = R"doc()doc";
+static const char *__doc_sgl_Device_create_render_pipeline = R"doc(Create a render pipeline.)doc";
 
-static const char *__doc_sgl_Device_create_root_shader_object = R"doc()doc";
+static const char *__doc_sgl_Device_create_root_shader_object = R"doc(Create a root shader object for a shader program.)doc";
 
 static const char *__doc_sgl_Device_create_sampler =
 R"doc(Create a new sampler.
@@ -2956,11 +2983,11 @@ Parameter ``label``:
 Returns:
     New sampler object.)doc";
 
-static const char *__doc_sgl_Device_create_shader_object = R"doc()doc";
+static const char *__doc_sgl_Device_create_shader_object = R"doc(Create a shader object from a type layout.)doc";
 
-static const char *__doc_sgl_Device_create_shader_object_2 = R"doc()doc";
+static const char *__doc_sgl_Device_create_shader_object_2 = R"doc(Create a shader object from a reflection cursor.)doc";
 
-static const char *__doc_sgl_Device_create_shader_table = R"doc()doc";
+static const char *__doc_sgl_Device_create_shader_table = R"doc(Create a new shader table.)doc";
 
 static const char *__doc_sgl_Device_create_slang_session =
 R"doc(Create a new slang session.
@@ -3035,9 +3062,9 @@ Parameter ``data``:
 Returns:
     New texture object.)doc";
 
-static const char *__doc_sgl_Device_create_texture_from_resource = R"doc()doc";
+static const char *__doc_sgl_Device_create_texture_from_resource = R"doc(Create a texture from an existing RHI resource.)doc";
 
-static const char *__doc_sgl_Device_create_texture_view = R"doc()doc";
+static const char *__doc_sgl_Device_create_texture_view = R"doc(Create a new texture view.)doc";
 
 static const char *__doc_sgl_Device_cuda_device = R"doc()doc";
 
@@ -3082,7 +3109,7 @@ Parameter ``desc``:
 Returns:
     Acceleration structure sizes.)doc";
 
-static const char *__doc_sgl_Device_get_coop_vec_matrix_size = R"doc()doc";
+static const char *__doc_sgl_Device_get_coop_vec_matrix_size = R"doc(Get the size of a cooperative vector matrix in bytes.)doc";
 
 static const char *__doc_sgl_Device_get_created_devices = R"doc(Lists all created devices)doc";
 
@@ -3113,13 +3140,13 @@ Parameter ``id``:
 Returns:
     True if the submission is finished executing.)doc";
 
-static const char *__doc_sgl_Device_link_program = R"doc()doc";
+static const char *__doc_sgl_Device_link_program = R"doc(Link modules and entry points into a shader program.)doc";
 
-static const char *__doc_sgl_Device_load_module = R"doc()doc";
+static const char *__doc_sgl_Device_load_module = R"doc(Load a slang module by name.)doc";
 
-static const char *__doc_sgl_Device_load_module_from_source = R"doc()doc";
+static const char *__doc_sgl_Device_load_module_from_source = R"doc(Load a slang module from source code.)doc";
 
-static const char *__doc_sgl_Device_load_program = R"doc()doc";
+static const char *__doc_sgl_Device_load_program = R"doc(Load a module and link a shader program in one step.)doc";
 
 static const char *__doc_sgl_Device_m_blitter = R"doc()doc";
 
@@ -3238,7 +3265,7 @@ workaround during shutdown, to ensure all resources are released when
 slangpy fails to clean up properly due to reference cycles introduced
 in Python.)doc";
 
-static const char *__doc_sgl_Device_reload_all_programs = R"doc()doc";
+static const char *__doc_sgl_Device_reload_all_programs = R"doc(Reload all shader programs.)doc";
 
 static const char *__doc_sgl_Device_report_heaps =
 R"doc(Report status of internal heaps used by the device.
@@ -8975,6 +9002,12 @@ static const char *__doc_sgl_comparator = R"doc()doc";
 
 static const char *__doc_sgl_comparator_operator_call = R"doc()doc";
 
+static const char *__doc_sgl_compose_modules = R"doc(Compose multiple slang modules into one.)doc";
+
+static const char *__doc_sgl_convert_coop_vec_matrices = R"doc(Convert multiple cooperative vector matrices between formats.)doc";
+
+static const char *__doc_sgl_convert_coop_vec_matrix = R"doc(Convert a single cooperative vector matrix between formats.)doc";
+
 static const char *__doc_sgl_crashpad_is_supported = R"doc(Returns true if Crashpad is supported in this build.)doc";
 
 static const char *__doc_sgl_crashpad_start_handler =
@@ -8993,6 +9026,234 @@ Parameter ``database``:
 
 Parameter ``annotations``:
     Annotations to include with crash reports.)doc";
+
+static const char *__doc_sgl_create_acceleration_structure = R"doc(Create a new acceleration structure.)doc";
+
+static const char *__doc_sgl_create_acceleration_structure_instance_list = R"doc(Create a new acceleration structure instance list.)doc";
+
+static const char *__doc_sgl_create_buffer =
+R"doc(Create a new buffer.
+
+Parameter ``size``:
+    Buffer size in bytes.
+
+Parameter ``element_count``:
+    Buffer size in number of struct elements. Can be used instead of
+    ``size``.
+
+Parameter ``struct_size``:
+    Struct size in bytes.
+
+Parameter ``resource_type_layout``:
+    Resource type layout of the buffer. Can be used instead of
+    ``struct_size`` to specify the size of the struct.
+
+Parameter ``format``:
+    Buffer format. Used when creating typed buffer views.
+
+Parameter ``initial_state``:
+    Initial resource state.
+
+Parameter ``usage``:
+    Resource usage flags.
+
+Parameter ``memory_type``:
+    Memory type.
+
+Parameter ``label``:
+    Debug label.
+
+Parameter ``data``:
+    Initial data to upload to the buffer.
+
+Parameter ``data_size``:
+    Size of the initial data in bytes.
+
+Returns:
+    New buffer object.)doc";
+
+static const char *__doc_sgl_create_buffer_view = R"doc(Create a new buffer view.)doc";
+
+static const char *__doc_sgl_create_command_encoder = R"doc(Create a command encoder.)doc";
+
+static const char *__doc_sgl_create_compute_kernel = R"doc(Create a compute kernel.)doc";
+
+static const char *__doc_sgl_create_compute_pipeline = R"doc(Create a compute pipeline.)doc";
+
+static const char *__doc_sgl_create_coop_vec_matrix_desc = R"doc(Create a cooperative vector matrix descriptor.)doc";
+
+static const char *__doc_sgl_create_fence =
+R"doc(Create a new fence.
+
+Parameter ``initial_value``:
+    Initial fence value.
+
+Parameter ``shared``:
+    Create a shared fence.
+
+Returns:
+    New fence object.)doc";
+
+static const char *__doc_sgl_create_input_layout =
+R"doc(Create a new input layout.
+
+Parameter ``input_elements``:
+    List of input elements (see InputElementDesc for details).
+
+Parameter ``vertex_streams``:
+    List of vertex streams (see VertexStreamDesc for details).
+
+Returns:
+    New input layout object.)doc";
+
+static const char *__doc_sgl_create_query_pool =
+R"doc(Create a new query pool.
+
+Parameter ``type``:
+    Query type.
+
+Parameter ``count``:
+    Number of queries in the pool.
+
+Returns:
+    New query pool object.)doc";
+
+static const char *__doc_sgl_create_ray_tracing_pipeline = R"doc(Create a ray tracing pipeline.)doc";
+
+static const char *__doc_sgl_create_render_pipeline = R"doc(Create a render pipeline.)doc";
+
+static const char *__doc_sgl_create_root_shader_object = R"doc(Create a root shader object for a shader program.)doc";
+
+static const char *__doc_sgl_create_sampler =
+R"doc(Create a new sampler.
+
+Parameter ``min_filter``:
+    Minification filter.
+
+Parameter ``mag_filter``:
+    Magnification filter.
+
+Parameter ``mip_filter``:
+    Mip-map filter.
+
+Parameter ``reduction_op``:
+    Reduction operation.
+
+Parameter ``address_u``:
+    Texture addressing mode for the U coordinate.
+
+Parameter ``address_v``:
+    Texture addressing mode for the V coordinate.
+
+Parameter ``address_w``:
+    Texture addressing mode for the W coordinate.
+
+Parameter ``mip_lod_bias``:
+    Mip-map LOD bias.
+
+Parameter ``max_anisotropy``:
+    Maximum anisotropy.
+
+Parameter ``comparison_func``:
+    Comparison function.
+
+Parameter ``border_color``:
+    Border color.
+
+Parameter ``min_lod``:
+    Minimum LOD level.
+
+Parameter ``max_lod``:
+    Maximum LOD level.
+
+Parameter ``label``:
+    Debug label.
+
+Returns:
+    New sampler object.)doc";
+
+static const char *__doc_sgl_create_shader_object = R"doc(Create a shader object from a type layout.)doc";
+
+static const char *__doc_sgl_create_shader_object_2 = R"doc(Create a shader object from a reflection cursor.)doc";
+
+static const char *__doc_sgl_create_shader_table = R"doc(Create a new shader table.)doc";
+
+static const char *__doc_sgl_create_slang_session =
+R"doc(Create a new slang session.
+
+Parameter ``compiler_options``:
+    Compiler options (see SlangCompilerOptions for details).
+
+Returns:
+    New slang session object.)doc";
+
+static const char *__doc_sgl_create_surface =
+R"doc(Create a new surface.
+
+Parameter ``window``:
+    Window to create the surface for.
+
+Returns:
+    New surface object.)doc";
+
+static const char *__doc_sgl_create_surface_2 =
+R"doc(Create a new surface.
+
+Parameter ``window_handle``:
+    Native window handle to create the surface for.
+
+Returns:
+    New surface object.)doc";
+
+static const char *__doc_sgl_create_texture =
+R"doc(Create a new texture.
+
+Parameter ``type``:
+    Texture type.
+
+Parameter ``format``:
+    Texture format.
+
+Parameter ``width``:
+    Width in pixels.
+
+Parameter ``height``:
+    Height in pixels.
+
+Parameter ``depth``:
+    Depth in pixels.
+
+Parameter ``array_length``:
+    Array length.
+
+Parameter ``mip_count``:
+    Mip level count. Number of mip levels (ALL_MIPS for all mip
+    levels).
+
+Parameter ``sample_count``:
+    Number of samples for multisampled textures.
+
+Parameter ``quality``:
+    Quality level for multisampled textures.
+
+Parameter ``usage``:
+    Resource usage.
+
+Parameter ``memory_type``:
+    Memory type.
+
+Parameter ``label``:
+    Debug label.
+
+Parameter ``data``:
+    Initial data.
+
+Returns:
+    New texture object.)doc";
+
+static const char *__doc_sgl_create_texture_from_resource = R"doc(Create a texture from an existing RHI resource.)doc";
+
+static const char *__doc_sgl_create_texture_view = R"doc(Create a new texture view.)doc";
 
 static const char *__doc_sgl_cuda_ContextScope = R"doc()doc";
 
@@ -9133,6 +9394,13 @@ static const char *__doc_sgl_cuda_memset_device_async = R"doc()doc";
 static const char *__doc_sgl_cuda_signal_external_semaphore = R"doc()doc";
 
 static const char *__doc_sgl_cuda_wait_external_semaphore = R"doc()doc";
+
+static const char *__doc_sgl_current_device =
+R"doc(Get the current device from the top of the thread-local device stack.
+Throws if the stack is empty.
+
+Returns:
+    The current device.)doc";
 
 static const char *__doc_sgl_cursor_utils_check_array = R"doc()doc";
 
@@ -9426,6 +9694,18 @@ static const char *__doc_sgl_flip_bit_12 = R"doc()doc";
 
 static const char *__doc_sgl_flip_bit_13 = R"doc()doc";
 
+static const char *__doc_sgl_get_acceleration_structure_sizes =
+R"doc(Query the device for buffer sizes required for acceleration structure
+builds.
+
+Parameter ``desc``:
+    Acceleration structure build description.
+
+Returns:
+    Acceleration structure sizes.)doc";
+
+static const char *__doc_sgl_get_coop_vec_matrix_size = R"doc(Get the size of a cooperative vector matrix in bytes.)doc";
+
 static const char *__doc_sgl_get_cuda_current_context_native_handles =
 R"doc(Gets the device and context handles for the current CUDA context. Use
 to retrieve an existing context (eg from PyTorch) to pass as the
@@ -9495,6 +9775,14 @@ static const char *__doc_sgl_is_set_13 = R"doc()doc";
 static const char *__doc_sgl_layout_from_rhilayout = R"doc()doc";
 
 static const char *__doc_sgl_lerp = R"doc(Linearly interpolate between a and b.)doc";
+
+static const char *__doc_sgl_link_program = R"doc(Link modules and entry points into a shader program.)doc";
+
+static const char *__doc_sgl_load_module = R"doc(Load a slang module by name.)doc";
+
+static const char *__doc_sgl_load_module_from_source = R"doc(Load a slang module from source code.)doc";
+
+static const char *__doc_sgl_load_program = R"doc(Load a module and link a shader program in one step.)doc";
 
 static const char *__doc_sgl_log_debug = R"doc()doc";
 
@@ -10835,6 +11123,17 @@ static const char *__doc_sgl_platform_set_window_icon = R"doc(Set the window ico
 static const char *__doc_sgl_platform_static_init = R"doc(Initialize the platform layer.)doc";
 
 static const char *__doc_sgl_platform_static_shutdown = R"doc(Shutdown the platform layer.)doc";
+
+static const char *__doc_sgl_pop_device =
+R"doc(Pop the top device from the thread-local device stack. Throws if the
+stack is empty.)doc";
+
+static const char *__doc_sgl_push_device =
+R"doc(Push a device onto the thread-local device stack. The device must
+outlive the corresponding pop_device() call.
+
+Parameter ``device``:
+    Device to push (must not be null).)doc";
 
 static const char *__doc_sgl_ref = R"doc()doc";
 

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -2766,6 +2766,10 @@ static const char *__doc_sgl_DeviceScope =
 R"doc(RAII scope that pushes a device on construction and pops it on
 destruction.
 
+The device stack must not be externally mutated (push/pop) while a
+DeviceScope is active; doing so may cause the destructor to pop the
+wrong device. In debug builds an assertion checks LIFO ordering.
+
 Usage:
 
 ```
@@ -2784,6 +2788,8 @@ static const char *__doc_sgl_DeviceScope_DeviceScope_2 = R"doc()doc";
 static const char *__doc_sgl_DeviceScope_DeviceScope_3 = R"doc()doc";
 
 static const char *__doc_sgl_DeviceScope_m_active = R"doc()doc";
+
+static const char *__doc_sgl_DeviceScope_m_device = R"doc()doc";
 
 static const char *__doc_sgl_DeviceScope_operator_assign = R"doc()doc";
 
@@ -11126,11 +11132,21 @@ static const char *__doc_sgl_platform_static_shutdown = R"doc(Shutdown the platf
 
 static const char *__doc_sgl_pop_device =
 R"doc(Pop the top device from the thread-local device stack. Throws if the
-stack is empty.)doc";
+stack is empty.
+
+Returns:
+    The popped device.)doc";
 
 static const char *__doc_sgl_push_device =
-R"doc(Push a device onto the thread-local device stack. The device must
-outlive the corresponding pop_device() call.
+R"doc(Push a device onto the thread-local device stack.
+
+Stores a raw pointer in the thread-local stack. The caller must ensure
+that the device (and any devices below it on the stack) outlive their
+corresponding pop_device() calls. Device::close() only auto-pops if
+the device is on top of the stack; a closed device lower in the stack
+remains as a stale pointer - calling current_device() or pop_device()
+on that entry is undefined behavior unless the device is kept alive
+(refcount > 0) until popped.
 
 Parameter ``device``:
     Device to push (must not be null).)doc";


### PR DESCRIPTION
- Add free standing device API (mirroring the members on `Device` class)
- Add thread-local device stack and `push_current_device`, `pop_current_device` and `current_device` API
- Add context manager for Python `Device`
- Creating a device automatically pushes it to the device stack (allowing free standing API to "just work")
- Closing a device automatically pops it from the device stack if at the top
- Matching push/pop semantics to what CUDA context handling does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Device context management system: push, pop, and retrieve the current device across operations
  - Device context manager support enabling Python `with` statement usage
  - Free-standing creation functions for resources (buffers, textures, surfaces, samplers, pipelines, kernels, etc.) that delegate to the current device

* **Tests**
  - Comprehensive test suite for device API functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->