### PR TITLE
Test pre-commit failure comment

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -1,4 +1,4 @@
-name: Format PR  
+name: Format PR
 
 on:
   issue_comment:

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -45,6 +45,17 @@ jobs:
 
             core.setOutput("head_ref", pr.head.ref);
 
+            try {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body: "Formatting requested - I'm on it!"
+              });
+            } catch (error) {
+              core.warning(`Failed to post formatting start comment: ${error.message}`);
+            }
+
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -1,4 +1,4 @@
-name: Format PR
+name: Format PR  
 
 on:
   issue_comment:


### PR DESCRIPTION
Test PR for the remote formatting flow.

This intentionally includes a trailing-whitespace pre-commit failure so the automatic pre-commit help comment and /format workflow can be verified.