### PR TITLE
Remove Python side Tensor

### DIFF
--- a/slangpy/builtin/tensor.py
+++ b/slangpy/builtin/tensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import Any, Optional, cast
-from slangpy.types.tensor import Tensor
 from slangpy.core.native import NativeTensorMarshall, NativeTensor
 
 from slangpy import ShaderObject, ShaderCursor, BufferUsage
@@ -199,4 +198,3 @@ def create_tensor_marshall(layout: SlangProgramLayout, value: Any):
 
 
 PYTHON_TYPES[NativeTensor] = create_tensor_marshall
-PYTHON_TYPES[Tensor] = create_tensor_marshall

--- a/slangpy/types/tensor.py
+++ b/slangpy/types/tensor.py
@@ -1,356 +1,66 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Tensor is now a native C++ class exposed via nanobind.
+
+This module re-exports Tensor and NativeTensor from the native extension, and
+adds the ``load_from_image`` and deprecated ``numpy`` class methods that rely
+on heavy Python-side helpers (Bitmap / numpy image processing).
+"""
 from __future__ import annotations
 from os import PathLike
 import warnings
 
-from slangpy import (
-    Device,
-    Buffer,
-    BufferUsage,
-    CommandEncoder,
-    MemoryType,
-)
-from slangpy.reflection import SlangType, SlangProgramLayout
-from slangpy.core.native import Shape
-from slangpy.core.shapes import TShapeOrTuple
-from slangpy.reflection.lookup import resolve_program_layout, resolve_element_type, numpy_to_slang
-from slangpy.core.native import Shape, NativeTensor, NativeTensorDesc
+from slangpy import Device
+from slangpy.core.native import NativeTensor
 from slangpy.types.common import load_buffer_data_from_image
 
-from warnings import warn
+from typing import Any, Union
 
-from typing import Optional, Any, Union, cast, TYPE_CHECKING
 import numpy as np
-import math
 
-if TYPE_CHECKING:
-    import torch
+# The canonical Tensor type is the C++ NativeTensor, exposed as "Tensor" in the binding.
+# Both names are exported for backward compatibility.
+Tensor = NativeTensor
 
 
-class Tensor(NativeTensor):
+def _tensor_load_from_image(
+    device: Device,
+    path: Union[str, PathLike[str]],
+    flip_y: bool = False,
+    linearize: bool = False,
+    scale: float = 1.0,
+    offset: float = 0.0,
+    grayscale: bool = False,
+) -> NativeTensor:
     """
-    Represents an N-D view of an underlying buffer with given shape and element type,
-    and has optional gradient information attached.
-
-    Strides and offset can optionally be specified and are given in terms of elements, not bytes.
-    If omitted, a dense N-D grid is assumed (row-major).
+    Helper to load an image from a file and convert it to a floating point tensor.
     """
+    data = load_buffer_data_from_image(path, flip_y, linearize, scale, offset, grayscale)
 
-    def __init__(
-        self,
-        storage: Buffer,
-        dtype: SlangType,
-        shape: TShapeOrTuple,
-        strides: Optional[TShapeOrTuple] = None,
-        offset: int = 0,
-        grad_in: Optional[Tensor] = None,
-        grad_out: Optional[Tensor] = None,
-    ):
+    if len(data.shape) == 2 or data.shape[2] == 1:
+        dtype = "float"
+    elif data.shape[2] == 2:
+        dtype = "float2"
+    elif data.shape[2] == 3:
+        dtype = "float3"
+    elif data.shape[2] == 4:
+        dtype = "float4"
+    else:
+        raise ValueError(f"Unsupported number of channels: {data.shape[2]}")
+    tensor = Tensor.empty(device, data.shape[:2], dtype)
+    tensor.copy_from_numpy(data)
+    return tensor
 
-        # Setup shape and stride.
-        shape = Shape(shape)
-        if strides is None:
-            strides = shape.calc_contiguous_strides()
-        if len(strides) != len(shape):
-            raise ValueError("Number of strides must match number of dimensions")
 
-        # Fill out native descriptor and initialize.
-        desc = NativeTensorDesc()
-        desc.shape = Shape(shape)
-        desc.strides = Shape(strides)
-        desc.offset = offset
-        desc.dtype = dtype
-        desc.offset = offset
-        desc.element_layout = dtype.buffer_layout.reflection
-        desc.usage = storage.desc.usage
-        super().__init__(desc, storage, grad_in, grad_out)
+def _tensor_numpy(device: Device, ndarray: np.ndarray[Any, Any]) -> NativeTensor:
+    warnings.warn(
+        "Tensor.numpy is deprecated. Use Tensor.from_numpy instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return Tensor.from_numpy(device, ndarray)
 
-        # Fix up some typing info
-        self.dtype: SlangType
-        self.grad_in: Optional[Tensor]
-        self.grad_out: Optional[Tensor]
 
-    def broadcast_to(self, shape: TShapeOrTuple):
-        """
-        Returns a new view of the tensor with the requested shape, following standard broadcasting rules.
-        """
-        return cast(Tensor, super().broadcast_to(Shape(shape)))
-
-    def view(self, shape: TShapeOrTuple, strides: TShapeOrTuple = Shape(), offset: int = 0):
-        """
-        Returns a new view of the tensor with the requested shape, strides and offset
-        The offset is in elements (not bytes) and is specified relative to the current offset
-        """
-        return cast(Tensor, super().view(Shape(shape), Shape(strides), offset))
-
-    def __str__(self):
-        return str(self.to_numpy())
-
-    def to_numpy(self) -> np.ndarray[Any, Any]:
-        """
-        Copies tensor data into a numpy array with the same shape and strides. If the element type
-        of the tensor is representable in numpy (e.g. floats, ints, arrays/vectors thereof), the
-        ndarray will have a matching dtype. If the element type can't be represented in numpy (e.g. structs),
-        the ndarray will be an array over the bytes of the buffer elements
-
-        Examples:
-        Tensor of dtype float3 with shape (4, 5)
-            -> ndarray of dtype np.float32 with shape (4, 5, 3)
-        Tensor of dtype struct Foo {...} with shape (5, )
-            -> ndarray of dtype np.uint8 with shape (5, sizeof(Foo))
-        """
-        return cast(np.ndarray[Any, Any], super().to_numpy())
-
-    def to_torch(self) -> "torch.Tensor":
-        """
-        Returns a view of the buffer data as a torch tensor with the same shape and strides.
-        See to_numpy for notes on dtype conversion
-        """
-        return cast("torch.Tensor", super().to_torch())
-
-    def with_grads(
-        self,
-        grad_in: Optional[Tensor] = None,
-        grad_out: Optional[Tensor] = None,
-        zero: bool = True,
-    ):
-        """
-        Returns a new tensor view with gradients attached. If called with no arguments, the
-        tensor defaults to attaching a zeros-like initialized gradient tensor for both input and
-        output gradients.
-
-        Specifying input gradients (grad_in) and/or output gradients (grad_out) allows more precise
-        control over the gradient tensors, and is key when using a function that has inout parameters,
-        so will want to both read and write gradients without causing race conditions.
-
-        When differentiating a slang call that wrote results to a tensor, gradients of the output will
-        be read from grad_in (if not None). When differentiating a slang call that read inputs from a
-        tensor, input gradients will be written to grad_out (if not None).
-        """
-        return cast(Tensor, super().with_grads(grad_in, grad_out, zero))
-
-    def detach(self):
-        """
-        Returns a new tensor view with gradients detached. The returned tensor will not have any
-        gradients attached, and will not be differentiable.
-        """
-        return cast(Tensor, super().detach())
-
-    def clear(self, command_encoder: Optional[CommandEncoder] = None):
-        """
-        Fill the tensor with zeros. If no command buffer is provided, a new one is created and
-        immediately submitted. If a command buffer is provided the clear is simply appended to it
-        but not automatically submitted.
-        """
-        super().clear(command_encoder)
-
-    @staticmethod
-    def numpy(device: Device, ndarray: np.ndarray[Any, Any]) -> Tensor:
-        warn(
-            "Tensor.numpy is deprecated. Use Tensor.from_numpy instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return Tensor.from_numpy(device, ndarray)
-
-    @staticmethod
-    def from_numpy(
-        device: Device,
-        ndarray: np.ndarray[Any, Any],
-        usage: BufferUsage = BufferUsage.shader_resource | BufferUsage.unordered_access,
-        memory_type: MemoryType = MemoryType.device_local,
-        program_layout: Optional[SlangProgramLayout] = None,
-    ) -> Tensor:
-        """
-        Creates a new tensor with the same contents, shape and strides as the given numpy array.
-        """
-
-        dtype = numpy_to_slang(ndarray.dtype, device, program_layout)
-        if dtype is None:
-            raise ValueError(f"Unsupported numpy dtype {ndarray.dtype}")
-        if (ndarray.nbytes % ndarray.itemsize) != 0:
-            raise ValueError(f"Unsupported numpy array")
-        for stride in ndarray.strides:
-            if (stride % ndarray.itemsize) != 0:
-                raise ValueError(f"Unsupported numpy array")
-
-        N = ndarray.nbytes // ndarray.itemsize
-        flattened = np.lib.stride_tricks.as_strided(ndarray, (N,), (ndarray.itemsize,))
-        strides = tuple(stride // ndarray.itemsize for stride in ndarray.strides)
-
-        buffer = device.create_buffer(
-            struct_size=ndarray.itemsize,
-            element_count=N,
-            usage=usage,
-            data=flattened,
-            memory_type=memory_type,
-        )
-
-        return Tensor(buffer, dtype, tuple(ndarray.shape), strides)
-
-    @staticmethod
-    def empty(
-        device: Device,
-        shape: TShapeOrTuple = (),
-        dtype: Any = None,
-        usage: BufferUsage = BufferUsage.shader_resource | BufferUsage.unordered_access,
-        memory_type: MemoryType = MemoryType.device_local,
-        program_layout: Optional[SlangProgramLayout] = None,
-        element_count: Optional[int] = None,
-    ) -> Tensor:
-        """
-        Creates a tensor with the requested shape and element type without attempting to initialize the data.
-        """
-        # If dtype supplied is not a SlangType, resolve it
-        if not isinstance(dtype, SlangType):
-            program_layout = resolve_program_layout(device, dtype, program_layout)
-            dtype = resolve_element_type(program_layout, dtype)
-
-        if element_count is not None:
-            warnings.warn(
-                "element_count parameter is deprecated; use shape instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            shape = (element_count,)
-
-        if dtype is None:
-            raise ValueError("Element type (dtype) must be specified")
-        if shape == ():
-            raise ValueError("Cannot create a tensor with zero dimensions")
-
-        shape_tuple = shape if isinstance(shape, tuple) else shape.as_tuple()
-        num_elems = math.prod(shape_tuple)
-
-        buffer = device.create_buffer(
-            element_count=num_elems,
-            struct_size=dtype.buffer_layout.stride,
-            usage=usage,
-            memory_type=memory_type,
-        )
-
-        return Tensor(buffer, dtype, shape)
-
-    @staticmethod
-    def zeros(
-        device: Device,
-        shape: TShapeOrTuple,
-        dtype: Any,
-        usage: BufferUsage = BufferUsage.shader_resource | BufferUsage.unordered_access,
-        memory_type: MemoryType = MemoryType.device_local,
-        program_layout: Optional[SlangProgramLayout] = None,
-    ) -> Tensor:
-        """
-        Creates a zero-initialized tensor with the requested shape and element type.
-        """
-        tensor = Tensor.empty(device, shape, dtype, usage, memory_type, program_layout)
-        tensor.clear()
-        return tensor
-
-    @staticmethod
-    def empty_like(other: Tensor) -> Tensor:
-        """
-        Creates a new tensor with the same shape and element type as the given tensor, without initializing the data.
-        """
-        return Tensor.empty(other.storage.device, other.shape, other.dtype, other.usage)
-
-    @staticmethod
-    def zeros_like(other: Tensor) -> Tensor:
-        """
-        Creates a zero-initialized tensor with the same shape and element type as the given tensor.
-        """
-        return Tensor.zeros(other.storage.device, other.shape, other.dtype, other.usage)
-
-    @staticmethod
-    def from_torch(
-        device: Device,
-        tensor: "torch.Tensor",
-        dtype: Any,
-        usage: BufferUsage = BufferUsage.shader_resource | BufferUsage.unordered_access,
-        program_layout: Optional[SlangProgramLayout] = None,
-    ) -> Tensor:
-        """
-        Reinterpret a torch.Tensor as a slangpy Tensor with a given element type.
-
-        The last dimension of the torch tensor is treated as packed storage for one
-        element of ``dtype``. For example, a ``torch.Tensor`` of shape ``(N, 2)`` with
-        ``dtype=module.Vec2`` (a struct with two float fields) produces a
-        ``Tensor`` of shape ``(N,)`` with element type ``Vec2``.
-
-        .. warning::
-
-            Struct layout may vary between platforms due to padding/alignment.
-            The caller is responsible for ensuring the torch tensor's memory layout
-            matches the Slang struct's buffer layout.
-        """
-        if not isinstance(dtype, SlangType):
-            program_layout = resolve_program_layout(device, dtype, program_layout)
-            dtype = resolve_element_type(program_layout, dtype)
-
-        struct_stride = dtype.buffer_layout.stride
-        scalar_size = tensor.element_size()
-        if struct_stride == 0 or scalar_size == 0 or struct_stride % scalar_size != 0:
-            raise ValueError(
-                f"Torch element size ({scalar_size}) is not compatible with "
-                f"Slang type '{dtype.full_name}' buffer stride ({struct_stride})"
-            )
-
-        scalars_per_element = struct_stride // scalar_size
-
-        if tensor.dim() < 1:
-            raise ValueError("Tensor must have at least 1 dimension")
-        if tensor.shape[-1] != scalars_per_element:
-            raise ValueError(
-                f"Last dimension size ({tensor.shape[-1]}) does not match "
-                f"the number of scalars per '{dtype.full_name}' element ({scalars_per_element})"
-            )
-        if tensor.stride(-1) != 1:
-            raise ValueError("Last dimension of the tensor must be contiguous")
-
-        contiguous = tensor.contiguous()
-        element_count = contiguous.numel()
-
-        buffer = device.create_buffer(
-            size=element_count * scalar_size,
-            struct_size=struct_stride,
-            usage=usage | BufferUsage.shared,
-        )
-
-        from slangpy import copy_torch_tensor_to_buffer
-
-        copy_torch_tensor_to_buffer(contiguous, buffer)
-
-        outer_shape = tuple(contiguous.shape[:-1])
-        return Tensor(buffer, dtype, outer_shape)
-
-    @staticmethod
-    def load_from_image(
-        device: Device,
-        path: Union[str, PathLike[str]],
-        flip_y: bool = False,
-        linearize: bool = False,
-        scale: float = 1.0,
-        offset: float = 0.0,
-        grayscale: bool = False,
-    ) -> Tensor:
-        """
-        Helper to load an image from a file and convert it to a floating point tensor.
-        """
-
-        # Load bitmap + convert to numpy array
-        data = load_buffer_data_from_image(path, flip_y, linearize, scale, offset, grayscale)
-
-        # Create tensor with appropriate dtype based on number of channels.
-        if len(data.shape) == 2 or data.shape[2] == 1:
-            dtype = "float"
-        elif data.shape[2] == 2:
-            dtype = "float2"
-        elif data.shape[2] == 3:
-            dtype = "float3"
-        elif data.shape[2] == 4:
-            dtype = "float4"
-        else:
-            raise ValueError(f"Unsupported number of channels: {data.shape[2]}")
-        tensor = Tensor.empty(device, data.shape[:2], dtype)
-        tensor.copy_from_numpy(data)
-        return tensor
+# Attach as class methods so users can call Tensor.load_from_image(...) etc.
+Tensor.load_from_image = staticmethod(_tensor_load_from_image)  # type: ignore[attr-defined]
+Tensor.numpy = staticmethod(_tensor_numpy)  # type: ignore[attr-defined]

--- a/src/slangpy_ext/utils/slangpystridedbufferview.cpp
+++ b/src/slangpy_ext/utils/slangpystridedbufferview.cpp
@@ -551,11 +551,36 @@ SGL_PY_EXPORT(utils_slangpy_strided_buffer_view)
         .def_prop_ro("usage", &StridedBufferView::usage)
         .def_prop_ro("memory_type", &StridedBufferView::memory_type)
         .def_prop_ro("storage", &StridedBufferView::storage)
-        .def("clear", &StridedBufferView::clear, "cmd"_a.none() = nullptr)
-        .def("cursor", &StridedBufferView::cursor, "start"_a.none() = std::nullopt, "count"_a.none() = std::nullopt)
+        .def(
+            "clear",
+            &StridedBufferView::clear,
+            "cmd"_a.none() = nb::none(),
+            "Fill the tensor with zeros. If no command buffer is provided, a new one is created and\n"
+            "immediately submitted. If a command buffer is provided the clear is simply appended to it\n"
+            "but not automatically submitted."
+        )
+        .def("cursor", &StridedBufferView::cursor, "start"_a.none() = nb::none(), "count"_a.none() = nb::none())
         .def("uniforms", &StridedBufferView::uniforms)
-        .def("to_numpy", &StridedBufferView::to_numpy, D_NA(StridedBufferView, to_numpy))
-        .def("to_torch", &StridedBufferView::to_torch, D_NA(StridedBufferView, to_torch))
+        .def(
+            "to_numpy",
+            &StridedBufferView::to_numpy,
+            "Copies tensor data into a numpy array with the same shape and strides. If the element type\n"
+            "of the tensor is representable in numpy (e.g. floats, ints, arrays/vectors thereof), the\n"
+            "ndarray will have a matching dtype. If the element type can't be represented in numpy (e.g. structs),\n"
+            "the ndarray will be an array over the bytes of the buffer elements\n"
+            "\n"
+            "Examples:\n"
+            "Tensor of dtype float3 with shape (4, 5)\n"
+            "    -> ndarray of dtype np.float32 with shape (4, 5, 3)\n"
+            "Tensor of dtype struct Foo {...} with shape (5, )\n"
+            "    -> ndarray of dtype np.uint8 with shape (5, sizeof(Foo))"
+        )
+        .def(
+            "to_torch",
+            &StridedBufferView::to_torch,
+            "Returns a view of the buffer data as a torch tensor with the same shape and strides.\n"
+            "See to_numpy for notes on dtype conversion."
+        )
         .def("copy_from_numpy", &StridedBufferView::copy_from_numpy, "data"_a, D_NA(StridedBufferView, copy_from_numpy))
         .def("copy_from_torch", &StridedBufferView::copy_from_torch, "tensor"_a)
         .def("is_contiguous", &StridedBufferView::is_contiguous, D_NA(&StridedBufferView, is_contiguous))

--- a/src/slangpy_ext/utils/slangpytensor.cpp
+++ b/src/slangpy_ext/utils/slangpytensor.cpp
@@ -18,34 +18,6 @@ extern void write_shader_cursor(ShaderCursor& cursor, nb::object value);
 namespace sgl::slangpy {
 
 namespace {
-    /// Helper function to extract shape from PyTorch tensor
-    /// Creates Shape directly and populates it - zero allocations for tensors with <=8 dimensions
-    Shape extract_shape(const nb::ndarray<nb::pytorch, nb::device::cuda>& tensor)
-    {
-        const size_t ndim = tensor.ndim();
-        Shape shape(ndim);
-        int* shape_data = shape.data(); // Get pointer once
-        for (size_t i = 0; i < ndim; i++) {
-            shape_data[i] = static_cast<int>(tensor.shape(i));
-        }
-        return shape;
-    }
-
-    /// Helper function to extract strides from PyTorch tensor
-    /// Returns element strides directly (PyTorch stride() already returns element strides for nanobind)
-    /// Creates Shape directly and populates it - zero allocations for tensors with <=8 dimensions
-    Shape extract_strides(const nb::ndarray<nb::pytorch, nb::device::cuda>& tensor)
-    {
-        const size_t ndim = tensor.ndim();
-        Shape strides(ndim);
-        int* strides_data = strides.data(); // Get pointer once
-        for (size_t i = 0; i < ndim; i++) {
-            // nanobind's tensor.stride() returns element strides, not byte strides
-            strides_data[i] = static_cast<int>(tensor.stride(i));
-        }
-        return strides;
-    }
-
     /// Overload accepting Shape directly and returning Shape (ZERO allocations for small shapes!)
     Shape apply_broadcast_stride_zeroing(
         const Shape& strides,
@@ -109,49 +81,6 @@ namespace {
         }
     }
 
-    /// Validate that a tensor's trailing dimensions match the expected vector type shape.
-    /// This mirrors the validation in Python's torchtensormarshall.py
-    /// Throws nb::value_error to match the Python behavior
-    void validate_tensor_shape(const Shape& tensor_shape, const Shape& vector_shape)
-    {
-        const size_t vector_dims = vector_shape.size();
-        if (vector_dims == 0) {
-            return; // No vector shape to validate against
-        }
-
-        const size_t tensor_dims = tensor_shape.size();
-        if (tensor_dims < vector_dims) {
-            throw nb::value_error(
-                fmt::format(
-                    "Tensor shape {} does not match expected shape {}",
-                    tensor_shape.to_string(),
-                    vector_shape.to_string()
-                )
-                    .c_str()
-            );
-        }
-
-        // Get raw pointers once to avoid per-element m_uses_heap branching
-        const int* tensor_data = tensor_shape.data();
-        const int* vector_data = vector_shape.data();
-
-        // Check trailing dimensions
-        for (size_t i = 0; i < vector_dims; i++) {
-            int expected = vector_data[vector_dims - 1 - i];
-            int actual = tensor_data[tensor_dims - 1 - i];
-            // -1 acts as a wildcard (matches any size)
-            if (expected != -1 && actual != expected) {
-                throw nb::value_error(
-                    fmt::format(
-                        "Tensor shape {} does not match expected shape {}",
-                        tensor_shape.to_string(),
-                        vector_shape.to_string()
-                    )
-                        .c_str()
-                );
-            }
-        }
-    }
 } // anonymous namespace
 
 
@@ -698,32 +627,449 @@ SGL_PY_EXPORT(utils_slangpy_tensor)
 
     nb::module_ slangpy = m.attr("slangpy");
 
+    // Allow tuples/lists to be passed wherever Shape is expected.
+    nb::implicitly_convertible<nb::tuple, Shape>();
+    nb::implicitly_convertible<nb::list, Shape>();
+
+    // ---------------------------------------------------------------------------
+    // Type resolution helpers (call back to Python reflection system)
+    // ---------------------------------------------------------------------------
+
+    /// Resolve dtype from various Python representations to NativeSlangType.
+    /// Fast path if dtype is already a NativeSlangType; otherwise calls Python.
+    auto resolve_dtype = [](Device* device, nb::object dtype, nb::object program_layout) -> ref<NativeSlangType>
+    {
+        if (nb::isinstance<NativeSlangType>(dtype))
+            return nb::cast<ref<NativeSlangType>>(dtype);
+        nb::module_ lookup = nb::module_::import_("slangpy.reflection.lookup");
+        nb::object layout = lookup.attr("resolve_program_layout")(device, dtype, program_layout);
+        return nb::cast<ref<NativeSlangType>>(lookup.attr("resolve_element_type")(layout, dtype));
+    };
+
+    /// Map a numpy dtype to a NativeSlangType, returns nullptr on failure.
+    auto resolve_numpy_dtype
+        = [](Device* device, nb::object np_dtype, nb::object program_layout) -> ref<NativeSlangType>
+    {
+        nb::module_ lookup = nb::module_::import_("slangpy.reflection.lookup");
+        nb::object result = lookup.attr("numpy_to_slang")(np_dtype, device, program_layout);
+        if (result.is_none())
+            return nullptr;
+        return nb::cast<ref<NativeSlangType>>(result);
+    };
+
+    /// Create a NativeTensor from storage buffer + dtype + shape + strides.
+    auto make_tensor = [](const ref<Buffer>& storage,
+                          const ref<NativeSlangType>& dtype,
+                          const Shape& shape,
+                          const Shape& strides,
+                          int offset = 0) -> ref<NativeTensor>
+    {
+        NativeTensorDesc desc;
+        desc.shape = shape;
+        desc.strides = strides;
+        desc.offset = offset;
+        desc.dtype = dtype;
+        desc.element_layout = dtype->buffer_type_layout();
+        desc.usage = storage->desc().usage;
+        return make_ref<NativeTensor>(desc, storage, nullptr, nullptr);
+    };
+
+    /// Shared implementation for empty().
+    auto tensor_empty_impl = [&](const ref<Device>& device,
+                                 const Shape& shape,
+                                 nb::object dtype_obj,
+                                 BufferUsage usage,
+                                 MemoryType memory_type,
+                                 nb::object program_layout) -> ref<NativeTensor>
+    {
+        ref<NativeSlangType> dtype = resolve_dtype(device, dtype_obj, program_layout);
+        if (!dtype)
+            throw nb::value_error("Element type (dtype) must be specified");
+        if (shape.size() == 0)
+            throw nb::value_error("Cannot create a tensor with zero dimensions");
+
+        size_t num_elems = shape.element_count();
+        ref<TypeLayoutReflection> layout = dtype->buffer_type_layout();
+
+        BufferDesc buffer_desc;
+        buffer_desc.element_count = num_elems;
+        buffer_desc.struct_size = layout->stride();
+        buffer_desc.usage = usage;
+        buffer_desc.memory_type = memory_type;
+
+        ref<Buffer> buffer = device->create_buffer(buffer_desc);
+        return make_tensor(buffer, dtype, shape, shape.calc_contiguous_strides());
+    };
+
+    // ---------------------------------------------------------------------------
+    // NativeTensorDesc
+    // ---------------------------------------------------------------------------
+
     nb::class_<NativeTensorDesc, StridedBufferViewDesc>(slangpy, "NativeTensorDesc").def(nb::init<>());
 
-    nb::class_<NativeTensor, StridedBufferView>(slangpy, "NativeTensor")
-        .def(
-            nb::init<NativeTensorDesc, const ref<Buffer>&, const ref<NativeTensor>&, const ref<NativeTensor>&>(),
-            "desc"_a,
-            "storage"_a,
-            "grad_in"_a.none(),
-            "grad_out"_a.none()
-        )
+    // ---------------------------------------------------------------------------
+    // Tensor (was NativeTensor)
+    // ---------------------------------------------------------------------------
+
+    auto tensor_cls = nb::class_<NativeTensor, StridedBufferView>(slangpy, "Tensor");
+
+    // Internal desc-based constructor (used by marshalls etc.)
+    tensor_cls.def(
+        nb::init<NativeTensorDesc, const ref<Buffer>&, const ref<NativeTensor>&, const ref<NativeTensor>&>(),
+        "desc"_a,
+        "storage"_a,
+        "grad_in"_a.none(),
+        "grad_out"_a.none()
+    );
+
+    // User-friendly constructor: Tensor(storage, dtype, shape, strides=None, offset=0, ...)
+    tensor_cls.def(
+        "__init__",
+        [](NativeTensor& self,
+           const ref<Buffer>& storage,
+           const ref<NativeSlangType>& dtype,
+           const Shape& shape,
+           std::optional<Shape> strides,
+           int offset,
+           ref<NativeTensor> grad_in,
+           ref<NativeTensor> grad_out)
+        {
+            Shape actual_strides = strides.has_value() ? *strides : shape.calc_contiguous_strides();
+            if (actual_strides.size() != shape.size())
+                throw nb::value_error("Number of strides must match number of dimensions");
+
+            NativeTensorDesc desc;
+            desc.shape = shape;
+            desc.strides = actual_strides;
+            desc.offset = offset;
+            desc.dtype = dtype;
+            desc.element_layout = dtype->buffer_type_layout();
+            desc.usage = storage->desc().usage;
+            new (&self) NativeTensor(desc, storage, grad_in, grad_out);
+        },
+        "storage"_a,
+        "dtype"_a,
+        "shape"_a,
+        "strides"_a.none() = nb::none(),
+        "offset"_a = 0,
+        "grad_in"_a.none() = nb::none(),
+        "grad_out"_a.none() = nb::none()
+    );
+
+    // Properties & methods inherited from StridedBufferView are already bound.
+    tensor_cls //
         .def_prop_rw("grad_in", &NativeTensor::grad_in, &NativeTensor::set_grad_in, nb::none())
         .def_prop_rw("grad_out", &NativeTensor::grad_out, &NativeTensor::set_grad_out, nb::none())
         .def_prop_ro("grad", &NativeTensor::grad)
-        .def("broadcast_to", &NativeTensor::broadcast_to, "shape"_a)
-        .def("view", &NativeTensor::view, "shape"_a, "strides"_a = Shape(), "offset"_a = 0)
+        .def(
+            "broadcast_to",
+            &NativeTensor::broadcast_to,
+            "shape"_a,
+            "Returns a new view of the tensor with the requested shape, following standard broadcasting rules."
+        )
+        .def(
+            "view",
+            &NativeTensor::view,
+            "shape"_a,
+            "strides"_a = Shape(),
+            "offset"_a = 0,
+            "Returns a new view of the tensor with the requested shape, strides and offset.\n"
+            "The offset is in elements (not bytes) and is specified relative to the current offset."
+        )
         .def("__getitem__", &NativeTensor::index)
         .def(
             "with_grads",
             &NativeTensor::with_grads,
-            "grad_in"_a.none() = nullptr,
-            "grad_out"_a.none() = nullptr,
-            "zero"_a = true
+            "grad_in"_a.none() = nb::none(),
+            "grad_out"_a.none() = nb::none(),
+            "zero"_a = true,
+            "Returns a new tensor view with gradients attached. If called with no arguments, the\n"
+            "tensor defaults to attaching a zeros-like initialized gradient tensor for both input and\n"
+            "output gradients.\n"
+            "\n"
+            "Specifying input gradients (grad_in) and/or output gradients (grad_out) allows more precise\n"
+            "control over the gradient tensors, and is key when using a function that has inout parameters,\n"
+            "so will want to both read and write gradients without causing race conditions.\n"
+            "\n"
+            "When differentiating a slang call that wrote results to a tensor, gradients of the output will\n"
+            "be read from grad_in (if not None). When differentiating a slang call that read inputs from a\n"
+            "tensor, input gradients will be written to grad_out (if not None)."
         )
-        .def("detach", &NativeTensor::detach)
-        .def("__repr__", &NativeTensor::to_string);
+        .def(
+            "detach",
+            &NativeTensor::detach,
+            "Returns a new tensor view with gradients detached. The returned tensor will not have any\n"
+            "gradients attached, and will not be differentiable."
+        )
+        .def("__repr__", &NativeTensor::to_string)
+        .def(
+            "__str__",
+            [](NativeTensor& self)
+            {
+                return nb::str(nb::cast(self.to_numpy()));
+            }
+        );
 
+    // ---------------------------------------------------------------------------
+    // Static factory methods
+    // ---------------------------------------------------------------------------
+
+    tensor_cls.def_static(
+        "from_numpy",
+        [&](const ref<Device>& device,
+            nb::object ndarray_obj,
+            BufferUsage usage,
+            MemoryType memory_type,
+            nb::object program_layout) -> ref<NativeTensor>
+        {
+            // Cast to ndarray for direct C++ access to shape/strides/data
+            nb::ndarray<nb::numpy> arr = nb::cast<nb::ndarray<nb::numpy>>(ndarray_obj);
+
+            // Resolve numpy dtype -> Slang type (requires Python object)
+            nb::object np_dtype = ndarray_obj.attr("dtype");
+            ref<NativeSlangType> dtype = resolve_numpy_dtype(device, np_dtype, program_layout);
+            if (!dtype)
+                throw nb::value_error(
+                    fmt::format("Unsupported numpy dtype {}", nb::cast<std::string>(nb::str(np_dtype))).c_str()
+                );
+
+            // Extract shape and strides directly from ndarray
+            // ndarray strides are already in elements (DLPack convention)
+            size_t ndim = arr.ndim();
+            size_t itemsize = arr.itemsize();
+            if (itemsize == 0)
+                throw nb::value_error("Unsupported numpy array");
+
+            Shape shape(ndim);
+            Shape strides(ndim);
+            for (size_t i = 0; i < ndim; i++) {
+                shape[i] = static_cast<int>(arr.shape(i));
+                strides[i] = static_cast<int>(arr.stride(i));
+            }
+
+            // Upload raw memory to GPU buffer
+            size_t N = arr.nbytes() / itemsize;
+            BufferDesc buffer_desc;
+            buffer_desc.struct_size = itemsize;
+            buffer_desc.element_count = N;
+            buffer_desc.usage = usage;
+            buffer_desc.memory_type = memory_type;
+            buffer_desc.data = arr.data();
+            buffer_desc.data_size = arr.nbytes();
+
+            ref<Buffer> buffer = device->create_buffer(buffer_desc);
+            return make_tensor(buffer, dtype, shape, strides);
+        },
+        "device"_a,
+        "ndarray"_a,
+        "usage"_a = BufferUsage::shader_resource | BufferUsage::unordered_access,
+        "memory_type"_a = MemoryType::device_local,
+        "program_layout"_a.none() = nb::none(),
+        "Creates a new tensor with the same contents, shape and strides as the given numpy array."
+    );
+
+    tensor_cls.def_static(
+        "empty",
+        [&](const ref<Device>& device,
+            nb::object shape_obj,
+            nb::object dtype_obj,
+            BufferUsage usage,
+            MemoryType memory_type,
+            nb::object program_layout,
+            nb::object element_count_obj) -> ref<NativeTensor>
+        {
+            Shape shape;
+            if (!element_count_obj.is_none()) {
+                nb::module_ warnings = nb::module_::import_("warnings");
+                warnings.attr("warn")(
+                    "element_count parameter is deprecated; use shape instead",
+                    nb::handle(PyExc_DeprecationWarning),
+                    "stacklevel"_a = 2
+                );
+                shape = Shape({nb::cast<int>(element_count_obj)});
+            } else {
+                shape = nb::cast<Shape>(shape_obj);
+            }
+            return tensor_empty_impl(device, shape, dtype_obj, usage, memory_type, program_layout);
+        },
+        "device"_a,
+        "shape"_a = Shape(),
+        "dtype"_a = nb::none(),
+        "usage"_a = BufferUsage::shader_resource | BufferUsage::unordered_access,
+        "memory_type"_a = MemoryType::device_local,
+        "program_layout"_a.none() = nb::none(),
+        "element_count"_a.none() = nb::none(),
+        "Creates a tensor with the requested shape and element type without attempting to initialize the data."
+    );
+
+    tensor_cls.def_static(
+        "zeros",
+        [&](const ref<Device>& device,
+            const Shape& shape,
+            nb::object dtype_obj,
+            BufferUsage usage,
+            MemoryType memory_type,
+            nb::object program_layout) -> ref<NativeTensor>
+        {
+            auto tensor = tensor_empty_impl(device, shape, dtype_obj, usage, memory_type, program_layout);
+            tensor->clear();
+            return tensor;
+        },
+        "device"_a,
+        "shape"_a,
+        "dtype"_a,
+        "usage"_a = BufferUsage::shader_resource | BufferUsage::unordered_access,
+        "memory_type"_a = MemoryType::device_local,
+        "program_layout"_a.none() = nb::none(),
+        "Creates a zero-initialized tensor with the requested shape and element type."
+    );
+
+    tensor_cls.def_static(
+        "empty_like",
+        [](const ref<NativeTensor>& other) -> ref<NativeTensor>
+        {
+            NativeTensorDesc desc;
+            desc.shape = other->shape();
+            desc.strides = other->shape().calc_contiguous_strides();
+            desc.offset = 0;
+            desc.dtype = other->dtype();
+            desc.element_layout = other->desc().element_layout;
+            desc.usage = other->usage();
+
+            BufferDesc buffer_desc;
+            buffer_desc.element_count = desc.shape.element_count();
+            buffer_desc.struct_size = desc.element_layout->stride();
+            buffer_desc.usage = desc.usage;
+
+            ref<Buffer> buffer = other->device()->create_buffer(buffer_desc);
+            return make_ref<NativeTensor>(desc, buffer, nullptr, nullptr);
+        },
+        "other"_a,
+        "Creates a new tensor with the same shape and element type as the given tensor, without initializing the data."
+    );
+
+    tensor_cls.def_static(
+        "zeros_like",
+        [](const ref<NativeTensor>& other) -> ref<NativeTensor>
+        {
+            NativeTensorDesc desc;
+            desc.shape = other->shape();
+            desc.strides = other->shape().calc_contiguous_strides();
+            desc.offset = 0;
+            desc.dtype = other->dtype();
+            desc.element_layout = other->desc().element_layout;
+            desc.usage = other->usage();
+
+            BufferDesc buffer_desc;
+            buffer_desc.element_count = desc.shape.element_count();
+            buffer_desc.struct_size = desc.element_layout->stride();
+            buffer_desc.usage = desc.usage;
+
+            ref<Buffer> buffer = other->device()->create_buffer(buffer_desc);
+            auto tensor = make_ref<NativeTensor>(desc, buffer, nullptr, nullptr);
+            tensor->clear();
+            return tensor;
+        },
+        "other"_a,
+        "Creates a zero-initialized tensor with the same shape and element type as the given tensor."
+    );
+
+    tensor_cls.def_static(
+        "from_torch",
+        [&](const ref<Device>& device,
+            nb::object torch_tensor,
+            nb::object dtype_obj,
+            BufferUsage usage,
+            nb::object program_layout) -> ref<NativeTensor>
+        {
+            ref<NativeSlangType> dtype = resolve_dtype(device, dtype_obj, program_layout);
+
+            size_t struct_stride = dtype->buffer_type_layout()->stride();
+            size_t scalar_size = nb::cast<size_t>(torch_tensor.attr("element_size")());
+
+            if (struct_stride == 0 || scalar_size == 0 || struct_stride % scalar_size != 0)
+                throw nb::value_error(
+                    fmt::format(
+                        "Torch element size ({}) is not compatible with Slang type '{}' buffer stride ({})",
+                        scalar_size,
+                        dtype->type_reflection()->full_name(),
+                        struct_stride
+                    )
+                        .c_str()
+                );
+
+            size_t scalars_per_element = struct_stride / scalar_size;
+            int dim = nb::cast<int>(torch_tensor.attr("dim")());
+            if (dim < 1)
+                throw nb::value_error("Tensor must have at least 1 dimension");
+
+            nb::tuple torch_shape = nb::cast<nb::tuple>(torch_tensor.attr("shape"));
+            size_t last_dim = nb::cast<size_t>(torch_shape[dim - 1]);
+            if (last_dim != scalars_per_element)
+                throw nb::value_error(
+                    fmt::format(
+                        "Last dimension size ({}) does not match the number of scalars per '{}' element ({})",
+                        last_dim,
+                        dtype->type_reflection()->full_name(),
+                        scalars_per_element
+                    )
+                        .c_str()
+                );
+
+            int64_t last_stride = nb::cast<int64_t>(torch_tensor.attr("stride")(dim - 1));
+            if (last_stride != 1)
+                throw nb::value_error("Last dimension of the tensor must be contiguous");
+
+            // Make contiguous and compute element count
+            nb::object contiguous = torch_tensor.attr("contiguous")();
+            size_t element_count = nb::cast<size_t>(contiguous.attr("numel")());
+
+            // Create buffer
+            BufferDesc buffer_desc;
+            buffer_desc.size = element_count * scalar_size;
+            buffer_desc.struct_size = struct_stride;
+            buffer_desc.usage = usage | BufferUsage::shared;
+
+            ref<Buffer> buffer = device->create_buffer(buffer_desc);
+
+            // Copy data from torch tensor to buffer
+            nb::module_ spy_ext = nb::module_::import_("slangpy");
+            spy_ext.attr("copy_torch_tensor_to_buffer")(contiguous, nb::cast(buffer));
+
+            // Build outer shape (all dims except last)
+            Shape outer_shape(dim - 1);
+            nb::tuple cont_shape = nb::cast<nb::tuple>(contiguous.attr("shape"));
+            for (int i = 0; i < dim - 1; i++)
+                outer_shape[i] = nb::cast<int>(cont_shape[i]);
+
+            return make_tensor(buffer, dtype, outer_shape, outer_shape.calc_contiguous_strides());
+        },
+        "device"_a,
+        "tensor"_a,
+        "dtype"_a,
+        "usage"_a = BufferUsage::shader_resource | BufferUsage::unordered_access,
+        "program_layout"_a.none() = nb::none(),
+        "Reinterpret a torch.Tensor as a slangpy Tensor with a given element type.\n"
+        "\n"
+        "The last dimension of the torch tensor is treated as packed storage for one\n"
+        "element of ``dtype``. For example, a ``torch.Tensor`` of shape ``(N, 2)`` with\n"
+        "``dtype=module.Vec2`` (a struct with two float fields) produces a\n"
+        "``Tensor`` of shape ``(N,)`` with element type ``Vec2``.\n"
+        "\n"
+        ".. warning::\n"
+        "\n"
+        "    Struct layout may vary between platforms due to padding/alignment.\n"
+        "    The caller is responsible for ensuring the torch tensor's memory layout\n"
+        "    matches the Slang struct's buffer layout."
+    );
+
+    // Backward compatibility alias: NativeTensor = Tensor
+    slangpy.attr("NativeTensor") = slangpy.attr("Tensor");
+
+
+    // ---------------------------------------------------------------------------
+    // NativeTensorMarshall
+    // ---------------------------------------------------------------------------
 
     nb::class_<NativeTensorMarshall, PyNativeTensorMarshall, NativeMarshall>(slangpy, "NativeTensorMarshall") //
         .def(


### PR DESCRIPTION
- Replace Python `Tensor` class with native Tensor

@ccummingsNV should we rename `NativeTensor` -> `Tensor` and `NativeTensorMarshall` to `TensorMarshall` on the native side?