### PR TITLE
device: add enable_cuda_launch_from_gfx and enable_ray_tracing flags

### DIFF
--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -257,6 +257,8 @@ Device::Device(const DeviceDesc& desc)
         .enableAftermath = m_desc.enable_aftermath,
         .debugCallback = m_debug_logger.get(),
         .enableCompilationReports = m_desc.enable_compilation_reports,
+        .enableCUDALaunchFromGfx = m_desc.enable_cuda_launch_from_gfx,
+        .enableRayTracing = m_desc.enable_ray_tracing,
         .bindless = bindless_desc,
     };
     log_debug("Creating graphics device (type: {}, LUID: {}).", m_desc.type, m_desc.adapter_luid);

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -118,6 +118,20 @@ struct DeviceDesc {
     /// Enable CUDA interoperability.
     bool enable_cuda_interop{false};
 
+    /// Enable launching CUDA kernels from inside graphics command buffers
+    /// (Vulkan only, via VK_NVX_binary_import + VK_NVX_image_view_handle).
+    /// On by default. Set to false if the application doesn't need
+    /// vkCmdCuLaunchKernelNVX; enabling these extensions has been observed
+    /// to interfere with concurrent cuDNN usage on some driver/GPU pairs.
+    bool enable_cuda_launch_from_gfx{true};
+
+    /// Enable Vulkan ray tracing extensions (acceleration_structure,
+    /// ray_tracing_pipeline, ray_query, ray_tracing_position_fetch, plus
+    /// NV variants). On by default. Set to false if the application doesn't
+    /// use ray tracing; enabling these extensions has been observed to
+    /// interfere with concurrent cuDNN usage on some driver/GPU pairs.
+    bool enable_ray_tracing{true};
+
     /// Enable device side printing (adds performance overhead).
     bool enable_print{false};
 

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -59,6 +59,8 @@ SGL_DICT_TO_DESC_FIELD(rhi_validation_log_level, LogLevel)
 SGL_DICT_TO_DESC_FIELD(enable_ray_tracing_validation, bool)
 SGL_DICT_TO_DESC_FIELD(enable_aftermath, bool)
 SGL_DICT_TO_DESC_FIELD(enable_cuda_interop, bool)
+SGL_DICT_TO_DESC_FIELD(enable_cuda_launch_from_gfx, bool)
+SGL_DICT_TO_DESC_FIELD(enable_ray_tracing, bool)
 SGL_DICT_TO_DESC_FIELD(enable_print, bool)
 SGL_DICT_TO_DESC_FIELD(enable_hot_reload, bool)
 SGL_DICT_TO_DESC_FIELD(enable_compilation_reports, bool)
@@ -341,6 +343,12 @@ SGL_PY_EXPORT(device_device)
         )
         .def_rw("enable_aftermath", &DeviceDesc::enable_aftermath, D(DeviceDesc, enable_aftermath))
         .def_rw("enable_cuda_interop", &DeviceDesc::enable_cuda_interop, D(DeviceDesc, enable_cuda_interop))
+        .def_rw(
+            "enable_cuda_launch_from_gfx",
+            &DeviceDesc::enable_cuda_launch_from_gfx,
+            D(DeviceDesc, enable_cuda_launch_from_gfx)
+        )
+        .def_rw("enable_ray_tracing", &DeviceDesc::enable_ray_tracing, D(DeviceDesc, enable_ray_tracing))
         .def_rw("enable_print", &DeviceDesc::enable_print, D(DeviceDesc, enable_print))
         .def_rw("enable_hot_reload", &DeviceDesc::enable_hot_reload, D(DeviceDesc, adapter_luid))
         .def_rw(
@@ -490,6 +498,8 @@ SGL_PY_EXPORT(device_device)
            bool enable_ray_tracing_validation,
            bool enable_aftermath,
            bool enable_cuda_interop,
+           bool enable_cuda_launch_from_gfx,
+           bool enable_ray_tracing,
            bool enable_print,
            bool enable_hot_reload,
            bool enable_compilation_reports,
@@ -513,6 +523,8 @@ SGL_PY_EXPORT(device_device)
                  .enable_ray_tracing_validation = enable_ray_tracing_validation,
                  .enable_aftermath = enable_aftermath,
                  .enable_cuda_interop = enable_cuda_interop,
+                 .enable_cuda_launch_from_gfx = enable_cuda_launch_from_gfx,
+                 .enable_ray_tracing = enable_ray_tracing,
                  .enable_print = enable_print,
                  .enable_hot_reload = enable_hot_reload,
                  .enable_compilation_reports = enable_compilation_reports,
@@ -538,6 +550,8 @@ SGL_PY_EXPORT(device_device)
         "enable_ray_tracing_validation"_a = DeviceDesc().enable_ray_tracing_validation,
         "enable_aftermath"_a = DeviceDesc().enable_aftermath,
         "enable_cuda_interop"_a = DeviceDesc().enable_cuda_interop,
+        "enable_cuda_launch_from_gfx"_a = DeviceDesc().enable_cuda_launch_from_gfx,
+        "enable_ray_tracing"_a = DeviceDesc().enable_ray_tracing,
         "enable_print"_a = DeviceDesc().enable_print,
         "enable_hot_reload"_a = DeviceDesc().enable_hot_reload,
         "enable_compilation_reports"_a = DeviceDesc().enable_compilation_reports,

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -498,8 +498,6 @@ SGL_PY_EXPORT(device_device)
            bool enable_ray_tracing_validation,
            bool enable_aftermath,
            bool enable_cuda_interop,
-           bool enable_cuda_launch_from_gfx,
-           bool enable_ray_tracing,
            bool enable_print,
            bool enable_hot_reload,
            bool enable_compilation_reports,
@@ -512,6 +510,8 @@ SGL_PY_EXPORT(device_device)
            std::optional<BindlessDesc> bindless_options,
            std::optional<std::vector<std::string>> additional_vulkan_instance_extensions,
            std::optional<std::vector<std::string>> additional_vulkan_device_extensions,
+           bool enable_cuda_launch_from_gfx,
+           bool enable_ray_tracing,
            std::string label = "")
         {
             new (self) Device(
@@ -550,8 +550,6 @@ SGL_PY_EXPORT(device_device)
         "enable_ray_tracing_validation"_a = DeviceDesc().enable_ray_tracing_validation,
         "enable_aftermath"_a = DeviceDesc().enable_aftermath,
         "enable_cuda_interop"_a = DeviceDesc().enable_cuda_interop,
-        "enable_cuda_launch_from_gfx"_a = DeviceDesc().enable_cuda_launch_from_gfx,
-        "enable_ray_tracing"_a = DeviceDesc().enable_ray_tracing,
         "enable_print"_a = DeviceDesc().enable_print,
         "enable_hot_reload"_a = DeviceDesc().enable_hot_reload,
         "enable_compilation_reports"_a = DeviceDesc().enable_compilation_reports,
@@ -564,6 +562,8 @@ SGL_PY_EXPORT(device_device)
         "bindless_options"_a.none() = nb::none(),
         "additional_vulkan_instance_extensions"_a.none() = nb::none(),
         "additional_vulkan_device_extensions"_a.none() = nb::none(),
+        "enable_cuda_launch_from_gfx"_a = DeviceDesc().enable_cuda_launch_from_gfx,
+        "enable_ray_tracing"_a = DeviceDesc().enable_ray_tracing,
         "label"_a = DeviceDesc().label,
         D(Device, Device)
     );

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -2701,9 +2701,9 @@ static const char *__doc_sgl_DeviceDesc_enable_compilation_reports = R"doc(Enabl
 
 static const char *__doc_sgl_DeviceDesc_enable_cuda_interop = R"doc(Enable CUDA interoperability.)doc";
 
-static const char *__doc_sgl_DeviceDesc_enable_cuda_launch_from_gfx = R"doc(Enable launching CUDA kernels from inside Vulkan command buffers (via VK_NVX_binary_import + VK_NVX_image_view_handle). On by default. Set false on NVIDIA Linux + Blackwell sm_120 (driver 595.x) if vkCmdCuLaunchKernelNVX isn't needed.)doc";
+static const char *__doc_sgl_DeviceDesc_enable_cuda_launch_from_gfx = R"doc(Enable launching CUDA kernels from inside Vulkan command buffers (via VK_NVX_binary_import). On by default. Set to false if the application doesn't need vkCmdCuLaunchKernelNVX; enabling this extension has been observed to interfere with concurrent cuDNN usage on some driver/GPU pairs.)doc";
 
-static const char *__doc_sgl_DeviceDesc_enable_ray_tracing = R"doc(Enable Vulkan ray tracing extensions (acceleration_structure family). On by default. Set false on NVIDIA Linux + Blackwell sm_120 (driver 595.x) if ray tracing isn't used.)doc";
+static const char *__doc_sgl_DeviceDesc_enable_ray_tracing = R"doc(Enable Vulkan ray tracing extensions (acceleration_structure family). On by default. Set to false if the application doesn't use ray tracing; enabling these extensions has been observed to interfere with concurrent cuDNN usage on some driver/GPU pairs.)doc";
 
 static const char *__doc_sgl_DeviceDesc_enable_debug_layers = R"doc(Enable debug layers.)doc";
 

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -2701,6 +2701,10 @@ static const char *__doc_sgl_DeviceDesc_enable_compilation_reports = R"doc(Enabl
 
 static const char *__doc_sgl_DeviceDesc_enable_cuda_interop = R"doc(Enable CUDA interoperability.)doc";
 
+static const char *__doc_sgl_DeviceDesc_enable_cuda_launch_from_gfx = R"doc(Enable launching CUDA kernels from inside Vulkan command buffers (via VK_NVX_binary_import + VK_NVX_image_view_handle). On by default. Set false on NVIDIA Linux + Blackwell sm_120 (driver 595.x) if vkCmdCuLaunchKernelNVX isn't needed.)doc";
+
+static const char *__doc_sgl_DeviceDesc_enable_ray_tracing = R"doc(Enable Vulkan ray tracing extensions (acceleration_structure family). On by default. Set false on NVIDIA Linux + Blackwell sm_120 (driver 595.x) if ray tracing isn't used.)doc";
+
 static const char *__doc_sgl_DeviceDesc_enable_debug_layers = R"doc(Enable debug layers.)doc";
 
 static const char *__doc_sgl_DeviceDesc_enable_hot_reload =


### PR DESCRIPTION
## Summary

Mirrors the new `DeviceDesc::enableCUDALaunchFromGfx` and `DeviceDesc::enableRayTracing` flags from shader-slang/slang-rhi#760 (merged) through `sgl::DeviceDesc` and the Python binding.

Both default `true` to preserve current behaviour. Applications can opt out:

```python
device = spy.Device(
    type=spy.DeviceType.vulkan,
    enable_cuda_launch_from_gfx=False,
    enable_ray_tracing=False,
)