### PR TITLE
Fix SlangSession::load_module_from_source

### DIFF
--- a/slangpy/tests/device/test_shader.py
+++ b/slangpy/tests/device/test_shader.py
@@ -82,6 +82,41 @@ def test_load_module_from_source(test_id: str, device_type: spy.DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_load_module_from_source_dedup(test_id: str, device_type: spy.DeviceType):
+    device = helpers.get_device(type=device_type)
+
+    source = """
+        [shader("compute")]
+        [numthreads(1, 1, 1)]
+        void main(uint3 tid: SV_DispatchThreadID) { }
+    """
+
+    # Loading the same module name with the same source twice must succeed.
+    name = f"dedup_same_name_{test_id}"
+    module_a = device.load_module_from_source(module_name=name, source=source)
+    module_b = device.load_module_from_source(module_name=name, source=source)
+    assert module_a is not None
+    assert module_b is not None
+
+    # Loading the same module name with different source must raise an exception.
+    with pytest.raises(SlangCompileError, match="already loaded with different source"):
+        device.load_module_from_source(
+            module_name=name,
+            source="""
+                [shader("compute")]
+                [numthreads(2, 2, 1)]
+                void main(uint3 tid: SV_DispatchThreadID) { }
+            """,
+        )
+
+    # Loading the same source with two different module names must succeed.
+    module_c = device.load_module_from_source(module_name=f"dedup_name_1_{test_id}", source=source)
+    module_d = device.load_module_from_source(module_name=f"dedup_name_2_{test_id}", source=source)
+    assert module_c is not None
+    assert module_d is not None
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_load_program(device_type: spy.DeviceType):
     device = helpers.get_device(type=device_type)
 

--- a/src/sgl/device/shader.cpp
+++ b/src/sgl/device/shader.cpp
@@ -517,6 +517,22 @@ ref<SlangModule> SlangSession::load_module_from_source(
     std::optional<std::filesystem::path> path
 )
 {
+    // TODO: This is a workaround until we use a Slang release with this fix:
+    // https://github.com/shader-slang/slang/pull/10996
+    // Once this is fixed on the Slang side, we can remove the digest check and just rely on Slang's internal caching
+    // mechanism.
+    SHA1::Digest digest = SHA1(source).digest();
+    auto it = m_source_module_digests.find(module_name);
+    if (it != m_source_module_digests.end()) {
+        if (it->second != digest) {
+            throw SlangCompileError(
+                fmt::format("Module \"{}\" already loaded with different source in this session.", module_name)
+            );
+        }
+    } else {
+        m_source_module_digests.emplace(std::string{module_name}, digest);
+    }
+
     SlangModuleDesc desc;
     desc.module_name = module_name;
     desc.source = source;
@@ -916,9 +932,10 @@ void SlangModule::load(SlangSessionBuild& build_data) const
                 throw SlangCompileError(msg);
             }
         } else {
-            // TODO workaround: slang doesn't like loading the same source twice
-            static uint32_t id = 0;
-            std::string source_str = fmt::format("// {}\n{}", id++, desc.source);
+            // TODO: This is a workaround until we use a Slang release with this fix:
+            // https://github.com/shader-slang/slang/pull/10996
+            // Once this is fixed on the Slang side, we can remove this.
+            std::string source_str = fmt::format("// {}\n{}", desc.module_name, desc.source.value());
 
             SGL_CATCH_INTERNAL_SLANG_ERROR(
                 slang_module = session_data->slang_session->loadModuleFromSourceString(

--- a/src/sgl/device/shader.h
+++ b/src/sgl/device/shader.h
@@ -9,6 +9,7 @@
 
 #include "sgl/core/object.h"
 #include "sgl/core/enum.h"
+#include "sgl/core/crypto.h"
 
 #include <exception>
 #include <map>
@@ -358,6 +359,9 @@ private:
 
     /// Helper to create a module, updating cache afterwards.
     ref<SlangModule> create_module(SlangModuleDesc desc);
+
+    /// Cache of module name -> source SHA1 digest to detect same-name-different-source misuse.
+    std::map<std::string, SHA1::Digest, std::less<>> m_source_module_digests;
 };
 
 struct SlangModuleDesc {


### PR DESCRIPTION
Implement a workaround until https://github.com/shader-slang/slang/pull/10996 lands. Maintain a module name -> source digest map to check that loading a module from source behaves correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Module loading system now enforces consistency by detecting and rejecting attempts to reload the same module name with different source code, while still supporting repeated loads of identical modules and distinct modules sharing the same source.

* **Tests**
  * Added parametrized test suite validating module deduplication semantics and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->