### PR TITLE
Handle None being returned for overload

### DIFF
--- a/slangpy/reflection/reflectiontypes.py
+++ b/slangpy/reflection/reflectiontypes.py
@@ -1211,6 +1211,8 @@ class SlangFunction:
         if self._cached_overloads is None:
             overloads = []
             for refl in self.reflection.overloads:
+                if refl is None:
+                    continue
                 overloads.append(SlangFunction(self._program, refl, self._this, self._full_name))
             self._cached_overloads = tuple(overloads)
         return self._cached_overloads

--- a/slangpy/torchintegration/detection.py
+++ b/slangpy/torchintegration/detection.py
@@ -35,7 +35,7 @@ def detect_torch_tensors(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple
     global _torch_module
     if _torch_module is None:
         try:
-            import torch
+            import torch # @IgnoreException
 
             _torch_module = torch
         except ImportError:


### PR DESCRIPTION
Slang can return None for overloads in certain situations when requesting overloaded generic functions that don't fully resolve. This simply prevents slangpy crashing when encountering one.