### PR TITLE
Automatically marshall Python objects with get_this()

### DIFF
--- a/slangpy/tests/device/test_buffer_cursor.py
+++ b/slangpy/tests/device/test_buffer_cursor.py
@@ -10,6 +10,15 @@ from slangpy.testing import helpers
 
 from typing import Any
 
+
+class WrappedTextureHandle:
+    def __init__(self, value: int):
+        self.m_value = value
+
+    def get_this(self) -> dict[str, Any]:
+        return {"_type": "TextureHandle", "value": self.m_value}
+
+
 TESTS = [
     ("f_bool", "bool", "true", True),
     ("f_bool1", "bool1", "false", spy.bool1(False)),
@@ -328,6 +337,27 @@ def make_copy_module(device_type: spy.DeviceType, tests: list[Any]):
     return (device.create_compute_kernel(prog), resource_type_layout)
 
 
+def make_marshaled_object_layout(device_type: spy.DeviceType):
+    device = helpers.get_device(type=device_type)
+    module = device.load_module_from_source(
+        "test_buffer_cursor_marshaled_objects",
+        """
+struct TextureHandle {
+    uint value;
+};
+
+struct TestType {
+    TextureHandle textures[2];
+};
+
+StructuredBuffer<TestType> buffer;
+""",
+    )
+    return module.layout.get_type_layout(
+        module.layout.find_type_by_name("StructuredBuffer<TestType>")
+    )
+
+
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 @pytest.mark.parametrize("seed", RAND_SEEDS)
 def test_cursor_read_write(device_type: spy.DeviceType, seed: int):
@@ -458,6 +488,18 @@ def test_cursor_lifetime(device_type: spy.DeviceType):
 
     # Ensure we can still write to the element (as it should be holding a reference to the cursor)
     element["f_int32"] = 123
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_marshaled_object_list(device_type: spy.DeviceType):
+    resource_type_layout = make_marshaled_object_layout(device_type)
+
+    cursor = spy.BufferCursor(device_type, resource_type_layout.element_type_layout, 1)
+    element = cursor[0]
+    element["textures"] = [WrappedTextureHandle(11), WrappedTextureHandle(22)]
+
+    textures = element["textures"].read()
+    assert [texture["value"] for texture in textures] == [11, 22]
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)

--- a/slangpy/tests/device/test_buffer_cursor.py
+++ b/slangpy/tests/device/test_buffer_cursor.py
@@ -19,6 +19,11 @@ class WrappedTextureHandle:
         return {"_type": "TextureHandle", "value": self.m_value}
 
 
+class SelfReturningWrapper:
+    def get_this(self) -> "SelfReturningWrapper":
+        return self
+
+
 TESTS = [
     ("f_bool", "bool", "true", True),
     ("f_bool1", "bool1", "false", spy.bool1(False)),
@@ -500,6 +505,17 @@ def test_marshaled_object_list(device_type: spy.DeviceType):
 
     textures = element["textures"].read()
     assert [texture["value"] for texture in textures] == [11, 22]
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_marshaled_object_self_returning_get_this(device_type: spy.DeviceType):
+    resource_type_layout = make_marshaled_object_layout(device_type)
+
+    cursor = spy.BufferCursor(device_type, resource_type_layout.element_type_layout, 1)
+    element = cursor[0]
+
+    with pytest.raises(RuntimeError, match="Expected dict"):
+        element["textures"] = [SelfReturningWrapper(), SelfReturningWrapper()]
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -488,7 +488,7 @@ private:
     {
         bool had_unpack = false;
         nb::object unpacked = slangpy::unpack_arg(obj, had_unpack);
-        if (!had_unpack)
+        if (!had_unpack || unpacked.ptr() == obj.ptr())
             return false;
         write_internal(self, unpacked);
         return true;

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -12,6 +12,7 @@
 #include "sgl/math/vector_types.h"
 #include "sgl/math/matrix_types.h"
 
+#include "utils/slangpy.h"
 #include "utils/slangpypackedarg.h"
 #include "utils/slangpystridedbufferview.h"
 #include "sgl/device/buffer_cursor.h"
@@ -483,38 +484,10 @@ private:
 
     std::string build_error() { return fmt::format("{}", fmt::join(m_stack, ".")); }
 
-    nb::object unpack_object(nb::object obj, bool& out_had_unpack)
-    {
-        if (nb::hasattr(obj, "get_this")) {
-            obj = nb::getattr(obj, "get_this")();
-            out_had_unpack = true;
-        }
-
-        nb::dict dict;
-        if (nb::try_cast(obj, dict)) {
-            nb::dict normalized;
-            for (auto [key, value] : dict) {
-                normalized[key] = unpack_object(nb::cast<nb::object>(value), out_had_unpack);
-            }
-            return normalized;
-        }
-
-        nb::list list;
-        if (nb::try_cast(obj, list)) {
-            nb::list normalized;
-            for (auto value : list) {
-                normalized.append(unpack_object(nb::cast<nb::object>(value), out_had_unpack));
-            }
-            return normalized;
-        }
-
-        return obj;
-    }
-
     bool try_unpack_and_retry(CursorType& self, nb::object obj)
     {
         bool had_unpack = false;
-        nb::object unpacked = unpack_object(obj, had_unpack);
+        nb::object unpacked = slangpy::unpack_arg(obj, had_unpack);
         if (!had_unpack)
             return false;
         write_internal(self, unpacked);

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -483,6 +483,33 @@ private:
 
     std::string build_error() { return fmt::format("{}", fmt::join(m_stack, ".")); }
 
+    nb::object normalize_marshaled_object(nb::object obj)
+    {
+        if (nb::hasattr(obj, "get_this")) {
+            obj = nb::getattr(obj, "get_this")();
+        }
+
+        nb::dict dict;
+        if (nb::try_cast(obj, dict)) {
+            nb::dict normalized;
+            for (auto [key, value] : dict) {
+                normalized[key] = normalize_marshaled_object(nb::cast<nb::object>(value));
+            }
+            return normalized;
+        }
+
+        nb::list list;
+        if (nb::try_cast(obj, list)) {
+            nb::list normalized;
+            for (auto value : list) {
+                normalized.append(normalize_marshaled_object(nb::cast<nb::object>(value)));
+            }
+            return normalized;
+        }
+
+        return obj;
+    }
+
     void write_from_numpy_internal(BufferCursor& dst, BufferElementCursor self, nb::object nbval, bool unchecked_copy)
         requires std::same_as<CursorType, BufferElementCursor>
     {
@@ -666,6 +693,8 @@ private:
             auto view = nb::cast<sgl::slangpy::StridedBufferView*>(nbval);
             nbval = view->uniforms();
         }
+
+        nbval = normalize_marshaled_object(nbval);
 
         slang::TypeLayoutReflection* type_layout = self.slang_type_layout();
         auto kind = (TypeReflection::Kind)type_layout->getKind();

--- a/src/slangpy_ext/device/cursor_utils.h
+++ b/src/slangpy_ext/device/cursor_utils.h
@@ -483,17 +483,18 @@ private:
 
     std::string build_error() { return fmt::format("{}", fmt::join(m_stack, ".")); }
 
-    nb::object normalize_marshaled_object(nb::object obj)
+    nb::object unpack_object(nb::object obj, bool& out_had_unpack)
     {
         if (nb::hasattr(obj, "get_this")) {
             obj = nb::getattr(obj, "get_this")();
+            out_had_unpack = true;
         }
 
         nb::dict dict;
         if (nb::try_cast(obj, dict)) {
             nb::dict normalized;
             for (auto [key, value] : dict) {
-                normalized[key] = normalize_marshaled_object(nb::cast<nb::object>(value));
+                normalized[key] = unpack_object(nb::cast<nb::object>(value), out_had_unpack);
             }
             return normalized;
         }
@@ -502,12 +503,22 @@ private:
         if (nb::try_cast(obj, list)) {
             nb::list normalized;
             for (auto value : list) {
-                normalized.append(normalize_marshaled_object(nb::cast<nb::object>(value)));
+                normalized.append(unpack_object(nb::cast<nb::object>(value), out_had_unpack));
             }
             return normalized;
         }
 
         return obj;
+    }
+
+    bool try_unpack_and_retry(CursorType& self, nb::object obj)
+    {
+        bool had_unpack = false;
+        nb::object unpacked = unpack_object(obj, had_unpack);
+        if (!had_unpack)
+            return false;
+        write_internal(self, unpacked);
+        return true;
     }
 
     void write_from_numpy_internal(BufferCursor& dst, BufferElementCursor self, nb::object nbval, bool unchecked_copy)
@@ -694,8 +705,6 @@ private:
             nbval = view->uniforms();
         }
 
-        nbval = normalize_marshaled_object(nbval);
-
         slang::TypeLayoutReflection* type_layout = self.slang_type_layout();
         auto kind = (TypeReflection::Kind)type_layout->getKind();
 
@@ -703,17 +712,38 @@ private:
         case TypeReflection::Kind::scalar: {
             auto type = type_layout->getType();
             SGL_ASSERT(type);
-            return m_write_scalar[(int)type->getScalarType()](self, nbval);
+            try {
+                return m_write_scalar[(int)type->getScalarType()](self, nbval);
+            } catch (const std::exception&) {
+                if (try_unpack_and_retry(self, nbval))
+                    return;
+                throw;
+            }
         }
         case TypeReflection::Kind::vector: {
             auto type = type_layout->getType();
             SGL_ASSERT(type);
-            return m_write_vector[(int)type->getScalarType()][type->getColumnCount()](self, nbval);
+            try {
+                return m_write_vector[(int)type->getScalarType()][type->getColumnCount()](self, nbval);
+            } catch (const std::exception&) {
+                if (try_unpack_and_retry(self, nbval))
+                    return;
+                throw;
+            }
         }
         case TypeReflection::Kind::matrix: {
             auto type = type_layout->getType();
             SGL_ASSERT(type);
-            return m_write_matrix[(int)type->getScalarType()][type->getRowCount()][type->getColumnCount()](self, nbval);
+            try {
+                return m_write_matrix[(int)type->getScalarType()][type->getRowCount()][type->getColumnCount()](
+                    self,
+                    nbval
+                );
+            } catch (const std::exception&) {
+                if (try_unpack_and_retry(self, nbval))
+                    return;
+                throw;
+            }
         }
         case TypeReflection::Kind::pointer: {
             // Pointers are represented as uint64_t in slang.
@@ -745,6 +775,8 @@ private:
                 return;
             }
 
+            if (try_unpack_and_retry(self, nbval))
+                return;
             SGL_THROW("Expected dict");
             return;
         }
@@ -778,6 +810,8 @@ private:
                 }
                 return;
             } else {
+                if (try_unpack_and_retry(self, nbval))
+                    return;
                 SGL_THROW("Expected dict");
             }
         }
@@ -811,6 +845,8 @@ private:
                 m_stack.pop_back();
                 return;
             } else {
+                if (try_unpack_and_retry(self, nbval))
+                    return;
                 SGL_THROW("Expected list");
             }
         }
@@ -820,6 +856,9 @@ private:
 
         // In default case call the virtual write_value, and fail if it returns false.
         if (write_value(self, nbval))
+            return;
+
+        if (try_unpack_and_retry(self, nbval))
             return;
 
         SGL_THROW("Unsupported element type: {}", kind);


### PR DESCRIPTION
- Python objects with `get_this()` that haven't been marshalled into a Cursor by any other means will try to expand the `get_this()` as a last point before throwing as being incompatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering structured-buffer fields with arrays of nested/marshalled objects, verifying write/read round-trips preserve element values and ordering and that invalid wrapper types produce expected errors.

* **Refactor**
  * More robust input handling for buffer writes: attempts a safe retry when given wrapped or unpackable Python values, improving acceptance of common wrapper patterns and error clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->