### PR TITLE
A wrapper for Cursors that allows us to write virtual write_to_cursor

### DIFF
--- a/src/sgl/CMakeLists.txt
+++ b/src/sgl/CMakeLists.txt
@@ -69,6 +69,8 @@ target_sources(sgl PRIVATE
     core/window.h
 
     device/agility_sdk.h
+    device/any_cursor.cpp
+    device/any_cursor.h
     device/blit.cpp
     device/blit.h
     device/blit.slang

--- a/src/sgl/device/any_cursor.cpp
+++ b/src/sgl/device/any_cursor.cpp
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "any_cursor.h"
+
+#include "sgl/core/error.h"
+
+#include "sgl/device/cuda_interop.h"
+#include "sgl/device/resource.h"
+
+namespace sgl {
+namespace {
+
+    [[noreturn]] void throw_unsupported(std::string_view operation)
+    {
+        SGL_THROW("{} is not supported by BufferElementCursor-backed AnyCursor.", operation);
+    }
+
+    bool is_pointer_cursor(const BufferElementCursor& cursor)
+    {
+        slang::TypeLayoutReflection* type_layout = cursor.slang_type_layout();
+        slang::TypeReflection* type = type_layout ? type_layout->getType() : nullptr;
+        return type && type->getKind() == slang::TypeReflection::Kind::Pointer;
+    }
+
+    void require_pointer_cursor(const BufferElementCursor& cursor, std::string_view operation)
+    {
+        SGL_CHECK(
+            is_pointer_cursor(cursor),
+            "{} requires a pointer field when used with BufferElementCursor-backed AnyCursor.",
+            operation
+        );
+    }
+
+} // namespace
+
+AnyCursor::AnyCursor(ShaderCursor cursor)
+    : m_cursor(cursor)
+{
+}
+
+AnyCursor::AnyCursor(BufferElementCursor cursor)
+    : m_cursor(std::move(cursor))
+{
+}
+
+bool AnyCursor::is_shader_cursor() const
+{
+    return std::holds_alternative<ShaderCursor>(m_cursor);
+}
+
+bool AnyCursor::is_buffer_element_cursor() const
+{
+    return std::holds_alternative<BufferElementCursor>(m_cursor);
+}
+
+ShaderCursor* AnyCursor::as_shader_cursor()
+{
+    return std::get_if<ShaderCursor>(&m_cursor);
+}
+
+const ShaderCursor* AnyCursor::as_shader_cursor() const
+{
+    return std::get_if<ShaderCursor>(&m_cursor);
+}
+
+BufferElementCursor* AnyCursor::as_buffer_element_cursor()
+{
+    return std::get_if<BufferElementCursor>(&m_cursor);
+}
+
+const BufferElementCursor* AnyCursor::as_buffer_element_cursor() const
+{
+    return std::get_if<BufferElementCursor>(&m_cursor);
+}
+
+bool AnyCursor::is_valid() const
+{
+    return std::visit(
+        [](const auto& cursor)
+        {
+            return cursor.is_valid();
+        },
+        m_cursor
+    );
+}
+
+std::string AnyCursor::to_string() const
+{
+    return std::visit(
+        [](const auto& cursor)
+        {
+            return cursor.to_string();
+        },
+        m_cursor
+    );
+}
+
+slang::TypeLayoutReflection* AnyCursor::slang_type_layout() const
+{
+    return std::visit(
+        [](const auto& cursor)
+        {
+            return cursor.slang_type_layout();
+        },
+        m_cursor
+    );
+}
+
+AnyCursor AnyCursor::operator[](std::string_view name) const
+{
+    return std::visit(
+        [&](const auto& cursor) -> AnyCursor
+        {
+            return cursor[name];
+        },
+        m_cursor
+    );
+}
+
+AnyCursor AnyCursor::operator[](uint32_t index) const
+{
+    return std::visit(
+        [&](const auto& cursor) -> AnyCursor
+        {
+            return cursor[index];
+        },
+        m_cursor
+    );
+}
+
+AnyCursor AnyCursor::find_field(std::string_view name) const
+{
+    return std::visit(
+        [&](const auto& cursor) -> AnyCursor
+        {
+            return cursor.find_field(name);
+        },
+        m_cursor
+    );
+}
+
+AnyCursor AnyCursor::find_element(uint32_t index) const
+{
+    return std::visit(
+        [&](const auto& cursor) -> AnyCursor
+        {
+            return cursor.find_element(index);
+        },
+        m_cursor
+    );
+}
+
+bool AnyCursor::has_field(std::string_view name) const
+{
+    return std::visit(
+        [&](const auto& cursor)
+        {
+            return cursor.has_field(name);
+        },
+        m_cursor
+    );
+}
+
+bool AnyCursor::has_element(uint32_t index) const
+{
+    return std::visit(
+        [&](const auto& cursor)
+        {
+            return cursor.has_element(index);
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_object(const ref<ShaderObject>& object)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_object(object);
+            } else {
+                throw_unsupported("set_object");
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_buffer(const ref<Buffer>& buffer)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_buffer(buffer);
+            } else {
+                require_pointer_cursor(cursor, "set_buffer");
+                SGL_CHECK(buffer, "set_buffer requires a non-null buffer for pointer fields.");
+                cursor.set_pointer(buffer->device_address());
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_buffer_view(const ref<BufferView>& buffer_view)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_buffer_view(buffer_view);
+            } else {
+                require_pointer_cursor(cursor, "set_buffer_view");
+                SGL_CHECK(buffer_view && buffer_view->buffer(), "set_buffer_view requires a non-null buffer view.");
+                cursor.set_pointer(buffer_view->buffer()->device_address() + buffer_view->range().offset);
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_texture(const ref<Texture>& texture)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_texture(texture);
+            } else {
+                throw_unsupported("set_texture");
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_texture_view(const ref<TextureView>& texture_view)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_texture_view(texture_view);
+            } else {
+                throw_unsupported("set_texture_view");
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_sampler(const ref<Sampler>& sampler)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_sampler(sampler);
+            } else {
+                throw_unsupported("set_sampler");
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_acceleration_structure(const ref<AccelerationStructure>& acceleration_structure)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_acceleration_structure(acceleration_structure);
+            } else {
+                throw_unsupported("set_acceleration_structure");
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_descriptor_handle(const DescriptorHandle& handle)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_descriptor_handle(handle);
+            } else {
+                cursor.set(handle);
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_data(const void* data, size_t size)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            cursor.set_data(data, size);
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_cuda_tensor_view(const cuda::TensorView& tensor_view)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            using Cursor = std::decay_t<decltype(cursor)>;
+            if constexpr (std::is_same_v<Cursor, ShaderCursor>) {
+                cursor.set_cuda_tensor_view(tensor_view);
+            } else {
+                SGL_UNUSED(tensor_view);
+                throw_unsupported("set_cuda_tensor_view");
+            }
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::set_pointer(uint64_t pointer_value)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            cursor.set_pointer(pointer_value);
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::_set_array(
+    const void* data,
+    size_t size,
+    TypeReflection::ScalarType cpu_scalar_type,
+    size_t element_count
+)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            cursor._set_array(data, size, cpu_scalar_type, element_count);
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::_set_scalar(const void* data, size_t size, TypeReflection::ScalarType cpu_scalar_type)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            cursor._set_scalar(data, size, cpu_scalar_type);
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::_set_vector(const void* data, size_t size, TypeReflection::ScalarType cpu_scalar_type, int dimension)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            cursor._set_vector(data, size, cpu_scalar_type, dimension);
+        },
+        m_cursor
+    );
+}
+
+void AnyCursor::_set_matrix(
+    const void* data,
+    size_t size,
+    TypeReflection::ScalarType cpu_scalar_type,
+    int rows,
+    int cols
+)
+{
+    std::visit(
+        [&](auto& cursor)
+        {
+            cursor._set_matrix(data, size, cpu_scalar_type, rows, cols);
+        },
+        m_cursor
+    );
+}
+
+} // namespace sgl

--- a/src/sgl/device/any_cursor.h
+++ b/src/sgl/device/any_cursor.h
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "sgl/device/buffer_cursor.h"
+#include "sgl/device/shader_cursor.h"
+
+#include "sgl/core/config.h"
+
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace sgl {
+
+/// Type-erased writable cursor over ShaderCursor and BufferElementCursor.
+///
+/// AnyCursor is intentionally passed by value in polymorphic write_to_cursor
+/// implementations so concrete cursor temporaries, such as cursor["field"], can
+/// be used directly.
+class SGL_API AnyCursor {
+public:
+    AnyCursor(ShaderCursor cursor);
+    AnyCursor(BufferElementCursor cursor);
+
+    bool is_shader_cursor() const;
+    bool is_buffer_element_cursor() const;
+
+    ShaderCursor* as_shader_cursor();
+    const ShaderCursor* as_shader_cursor() const;
+    BufferElementCursor* as_buffer_element_cursor();
+    const BufferElementCursor* as_buffer_element_cursor() const;
+
+    bool is_valid() const;
+    std::string to_string() const;
+    slang::TypeLayoutReflection* slang_type_layout() const;
+
+    AnyCursor operator[](std::string_view name) const;
+    AnyCursor operator[](uint32_t index) const;
+
+    AnyCursor find_field(std::string_view name) const;
+    AnyCursor find_element(uint32_t index) const;
+
+    bool has_field(std::string_view name) const;
+    bool has_element(uint32_t index) const;
+
+    void set_object(const ref<ShaderObject>& object);
+
+    void set_buffer(const ref<Buffer>& buffer);
+    void set_buffer_view(const ref<BufferView>& buffer_view);
+    void set_texture(const ref<Texture>& texture);
+    void set_texture_view(const ref<TextureView>& texture_view);
+    void set_sampler(const ref<Sampler>& sampler);
+    void set_acceleration_structure(const ref<AccelerationStructure>& acceleration_structure);
+
+    void set_descriptor_handle(const DescriptorHandle& handle);
+
+    void set_data(const void* data, size_t size);
+    void set_cuda_tensor_view(const cuda::TensorView& tensor_view);
+    void set_pointer(uint64_t pointer_value);
+
+    template<typename T>
+    AnyCursor& operator=(const T& value)
+    {
+        set(value);
+        return *this;
+    }
+
+    template<typename T>
+    void set(const T& value)
+    {
+        using Value = std::decay_t<T>;
+        if constexpr (std::is_same_v<Value, ref<ShaderObject>>) {
+            set_object(value);
+        } else if constexpr (std::is_same_v<Value, ref<Buffer>>) {
+            set_buffer(value);
+        } else if constexpr (std::is_same_v<Value, ref<BufferView>>) {
+            set_buffer_view(value);
+        } else if constexpr (std::is_same_v<Value, ref<Texture>>) {
+            set_texture(value);
+        } else if constexpr (std::is_same_v<Value, ref<TextureView>>) {
+            set_texture_view(value);
+        } else if constexpr (std::is_same_v<Value, ref<Sampler>>) {
+            set_sampler(value);
+        } else if constexpr (std::is_same_v<Value, ref<AccelerationStructure>>) {
+            set_acceleration_structure(value);
+        } else if constexpr (std::is_same_v<Value, DescriptorHandle>) {
+            set_descriptor_handle(value);
+        } else if constexpr (std::is_same_v<Value, cuda::TensorView>) {
+            set_cuda_tensor_view(value);
+        } else if constexpr (HasWriteToCursor<T, AnyCursor>) {
+            value.write_to_cursor(*this);
+        } else {
+            std::visit(
+                [&](auto& cursor)
+                {
+                    cursor.set(value);
+                },
+                m_cursor
+            );
+        }
+    }
+
+    void _set_array(const void* data, size_t size, TypeReflection::ScalarType cpu_scalar_type, size_t element_count);
+    void _set_scalar(const void* data, size_t size, TypeReflection::ScalarType cpu_scalar_type);
+    void _set_vector(const void* data, size_t size, TypeReflection::ScalarType cpu_scalar_type, int dimension);
+    void
+    _set_matrix(const void* data, size_t size, TypeReflection::ScalarType cpu_scalar_type, int rows, int cols);
+
+private:
+    using CursorVariant = std::variant<ShaderCursor, BufferElementCursor>;
+
+    CursorVariant m_cursor;
+};
+
+/// Interface for values that can write themselves to any supported cursor type.
+class SGL_API CursorWritable {
+public:
+    virtual ~CursorWritable() = default;
+    virtual void write_to_cursor(AnyCursor cursor) const = 0;
+};
+
+} // namespace sgl

--- a/src/sgl/device/cursor_utils.h
+++ b/src/sgl/device/cursor_utils.h
@@ -115,10 +115,12 @@ concept WritableCursor
           { obj._set_matrix(data, size, scalar_type, 0, 0) } -> std::same_as<void>;
       };
 
-// Concept to detect if T has write_to_cursor method
+// Concept to detect if T has a write_to_cursor method compatible with TCursor.
+// This accepts both templated implementations, e.g. write_to_cursor<TCursor>(TCursor&),
+// and non-templated overloads, including write_to_cursor(AnyCursor).
 template<typename T, typename TCursor>
 concept HasWriteToCursor = requires(const T& obj, TCursor& cursor) {
-    { obj.template write_to_cursor<TCursor>(cursor) };
+    { obj.write_to_cursor(cursor) };
 };
 
 } // namespace sgl

--- a/src/sgl/device/fwd.h
+++ b/src/sgl/device/fwd.h
@@ -23,6 +23,11 @@ class Surface;
 class BufferCursor;
 class BufferElementCursor;
 
+// any_cursor.h
+
+class AnyCursor;
+class CursorWritable;
+
 // resource.h
 
 class Resource;

--- a/src/sgl/device/shader_cursor.h
+++ b/src/sgl/device/shader_cursor.h
@@ -94,14 +94,15 @@ public:
     }
 
     template<typename T>
-        requires(HasWriteToCursor<T, BufferElementCursor>)
+        requires(HasWriteToCursor<T, ShaderCursor>)
     void set(const T& value) const
     {
-        value.write_to_cursor(*this);
+        ShaderCursor cursor = *this;
+        value.write_to_cursor(cursor);
     }
 
     template<typename T>
-        requires(!HasWriteToCursor<T, BufferElementCursor>)
+        requires(!HasWriteToCursor<T, ShaderCursor>)
     void set(const T& value) const;
 
     void _set_array_unsafe(

--- a/tests/sgl/device/test_cursors.cpp
+++ b/tests/sgl/device/test_cursors.cpp
@@ -1,15 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "testing.h"
+#include "sgl/device/any_cursor.h"
 #include "sgl/device/device.h"
 #include "sgl/device/shader.h"
 #include "sgl/device/buffer_cursor.h"
-#include <fstream>
+
+#include <cstring>
 #include <filesystem>
+#include <fstream>
+#include <utility>
+#include <vector>
 
 using namespace sgl;
 
 namespace {
+
+template<typename TCursor>
+void write_test_struct_fields(TCursor& cursor, float f0, uint32_t data)
+{
+    cursor["f0"] = f0;
+    cursor["nested"]["data"] = data;
+}
 
 struct NestedTestStruct {
     uint32_t data = 123;
@@ -33,6 +45,69 @@ struct TestStruct {
     }
 };
 
+struct ConcreteCursorTestStruct {
+    float f0 = 0;
+    NestedTestStruct nested;
+
+    ConcreteCursorTestStruct(float f0_, NestedTestStruct nested_)
+        : f0(f0_)
+        , nested(nested_)
+    {
+    }
+
+    void write_to_cursor(ShaderCursor& cursor) const { write_test_struct_fields(cursor, f0, nested.data); }
+    void write_to_cursor(BufferElementCursor& cursor) const { write_test_struct_fields(cursor, f0, nested.data); }
+};
+
+struct PolymorphicTestStruct : CursorWritable {
+    float f0 = 0;
+    NestedTestStruct nested;
+
+    PolymorphicTestStruct(float f0_, NestedTestStruct nested_)
+        : f0(f0_)
+        , nested(nested_)
+    {
+    }
+
+    void write_to_cursor(AnyCursor cursor) const override { write_test_struct_fields(cursor, f0, nested.data); }
+};
+
+static_assert(HasWriteToCursor<TestStruct, ShaderCursor>);
+static_assert(HasWriteToCursor<TestStruct, BufferElementCursor>);
+static_assert(HasWriteToCursor<ConcreteCursorTestStruct, ShaderCursor>);
+static_assert(HasWriteToCursor<ConcreteCursorTestStruct, BufferElementCursor>);
+static_assert(HasWriteToCursor<PolymorphicTestStruct, ShaderCursor>);
+static_assert(HasWriteToCursor<PolymorphicTestStruct, BufferElementCursor>);
+static_assert(HasWriteToCursor<PolymorphicTestStruct, AnyCursor>);
+static_assert(HasWriteToCursor<CursorWritable, ShaderCursor>);
+static_assert(HasWriteToCursor<CursorWritable, BufferElementCursor>);
+
+template<typename TWrite>
+std::vector<uint8_t>
+write_to_buffer(DeviceType device_type, ref<const TypeLayoutReflection> element_type_layout, TWrite&& write)
+{
+    std::vector<uint8_t> data(element_type_layout->stride(), 0);
+    auto buffer_cursor = make_ref<BufferCursor>(device_type, element_type_layout, data.data(), data.size());
+    std::forward<TWrite>(write)((*buffer_cursor)[0]);
+    return data;
+}
+
+std::vector<uint8_t> write_reference_data(
+    DeviceType device_type,
+    ref<const TypeLayoutReflection> element_type_layout,
+    const TestStruct& value
+)
+{
+    return write_to_buffer(
+        device_type,
+        element_type_layout,
+        [&](BufferElementCursor cursor)
+        {
+            write_test_struct_fields(cursor, value.f0, value.nested.data);
+        }
+    );
+}
+
 } // namespace
 
 TEST_SUITE_BEGIN("cursors");
@@ -53,43 +128,99 @@ struct TestStruct
 };
 )SHADER";
 
-    // Just verify module loads.
-    SUBCASE("buffer_cursor")
+    ref<SlangModule> module = ctx.device->load_module_from_source("test", shader);
+    CHECK(module);
+
+    TestStruct cpu_struct;
+
+    auto layout = module->layout();
+    auto element_type = layout->find_type_by_name("TestStruct");
+    auto element_type_layout = layout->get_type_layout(element_type);
+    auto reference = write_reference_data(ctx.device->type(), element_type_layout, cpu_struct);
+
+    SUBCASE("templated_buffer_cursor")
     {
-        ref<SlangModule> module = ctx.device->load_module_from_source("test", shader);
-        CHECK(module);
-
-        TestStruct cpu_struct;
-
-        auto layout = module->layout();
-        auto element_type = layout->find_type_by_name("TestStruct");
-        auto element_type_layout = layout->get_type_layout(element_type);
-
-        // This is how much we actually use in the memory for one element.
-        size_t element_size = element_type_layout->stride();
-
-        std::vector<uint8_t> from_direct(element_size, 0);
-        auto direct_buffer_cursor = make_ref<sgl::BufferCursor>(
+        auto result = write_to_buffer(
             ctx.device->type(),
             element_type_layout,
-            from_direct.data(),
-            from_direct.size()
+            [&](BufferElementCursor cursor)
+            {
+                cursor = cpu_struct;
+            }
         );
 
-        (*direct_buffer_cursor)[0]["f0"] = cpu_struct.f0;
-        (*direct_buffer_cursor)[0]["nested"]["data"] = cpu_struct.nested.data;
+        CHECK(memcmp(reference.data(), result.data(), reference.size()) == 0);
+    }
 
-        std::vector<uint8_t> from_tocursor(element_size, 0);
-        auto tocursor_cursor = make_ref<sgl::BufferCursor>(
+    SUBCASE("concrete_buffer_cursor")
+    {
+        ConcreteCursorTestStruct concrete_struct{cpu_struct.f0, cpu_struct.nested};
+        auto result = write_to_buffer(
             ctx.device->type(),
             element_type_layout,
-            from_tocursor.data(),
-            from_tocursor.size()
+            [&](BufferElementCursor cursor)
+            {
+                cursor = concrete_struct;
+            }
         );
 
-        (*tocursor_cursor)[0] = cpu_struct;
+        CHECK(memcmp(reference.data(), result.data(), reference.size()) == 0);
+    }
 
-        CHECK(memcmp(from_direct.data(), from_tocursor.data(), from_direct.size()) == 0);
+    SUBCASE("polymorphic_buffer_cursor_direct")
+    {
+        PolymorphicTestStruct polymorphic_struct{cpu_struct.f0, cpu_struct.nested};
+        const CursorWritable& writable = polymorphic_struct;
+        auto result = write_to_buffer(
+            ctx.device->type(),
+            element_type_layout,
+            [&](BufferElementCursor cursor)
+            {
+                writable.write_to_cursor(cursor);
+            }
+        );
+
+        CHECK(memcmp(reference.data(), result.data(), reference.size()) == 0);
+    }
+
+    SUBCASE("polymorphic_buffer_cursor_assignment")
+    {
+        PolymorphicTestStruct polymorphic_struct{cpu_struct.f0, cpu_struct.nested};
+        const CursorWritable& writable = polymorphic_struct;
+        auto result = write_to_buffer(
+            ctx.device->type(),
+            element_type_layout,
+            [&](BufferElementCursor cursor)
+            {
+                cursor = writable;
+            }
+        );
+
+        CHECK(memcmp(reference.data(), result.data(), reference.size()) == 0);
+    }
+
+    SUBCASE("unsupported_buffer_cursor_resource_binding")
+    {
+        auto buffer_cursor
+            = make_ref<BufferCursor>(ctx.device->type(), element_type_layout, reference.data(), reference.size());
+        AnyCursor any_cursor((*buffer_cursor)[0]["f0"]);
+        CHECK_THROWS(any_cursor.set_buffer(nullptr));
+        CHECK_THROWS(any_cursor.set_texture(nullptr));
+    }
+
+    SUBCASE("shader_cursor_assignments")
+    {
+        auto shader_object = ctx.device->create_shader_object(element_type_layout.get());
+        ShaderCursor shader_cursor(shader_object.get());
+
+        ConcreteCursorTestStruct concrete_struct{cpu_struct.f0, cpu_struct.nested};
+        PolymorphicTestStruct polymorphic_struct{cpu_struct.f0, cpu_struct.nested};
+        const CursorWritable& writable = polymorphic_struct;
+
+        CHECK_NOTHROW(shader_cursor = cpu_struct);
+        CHECK_NOTHROW(shader_cursor = concrete_struct);
+        CHECK_NOTHROW(writable.write_to_cursor(shader_cursor));
+        CHECK_NOTHROW(shader_cursor = writable);
     }
 }
 


### PR DESCRIPTION
This wraps the common interface of BufferElementCursor and ShaderCursor, allowing us to a write one virtual interface that takes this generic cursor, rather than having to have two. This is a native code only, as Python can already do that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added polymorphic cursor abstraction providing a unified interface for different cursor types
  * Added writable interface enabling custom cursor-writing implementations

* **Tests**
  * Expanded test coverage for polymorphic cursor writing scenarios and type interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->