### PR TITLE
ci: add diagnostic watchdog to install-slangpy-torch

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -279,7 +279,7 @@ def install_slangpy_torch(args: Any):
         # Surface pip's own pass/fail summary outside the collapsed group
         # so the result is visible without expanding.
         for line in out.splitlines():
-            if line.startswith("Successfully installed") or line.startswith("ERROR"):
+            if line.startswith(("Successfully installed", "ERROR")):
                 print(line)
 
 

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -98,7 +98,7 @@ def run_command(
     process.communicate()
     if process.returncode != 0:
         err = RuntimeError(f'Error running "{command}"')
-        err.captured_output = out
+        err.captured_output = out  # type: ignore[attr-defined]
         raise err
 
     return out

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -245,9 +245,19 @@ def install_slangpy_torch(args: Any):
     cmd = [sys.executable, "-m", "pip", "install", "wheel"]
     run_command(cmd)
 
-    # Use --no-build-isolation to compile against the user's installed PyTorch
-    cmd = [sys.executable, "-m", "pip", "install", str(slangpy_torch_dir), "--no-build-isolation"]
-    run_command(cmd)
+    # -vvv so pip relays the PEP 517 build-backend's stdio live (a hang isn't
+    # a failure, so captured output is never flushed); env vars prevent stdio
+    # buffering and any interactive prompt that could wedge the install.
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-vvv",
+        str(slangpy_torch_dir),
+        "--no-build-isolation",
+    ]
+    run_command(cmd, env={"PYTHONUNBUFFERED": "1", "PIP_NO_INPUT": "1"})
 
 
 def main():

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -247,7 +247,9 @@ def install_slangpy_torch(args: Any):
 
     # -vvv so pip relays the PEP 517 build-backend's stdio live (a hang isn't
     # a failure, so captured output is never flushed); env vars prevent stdio
-    # buffering and any interactive prompt that could wedge the install.
+    # buffering and any interactive prompt that could wedge the install. On
+    # GitHub Actions, wrap the verbose output in a collapsible log group so
+    # the normal case stays readable while diagnostics remain one click away.
     cmd = [
         sys.executable,
         "-m",
@@ -257,7 +259,17 @@ def install_slangpy_torch(args: Any):
         str(slangpy_torch_dir),
         "--no-build-isolation",
     ]
-    run_command(cmd, env={"PYTHONUNBUFFERED": "1", "PIP_NO_INPUT": "1"})
+    env = {"PYTHONUNBUFFERED": "1", "PIP_NO_INPUT": "1"}
+    in_gha = os.environ.get("GITHUB_ACTIONS") == "true"
+    if in_gha:
+        print("::group::pip install slangpy-torch (verbose)")
+        sys.stdout.flush()
+    try:
+        run_command(cmd, env=env)
+    finally:
+        if in_gha:
+            print("::endgroup::")
+            sys.stdout.flush()
 
 
 def main():

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -97,7 +97,9 @@ def run_command(
 
     process.communicate()
     if process.returncode != 0:
-        raise RuntimeError(f'Error running "{command}"')
+        err = RuntimeError(f'Error running "{command}"')
+        err.captured_output = out
+        raise err
 
     return out
 
@@ -264,12 +266,21 @@ def install_slangpy_torch(args: Any):
     if in_gha:
         print("::group::pip install slangpy-torch (verbose)")
         sys.stdout.flush()
+    out = ""
     try:
-        run_command(cmd, env=env)
+        out = run_command(cmd, env=env)
+    except RuntimeError as e:
+        out = getattr(e, "captured_output", "")
+        raise
     finally:
         if in_gha:
             print("::endgroup::")
             sys.stdout.flush()
+        # Surface pip's own pass/fail summary outside the collapsed group
+        # so the result is visible without expanding.
+        for line in out.splitlines():
+            if line.startswith("Successfully installed") or line.startswith("ERROR"):
+                print(line)
 
 
 def main():


### PR DESCRIPTION
## Summary

The 2026-05-12 nightly (run [25708068653](https://github.com/shader-slang/slangpy/actions/runs/25708068653)) spent 1h25m wedged inside `pip install ./src/slangpy_torch --no-build-isolation` at `Preparing metadata (pyproject.toml): started` before the job-level timeout cancelled it, producing **zero diagnostic output**. pip captures the PEP 517 build-backend's stdio by default and only flushes it on failure — a hang isn't a failure, so the captured output never reached the log. The same wedge recurred on the run's attempt 2 on the same runner (`2u1g-b650-0468`).

This PR makes the next occurrence diagnosable, without cluttering the healthy-case log.

## Changes

`tools/ci.py` — `install_slangpy_torch()`:

- `pip -vvv` so pip relays the PEP 517 build-backend's stdio live instead of buffering it
- `PYTHONUNBUFFERED=1` so any Python subprocess in the build chain flushes stdio immediately
- `PIP_NO_INPUT=1` so pip never blocks on an interactive prompt
- On GitHub Actions, wrap the verbose output in a collapsible `::group::` so the normal log stays as short as it was on `main`, with the diagnostics one click away
- Surface pip's own `Successfully installed slangpy-torch-X.Y.Z` (or `ERROR: ...` on failure) outside the collapsed group, so the visible log still shows the result without expanding

`tools/ci.py` — `run_command()`:

- On non-zero exit, attach the captured stdout to the raised `RuntimeError` as `captured_output` so callers can inspect what pip actually printed. Additive change; existing callers are unaffected.

No behavior change on healthy installs (~2s, same line count in the visible log as on `main`).

## Test plan

- [x] `python tools/ci.py --help` still lists `install-slangpy-torch`
- [x] Smoke-tested env-merging and the `captured_output` attribute on success and failure paths
- [x] Smoke-tested that the `::group::`/`::endgroup::` markers wrap the verbose output and that pip's pass/fail summary line appears outside the group
- [ ] Next nightly that exercises this step finishes normally; visible log shows only `Successfully installed slangpy-torch-X.Y.Z` plus a collapsed `▶ pip install slangpy-torch (verbose)` toggle
- [ ] If a future hang triggers, the log contains live `setuptools` / `setup.py` output up to the wedge point (inside the group)