### PR TITLE
Update query APIs and add timestamp calibration API

### DIFF
--- a/src/sgl/device/command.cpp
+++ b/src/sgl/device/command.cpp
@@ -779,24 +779,6 @@ void CommandEncoder::query_acceleration_structure_properties(
     );
 }
 
-void CommandEncoder::serialize_acceleration_structure(BufferOffsetPair dst, AccelerationStructure* src)
-{
-    SGL_CHECK(m_open, "Command encoder is finished");
-    SGL_CHECK_NOT_NULL(dst.buffer);
-    SGL_CHECK_NOT_NULL(src);
-
-    m_rhi_command_encoder->serializeAccelerationStructure(detail::to_rhi(dst), src->rhi_acceleration_structure());
-}
-
-void CommandEncoder::deserialize_acceleration_structure(AccelerationStructure* dst, BufferOffsetPair src)
-{
-    SGL_CHECK(m_open, "Command encoder is finished");
-    SGL_CHECK_NOT_NULL(dst);
-    SGL_CHECK_NOT_NULL(src.buffer);
-
-    m_rhi_command_encoder->deserializeAccelerationStructure(dst->rhi_acceleration_structure(), detail::to_rhi(src));
-}
-
 void CommandEncoder::convert_coop_vec_matrices(
     Buffer* dst,
     std::span<const CoopVecMatrixDesc> dst_descs,

--- a/src/sgl/device/command.h
+++ b/src/sgl/device/command.h
@@ -368,9 +368,6 @@ public:
         std::span<AccelerationStructureQueryDesc> queries
     );
 
-    void serialize_acceleration_structure(BufferOffsetPair dst, AccelerationStructure* src);
-    void deserialize_acceleration_structure(AccelerationStructure* dst, BufferOffsetPair src);
-
     void convert_coop_vec_matrices(
         Buffer* dst,
         std::span<const CoopVecMatrixDesc> dst_descs,

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -1015,6 +1015,22 @@ void Device::wait_for_idle(CommandQueueType queue)
     }
 }
 
+TimestampCalibration Device::get_timestamp_calibration(CommandQueueType queue) const
+{
+    SGL_CHECK(queue == CommandQueueType::graphics, "Only graphics queue is supported.");
+
+    rhi::TimestampCalibration rhi_calibration;
+    SLANG_RHI_CALL(m_rhi_graphics_queue->getTimestampCalibration(&rhi_calibration), this);
+    return {
+        .cpu_domain = static_cast<CpuTimestampDomain>(rhi_calibration.cpuDomain),
+        .cpu_timestamp = rhi_calibration.cpuTimestamp,
+        .cpu_frequency = rhi_calibration.cpuFrequency,
+        .gpu_timestamp = rhi_calibration.gpuTimestamp,
+        .gpu_frequency = rhi_calibration.gpuFrequency,
+        .max_deviation_ns = rhi_calibration.maxDeviationNs
+    };
+}
+
 void Device::sync_to_cuda(void* cuda_stream)
 {
     // Signal fence from CUDA, wait for it on graphics queue.

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -649,6 +649,16 @@ public:
     void wait_for_idle(CommandQueueType queue = CommandQueueType::graphics);
 
     /**
+     * \brief Get timestamp calibration data for a queue.
+     *
+     * This can be used to synchronize CPU and GPU timestamps, which is necessary for accurate profiling and debugging.
+     *
+     * \param queue Command queue to get timestamp calibration data for.
+     * \return Timestamp calibration data
+     */
+    TimestampCalibration get_timestamp_calibration(CommandQueueType queue = CommandQueueType::graphics) const;
+
+    /**
      * \brief Synchronize CUDA -> device.
      *
      * This signals a shared CUDA semaphore from the CUDA stream and then waits for the signal on the command queue.

--- a/src/sgl/device/query.cpp
+++ b/src/sgl/device/query.cpp
@@ -26,11 +26,25 @@ void QueryPool::reset()
     SLANG_RHI_CALL(m_rhi_query_pool->reset(), m_device);
 }
 
+void QueryPool::reset(uint32_t index, uint32_t count)
+{
+    SGL_CHECK(index + count <= m_desc.count, "'index' / 'count' out of range");
+    SLANG_RHI_CALL(m_rhi_query_pool->reset(index, count), m_device);
+}
+
 void QueryPool::get_results(uint32_t index, uint32_t count, std::span<uint64_t> result)
 {
     SGL_CHECK(index + count <= m_desc.count, "'index' / 'count' out of range");
     SGL_CHECK(result.size() >= count, "'result' buffer too small");
     SLANG_RHI_CALL(m_rhi_query_pool->getResult(index, count, result.data()), m_device);
+}
+
+bool QueryPool::is_result_ready(uint32_t index, uint32_t count)
+{
+    SGL_CHECK(index + count <= m_desc.count, "'index' / 'count' out of range");
+    bool ready;
+    SLANG_RHI_CALL(m_rhi_query_pool->isResultReady(index, count, &ready), m_device);
+    return ready;
 }
 
 std::vector<uint64_t> QueryPool::get_results(uint32_t index, uint32_t count)

--- a/src/sgl/device/query.cpp
+++ b/src/sgl/device/query.cpp
@@ -28,20 +28,20 @@ void QueryPool::reset()
 
 void QueryPool::reset(uint32_t index, uint32_t count)
 {
-    SGL_CHECK(index + count <= m_desc.count, "'index' / 'count' out of range");
+    SGL_CHECK(uint64_t(index) + count <= m_desc.count, "'index' / 'count' out of range");
     SLANG_RHI_CALL(m_rhi_query_pool->reset(index, count), m_device);
 }
 
 void QueryPool::get_results(uint32_t index, uint32_t count, std::span<uint64_t> result)
 {
-    SGL_CHECK(index + count <= m_desc.count, "'index' / 'count' out of range");
+    SGL_CHECK(uint64_t(index) + count <= m_desc.count, "'index' / 'count' out of range");
     SGL_CHECK(result.size() >= count, "'result' buffer too small");
     SLANG_RHI_CALL(m_rhi_query_pool->getResult(index, count, result.data()), m_device);
 }
 
 bool QueryPool::is_result_ready(uint32_t index, uint32_t count)
 {
-    SGL_CHECK(index + count <= m_desc.count, "'index' / 'count' out of range");
+    SGL_CHECK(uint64_t(index) + count <= m_desc.count, "'index' / 'count' out of range");
     bool ready;
     SLANG_RHI_CALL(m_rhi_query_pool->isResultReady(index, count, &ready), m_device);
     return ready;
@@ -56,7 +56,7 @@ std::vector<uint64_t> QueryPool::get_results(uint32_t index, uint32_t count)
 
 uint64_t QueryPool::get_result(uint32_t index)
 {
-    SGL_CHECK(index < m_desc.count, "'index' out of range");
+    SGL_CHECK(uint64_t(index) < m_desc.count, "'index' out of range");
     uint64_t result;
     SLANG_RHI_CALL(m_rhi_query_pool->getResult(index, 1, &result), m_device);
     return result;

--- a/src/sgl/device/query.h
+++ b/src/sgl/device/query.h
@@ -33,6 +33,9 @@ public:
     const QueryPoolDesc& desc() const { return m_desc; }
 
     void reset();
+    void reset(uint32_t index, uint32_t count);
+
+    bool is_result_ready(uint32_t index, uint32_t count);
 
     void get_results(uint32_t index, uint32_t count, std::span<uint64_t> result);
     std::vector<uint64_t> get_results(uint32_t index, uint32_t count);

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -69,6 +69,7 @@ enum class Feature : uint32_t {
     cluster_acceleration_structure = static_cast<uint32_t>(rhi::Feature::ClusterAccelerationStructure),
     // Other features
     timestamp_query = static_cast<uint32_t>(rhi::Feature::TimestampQuery),
+    timestamp_calibration = static_cast<uint32_t>(rhi::Feature::TimestampCalibration),
     realtime_clock = static_cast<uint32_t>(rhi::Feature::RealtimeClock),
     cooperative_vector = static_cast<uint32_t>(rhi::Feature::CooperativeVector),
     cooperative_matrix = static_cast<uint32_t>(rhi::Feature::CooperativeMatrix),
@@ -146,6 +147,7 @@ SGL_ENUM_INFO(
         {Feature::ray_tracing_validation, "ray_tracing_validation"},
         {Feature::cluster_acceleration_structure, "cluster_acceleration_structure"},
         {Feature::timestamp_query, "timestamp_query"},
+        {Feature::timestamp_calibration, "timestamp_calibration"},
         {Feature::realtime_clock, "realtime_clock"},
         {Feature::cooperative_vector, "cooperative_vector"},
         {Feature::cooperative_matrix, "cooperative_matrix"},
@@ -777,7 +779,6 @@ struct RasterizerDesc {
 enum class QueryType : uint32_t {
     timestamp = static_cast<uint32_t>(rhi::QueryType::Timestamp),
     acceleration_structure_compacted_size = static_cast<uint32_t>(rhi::QueryType::AccelerationStructureCompactedSize),
-    acceleration_structure_serialized_size = static_cast<uint32_t>(rhi::QueryType::AccelerationStructureSerializedSize),
     acceleration_structure_current_size = static_cast<uint32_t>(rhi::QueryType::AccelerationStructureCurrentSize),
 };
 
@@ -786,11 +787,45 @@ SGL_ENUM_INFO(
     {
         {QueryType::timestamp, "timestamp"},
         {QueryType::acceleration_structure_compacted_size, "acceleration_structure_compacted_size"},
-        {QueryType::acceleration_structure_serialized_size, "acceleration_structure_serialized_size"},
         {QueryType::acceleration_structure_current_size, "acceleration_structure_current_size"},
     }
 );
 SGL_ENUM_REGISTER(QueryType);
+
+enum class CpuTimestampDomain : uint32_t {
+    unknown = static_cast<uint32_t>(rhi::CpuTimestampDomain::Unknown),
+    query_performance_counter = static_cast<uint32_t>(rhi::CpuTimestampDomain::QueryPerformanceCounter),
+    clock_monotonic = static_cast<uint32_t>(rhi::CpuTimestampDomain::ClockMonotonic),
+    clock_monotonic_raw = static_cast<uint32_t>(rhi::CpuTimestampDomain::ClockMonotonicRaw),
+    mach_absolute_time = static_cast<uint32_t>(rhi::CpuTimestampDomain::MachAbsoluteTime),
+};
+
+SGL_ENUM_INFO(
+    CpuTimestampDomain,
+    {
+        {CpuTimestampDomain::unknown, "unknown"},
+        {CpuTimestampDomain::query_performance_counter, "query_performance_counter"},
+        {CpuTimestampDomain::clock_monotonic, "clock_monotonic"},
+        {CpuTimestampDomain::clock_monotonic_raw, "clock_monotonic_raw"},
+        {CpuTimestampDomain::mach_absolute_time, "mach_absolute_time"},
+    }
+);
+SGL_ENUM_REGISTER(CpuTimestampDomain);
+
+struct TimestampCalibration {
+    /// The domain of the CPU timestamp.
+    CpuTimestampDomain cpu_domain{CpuTimestampDomain::unknown};
+    /// The current CPU timestamp.
+    uint64_t cpu_timestamp{0};
+    /// The frequency of the CPU timestamp in ticks per second.
+    uint64_t cpu_frequency{0};
+    /// The current GPU timestamp.
+    uint64_t gpu_timestamp{0};
+    /// The frequency of the GPU timestamp in ticks per second.
+    uint64_t gpu_frequency{0};
+    /// The maximum deviation between the CPU and GPU timestamps in nanoseconds.
+    uint64_t max_deviation_ns{0};
+};
 
 // ----------------------------------------------------------------------------
 // RayTracing

--- a/src/slangpy_ext/device/command.cpp
+++ b/src/slangpy_ext/device/command.cpp
@@ -505,20 +505,6 @@ SGL_PY_EXPORT(device_command)
             D(CommandEncoder, query_acceleration_structure_properties)
         )
         .def(
-            "serialize_acceleration_structure",
-            &CommandEncoder::serialize_acceleration_structure,
-            "dst"_a,
-            "src"_a,
-            D(CommandEncoder, serialize_acceleration_structure)
-        )
-        .def(
-            "deserialize_acceleration_structure",
-            &CommandEncoder::deserialize_acceleration_structure,
-            "dst"_a,
-            "src"_a,
-            D(CommandEncoder, deserialize_acceleration_structure)
-        )
-        .def(
             "convert_coop_vec_matrices",
             &CommandEncoder::convert_coop_vec_matrices,
             "dst"_a,

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -865,6 +865,12 @@ SGL_PY_EXPORT(device_device)
     device
         .def("wait_for_idle", &Device::wait_for_idle, "queue"_a = CommandQueueType::graphics, D(Device, wait_for_idle));
     device.def(
+        "get_timestamp_calibration",
+        &Device::get_timestamp_calibration,
+        "queue"_a = CommandQueueType::graphics,
+        D(Device, get_timestamp_calibration)
+    );
+    device.def(
         "sync_to_cuda",
         [](Device* self, uint64_t cuda_stream)
         {

--- a/src/slangpy_ext/device/query.cpp
+++ b/src/slangpy_ext/device/query.cpp
@@ -30,14 +30,22 @@ SGL_PY_EXPORT(device_query)
 
     nb::class_<QueryPool, DeviceChild>(m, "QueryPool", D(QueryPool))
         .def_prop_ro("desc", &QueryPool::desc, D(QueryPool, desc))
-        .def("reset", &QueryPool::reset, D(QueryPool, reset))
+        .def("reset", nb::overload_cast<>(&QueryPool::reset), D(QueryPool, reset))
+        .def(
+            "reset",
+            nb::overload_cast<uint32_t, uint32_t>(&QueryPool::reset),
+            "index"_a,
+            "count"_a,
+            D(QueryPool, reset, 2)
+        )
+        .def("is_result_ready", &QueryPool::is_result_ready, "index"_a, "count"_a, D(QueryPool, is_result_ready))
         .def("get_result", &QueryPool::get_result, "index"_a, D(QueryPool, get_result))
         .def(
             "get_results",
             nb::overload_cast<uint32_t, uint32_t>(&QueryPool::get_results),
             "index"_a,
             "count"_a,
-            D(QueryPool, get_results)
+            D(QueryPool, get_results, 2)
         )
         .def("get_timestamp_result", &QueryPool::get_timestamp_result, "index"_a, D(QueryPool, get_timestamp_result))
         .def(
@@ -45,6 +53,6 @@ SGL_PY_EXPORT(device_query)
             nb::overload_cast<uint32_t, uint32_t>(&QueryPool::get_timestamp_results),
             "index"_a,
             "count"_a,
-            D(QueryPool, get_timestamp_results)
+            D(QueryPool, get_timestamp_results, 2)
         );
 }

--- a/src/slangpy_ext/device/types.cpp
+++ b/src/slangpy_ext/device/types.cpp
@@ -329,6 +329,16 @@ SGL_PY_EXPORT(device_types)
     // ------------------------------------------------------------------------
 
     nb::sgl_enum<QueryType>(m, "QueryType");
+    nb::sgl_enum<CpuTimestampDomain>(m, "CpuTimestampDomain");
+
+    nb::class_<TimestampCalibration>(m, "TimestampCalibration", D(TimestampCalibration))
+        .def(nb::init<>())
+        .def_ro("cpu_domain", &TimestampCalibration::cpu_domain, D(TimestampCalibration, cpu_domain))
+        .def_ro("cpu_timestamp", &TimestampCalibration::cpu_timestamp, D(TimestampCalibration, cpu_timestamp))
+        .def_ro("cpu_frequency", &TimestampCalibration::cpu_frequency, D(TimestampCalibration, cpu_frequency))
+        .def_ro("gpu_timestamp", &TimestampCalibration::gpu_timestamp, D(TimestampCalibration, gpu_timestamp))
+        .def_ro("gpu_frequency", &TimestampCalibration::gpu_frequency, D(TimestampCalibration, gpu_frequency))
+        .def_ro("max_deviation_ns", &TimestampCalibration::max_deviation_ns, D(TimestampCalibration, max_deviation_ns));
 
     // ------------------------------------------------------------------------
     // Raytracing

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -350,6 +350,8 @@ static const char *__doc_sgl_AccelerationStructure_rhi_acceleration_structure = 
 
 static const char *__doc_sgl_AccelerationStructure_to_string = R"doc()doc";
 
+static const char *__doc_sgl_AccelerationStructure_write_to_cursor = R"doc(Bind a nullable acceleration structure value to a shader cursor.)doc";
+
 static const char *__doc_sgl_AdapterInfo = R"doc()doc";
 
 static const char *__doc_sgl_AdapterInfo_device_id =
@@ -1189,6 +1191,8 @@ provides read/write tools to access its members via reflection.)doc";
 
 static const char *__doc_sgl_BufferElementCursor_2 = R"doc()doc";
 
+static const char *__doc_sgl_BufferElementCursor_3 = R"doc()doc";
+
 static const char *__doc_sgl_BufferElementCursor_BufferElementCursor = R"doc()doc";
 
 static const char *__doc_sgl_BufferElementCursor_BufferElementCursor_2 = R"doc(Create with none-owning view of specific block of memory)doc";
@@ -1236,6 +1240,8 @@ static const char *__doc_sgl_BufferElementCursor_reinterpret = R"doc(Reinterpret
 static const char *__doc_sgl_BufferElementCursor_set = R"doc()doc";
 
 static const char *__doc_sgl_BufferElementCursor_set_2 = R"doc()doc";
+
+static const char *__doc_sgl_BufferElementCursor_set_3 = R"doc()doc";
 
 static const char *__doc_sgl_BufferElementCursor_set_data = R"doc()doc";
 
@@ -1345,6 +1351,8 @@ static const char *__doc_sgl_BufferView_release_rhi_resources = R"doc()doc";
 
 static const char *__doc_sgl_BufferView_to_string = R"doc()doc";
 
+static const char *__doc_sgl_BufferView_write_to_cursor = R"doc(Bind a nullable buffer view value to a shader cursor.)doc";
+
 static const char *__doc_sgl_Buffer_Buffer = R"doc()doc";
 
 static const char *__doc_sgl_Buffer_class_name = R"doc()doc";
@@ -1438,6 +1446,10 @@ static const char *__doc_sgl_Buffer_struct_size = R"doc()doc";
 static const char *__doc_sgl_Buffer_to_string = R"doc()doc";
 
 static const char *__doc_sgl_Buffer_unmap = R"doc(Unmap the buffer.)doc";
+
+static const char *__doc_sgl_Buffer_write_slangpy_signature = R"doc(Write the SlangPy cache signature used by functional dispatch.)doc";
+
+static const char *__doc_sgl_Buffer_write_to_cursor = R"doc(Bind a nullable buffer value to a shader cursor.)doc";
 
 static const char *__doc_sgl_ColorTargetDesc = R"doc()doc";
 
@@ -1665,8 +1677,6 @@ Parameter ``src_offset``:
 Parameter ``extent``:
     Extent in texels (-1 for maximum possible extent).)doc";
 
-static const char *__doc_sgl_CommandEncoder_deserialize_acceleration_structure = R"doc()doc";
-
 static const char *__doc_sgl_CommandEncoder_execute_callback =
 R"doc(Execute a callback while recording/executing the active native command
 context.
@@ -1735,8 +1745,6 @@ static const char *__doc_sgl_CommandEncoder_release_rhi_resources = R"doc()doc";
 static const char *__doc_sgl_CommandEncoder_resolve_query = R"doc()doc";
 
 static const char *__doc_sgl_CommandEncoder_rhi_command_encoder = R"doc()doc";
-
-static const char *__doc_sgl_CommandEncoder_serialize_acceleration_structure = R"doc()doc";
 
 static const char *__doc_sgl_CommandEncoder_set_buffer_state =
 R"doc(Transition resource state of a buffer and add a barrier if state has
@@ -1985,6 +1993,20 @@ static const char *__doc_sgl_CoopVecMatrixLayout_info = R"doc()doc";
 static const char *__doc_sgl_CoopVecMatrixLayout_row_major = R"doc()doc";
 
 static const char *__doc_sgl_CoopVecMatrixLayout_training_optimal = R"doc()doc";
+
+static const char *__doc_sgl_CpuTimestampDomain = R"doc()doc";
+
+static const char *__doc_sgl_CpuTimestampDomain_clock_monotonic = R"doc()doc";
+
+static const char *__doc_sgl_CpuTimestampDomain_clock_monotonic_raw = R"doc()doc";
+
+static const char *__doc_sgl_CpuTimestampDomain_info = R"doc()doc";
+
+static const char *__doc_sgl_CpuTimestampDomain_mach_absolute_time = R"doc()doc";
+
+static const char *__doc_sgl_CpuTimestampDomain_query_performance_counter = R"doc()doc";
+
+static const char *__doc_sgl_CpuTimestampDomain_unknown = R"doc()doc";
 
 static const char *__doc_sgl_CullMode = R"doc()doc";
 
@@ -2647,6 +2669,10 @@ static const char *__doc_sgl_DescriptorHandle_type = R"doc()doc";
 
 static const char *__doc_sgl_DescriptorHandle_value = R"doc()doc";
 
+static const char *__doc_sgl_DescriptorHandle_write_to_cursor = R"doc(Write a bindless descriptor handle to a shader cursor.)doc";
+
+static const char *__doc_sgl_DescriptorHandle_write_to_cursor_2 = R"doc(Write a bindless descriptor handle value into buffer cursor storage.)doc";
+
 static const char *__doc_sgl_Device = R"doc()doc";
 
 static const char *__doc_sgl_Device_2 = R"doc()doc";
@@ -2701,9 +2727,12 @@ static const char *__doc_sgl_DeviceDesc_enable_compilation_reports = R"doc(Enabl
 
 static const char *__doc_sgl_DeviceDesc_enable_cuda_interop = R"doc(Enable CUDA interoperability.)doc";
 
-static const char *__doc_sgl_DeviceDesc_enable_cuda_launch_from_gfx = R"doc(Enable launching CUDA kernels from inside Vulkan command buffers (via VK_NVX_binary_import). On by default. Set to false if the application doesn't need vkCmdCuLaunchKernelNVX; enabling this extension has been observed to interfere with concurrent cuDNN usage on some driver/GPU pairs.)doc";
-
-static const char *__doc_sgl_DeviceDesc_enable_ray_tracing = R"doc(Enable Vulkan ray tracing extensions (acceleration_structure family). On by default. Set to false if the application doesn't use ray tracing; enabling these extensions has been observed to interfere with concurrent cuDNN usage on some driver/GPU pairs.)doc";
+static const char *__doc_sgl_DeviceDesc_enable_cuda_launch_from_gfx =
+R"doc(Enable launching CUDA kernels from inside graphics command buffers
+(Vulkan only, via VK_NVX_binary_import + VK_NVX_image_view_handle). On
+by default. Set to false if the application doesn't need
+vkCmdCuLaunchKernelNVX; enabling these extensions has been observed to
+interfere with concurrent cuDNN usage on some driver/GPU pairs.)doc";
 
 static const char *__doc_sgl_DeviceDesc_enable_debug_layers = R"doc(Enable debug layers.)doc";
 
@@ -2712,6 +2741,13 @@ R"doc(Enable automatic shader reload in response to file changes. Note:
 Currently windows and linux only.)doc";
 
 static const char *__doc_sgl_DeviceDesc_enable_print = R"doc(Enable device side printing (adds performance overhead).)doc";
+
+static const char *__doc_sgl_DeviceDesc_enable_ray_tracing =
+R"doc(Enable Vulkan ray tracing extensions (acceleration_structure,
+ray_tracing_pipeline, ray_query, ray_tracing_position_fetch, plus NV
+variants). On by default. Set to false if the application doesn't use
+ray tracing; enabling these extensions has been observed to interfere
+with concurrent cuDNN usage on some driver/GPU pairs.)doc";
 
 static const char *__doc_sgl_DeviceDesc_enable_ray_tracing_validation = R"doc(Enable ray-tracing validation.)doc";
 
@@ -3176,6 +3212,18 @@ static const char *__doc_sgl_Device_get_format_support = R"doc(Returns the suppo
 static const char *__doc_sgl_Device_get_native_command_queue_handle =
 R"doc(Returns the native API handle for the command queue: - D3D12:
 ID3D12CommandQueue* - Vulkan: VkQueue (Vulkan))doc";
+
+static const char *__doc_sgl_Device_get_timestamp_calibration =
+R"doc(Get timestamp calibration data for a queue.
+
+This can be used to synchronize CPU and GPU timestamps, which is
+necessary for accurate profiling and debugging.
+
+Parameter ``queue``:
+    Command queue to get timestamp calibration data for.
+
+Returns:
+    Timestamp calibration data)doc";
 
 static const char *__doc_sgl_Device_global_session = R"doc()doc";
 
@@ -3694,6 +3742,8 @@ static const char *__doc_sgl_Feature_sm_6_9 = R"doc()doc";
 static const char *__doc_sgl_Feature_software_device = R"doc()doc";
 
 static const char *__doc_sgl_Feature_surface = R"doc()doc";
+
+static const char *__doc_sgl_Feature_timestamp_calibration = R"doc()doc";
 
 static const char *__doc_sgl_Feature_timestamp_query = R"doc()doc";
 
@@ -6363,6 +6413,8 @@ static const char *__doc_sgl_QueryPool_get_timestamp_results = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_get_timestamp_results_2 = R"doc()doc";
 
+static const char *__doc_sgl_QueryPool_is_result_ready = R"doc()doc";
+
 static const char *__doc_sgl_QueryPool_m_desc = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_m_rhi_query_pool = R"doc()doc";
@@ -6370,6 +6422,8 @@ static const char *__doc_sgl_QueryPool_m_rhi_query_pool = R"doc()doc";
 static const char *__doc_sgl_QueryPool_release_rhi_resources = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_reset = R"doc()doc";
+
+static const char *__doc_sgl_QueryPool_reset_2 = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_rhi_query_pool = R"doc()doc";
 
@@ -6380,8 +6434,6 @@ static const char *__doc_sgl_QueryType = R"doc()doc";
 static const char *__doc_sgl_QueryType_acceleration_structure_compacted_size = R"doc()doc";
 
 static const char *__doc_sgl_QueryType_acceleration_structure_current_size = R"doc()doc";
-
-static const char *__doc_sgl_QueryType_acceleration_structure_serialized_size = R"doc()doc";
 
 static const char *__doc_sgl_QueryType_info = R"doc()doc";
 
@@ -6941,6 +6993,8 @@ static const char *__doc_sgl_Sampler_rhi_sampler = R"doc()doc";
 
 static const char *__doc_sgl_Sampler_to_string = R"doc()doc";
 
+static const char *__doc_sgl_Sampler_write_to_cursor = R"doc(Bind a nullable sampler value to a shader cursor.)doc";
+
 static const char *__doc_sgl_ScissorRect = R"doc()doc";
 
 static const char *__doc_sgl_ScissorRect_from_size = R"doc()doc";
@@ -6980,6 +7034,8 @@ performance implications of allocating/freeing them repeatedly. This
 is far faster, however does introduce a risk of mem access problems if
 the shader cursor is kept alive longer than the shader object it was
 created from.)doc";
+
+static const char *__doc_sgl_ShaderCursor_3 = R"doc()doc";
 
 static const char *__doc_sgl_ShaderCursor_ShaderCursor = R"doc()doc";
 
@@ -7038,9 +7094,15 @@ immutability of a ShaderObject. To use safely, ensure that the address
 returned is immediately populated, not retained. Prefer using set_data
 unless absolutely necessary.)doc";
 
-static const char *__doc_sgl_ShaderCursor_set = R"doc()doc";
+static const char *__doc_sgl_ShaderCursor_set =
+R"doc(Let values that know how to write to ShaderCursor populate this cursor
+directly.)doc";
 
-static const char *__doc_sgl_ShaderCursor_set_2 = R"doc()doc";
+static const char *__doc_sgl_ShaderCursor_set_2 = R"doc(Let ref-counted values forward to their type's cursor writer.)doc";
+
+static const char *__doc_sgl_ShaderCursor_set_3 =
+R"doc(Fall back to the built-in ShaderCursor setter specializations for non
+cursor-writer values.)doc";
 
 static const char *__doc_sgl_ShaderCursor_set_acceleration_structure = R"doc()doc";
 
@@ -7170,6 +7232,8 @@ static const char *__doc_sgl_ShaderObject_set_texture = R"doc()doc";
 static const char *__doc_sgl_ShaderObject_set_texture_view = R"doc()doc";
 
 static const char *__doc_sgl_ShaderObject_slang_element_type_layout = R"doc()doc";
+
+static const char *__doc_sgl_ShaderObject_write_to_cursor = R"doc()doc";
 
 static const char *__doc_sgl_ShaderOffset =
 R"doc(Represents the offset of a shader variable relative to its enclosing
@@ -7341,6 +7405,42 @@ static const char *__doc_sgl_ShaderTable_release_rhi_resources = R"doc()doc";
 static const char *__doc_sgl_ShaderTable_rhi_shader_table = R"doc()doc";
 
 static const char *__doc_sgl_ShaderTable_to_string = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer =
+R"doc(Stack-allocated signature buffer. Used in hot paths that need cheap,
+append-only signature construction.)doc";
+
+static const char *__doc_sgl_SignatureBuffer_2 = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer_3 = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer_SignatureBuffer = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer_SignatureBuffer_2 = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer_add =
+R"doc(Append string data exactly as bytes; no separators or terminators are
+added.)doc";
+
+static const char *__doc_sgl_SignatureBuffer_add_2 =
+R"doc(Append string-view data exactly as bytes; no separators or terminators
+are added.)doc";
+
+static const char *__doc_sgl_SignatureBuffer_add_3 = R"doc(Append a null-terminated string without the trailing null byte.)doc";
+
+static const char *__doc_sgl_SignatureBuffer_add_4 = R"doc(Append a 32-bit value as fixed-width lower-case hexadecimal text.)doc";
+
+static const char *__doc_sgl_SignatureBuffer_add_5 = R"doc(Append a 64-bit value as fixed-width lower-case hexadecimal text.)doc";
+
+static const char *__doc_sgl_SignatureBuffer_add_bytes = R"doc(Shared append primitive used by all public add overloads.)doc";
+
+static const char *__doc_sgl_SignatureBuffer_m_buf = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer_operator_assign = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer_operator_lshift = R"doc()doc";
+
+static const char *__doc_sgl_SignatureBuffer_view = R"doc(Return a non-owning view of the accumulated signature bytes.)doc";
 
 static const char *__doc_sgl_SlangCompileError = R"doc(Exception thrown on compilation errors.)doc";
 
@@ -8335,6 +8435,8 @@ static const char *__doc_sgl_TextureView_texture = R"doc()doc";
 
 static const char *__doc_sgl_TextureView_to_string = R"doc()doc";
 
+static const char *__doc_sgl_TextureView_write_to_cursor = R"doc(Bind a nullable texture view value to a shader cursor.)doc";
+
 static const char *__doc_sgl_Texture_Texture = R"doc()doc";
 
 static const char *__doc_sgl_Texture_Texture_2 = R"doc()doc";
@@ -8427,6 +8529,10 @@ static const char *__doc_sgl_Texture_type = R"doc()doc";
 
 static const char *__doc_sgl_Texture_width = R"doc()doc";
 
+static const char *__doc_sgl_Texture_write_slangpy_signature = R"doc(Write the SlangPy cache signature used by functional dispatch.)doc";
+
+static const char *__doc_sgl_Texture_write_to_cursor = R"doc(Bind a nullable texture value to a shader cursor.)doc";
+
 static const char *__doc_sgl_Timer = R"doc()doc";
 
 static const char *__doc_sgl_Timer_2 = R"doc(High resolution CPU timer.)doc";
@@ -8454,6 +8560,22 @@ static const char *__doc_sgl_Timer_m_start = R"doc()doc";
 static const char *__doc_sgl_Timer_now = R"doc(Current time point in nanoseconds since epoch.)doc";
 
 static const char *__doc_sgl_Timer_reset = R"doc(Reset the timer.)doc";
+
+static const char *__doc_sgl_TimestampCalibration = R"doc()doc";
+
+static const char *__doc_sgl_TimestampCalibration_cpu_domain = R"doc(The domain of the CPU timestamp.)doc";
+
+static const char *__doc_sgl_TimestampCalibration_cpu_frequency = R"doc(The frequency of the CPU timestamp in ticks per second.)doc";
+
+static const char *__doc_sgl_TimestampCalibration_cpu_timestamp = R"doc(The current CPU timestamp.)doc";
+
+static const char *__doc_sgl_TimestampCalibration_gpu_frequency = R"doc(The frequency of the GPU timestamp in ticks per second.)doc";
+
+static const char *__doc_sgl_TimestampCalibration_gpu_timestamp = R"doc(The current GPU timestamp.)doc";
+
+static const char *__doc_sgl_TimestampCalibration_max_deviation_ns =
+R"doc(The maximum deviation between the CPU and GPU timestamps in
+nanoseconds.)doc";
 
 static const char *__doc_sgl_TypeConformance =
 R"doc(Type conformance entry. Type conformances are used to narrow the set
@@ -9512,6 +9634,32 @@ Throws if the stack is empty.
 Returns:
     The current device.)doc";
 
+static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo =
+R"doc(Native registry entry for one cursor-writable value type.
+
+The SlangPy cache signature is required, while the simple
+WriteToCursorMarshall fallback type name is optional. This lets
+resource types provide native signatures and direct cursor writes
+while still using bespoke functional API marshalls.)doc";
+
+static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo_imports =
+R"doc(Static imports copied from T::slangpy_imports() at registration time
+for the simple functional fallback.)doc";
+
+static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo_slang_type_name =
+R"doc(Static Slang type name supplied by T::slang_type_name for the simple
+functional fallback.)doc";
+
+static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo_type = R"doc(Native C++ type exposed through nanobind.)doc";
+
+static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo_write_buffer_cursor = R"doc(Write an object instance into a BufferElementCursor.)doc";
+
+static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo_write_shader_cursor = R"doc(Write an object instance into a ShaderCursor.)doc";
+
+static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo_write_signature =
+R"doc(Writes the cache signature for a concrete value instance when native
+signature metadata is available.)doc";
+
 static const char *__doc_sgl_cursor_utils_check_array = R"doc()doc";
 
 static const char *__doc_sgl_cursor_utils_check_matrix = R"doc()doc";
@@ -9520,11 +9668,38 @@ static const char *__doc_sgl_cursor_utils_check_scalar = R"doc()doc";
 
 static const char *__doc_sgl_cursor_utils_check_vector = R"doc()doc";
 
+static const char *__doc_sgl_cursor_utils_cursor_writer_type_infos = R"doc(Return a read-only view of all registered cursor-writer type entries.)doc";
+
+static const char *__doc_sgl_cursor_utils_find_cursor_writer_type_info =
+R"doc(Find the exact native cursor-writer entry for a std::type_info, if one
+exists.)doc";
+
 static const char *__doc_sgl_cursor_utils_get_scalar_type_cpu_size = R"doc()doc";
+
+static const char *__doc_sgl_cursor_utils_register_cursor_writer =
+R"doc(Register T as a native bindable value for direct cursor writes.
+
+If T also owns static slang_type_name metadata, it is used as a simple
+functional API fallback. Types with bespoke marshalls should omit that
+metadata and keep the Python/native marshall as owner.)doc";
+
+static const char *__doc_sgl_cursor_utils_register_cursor_writer_type =
+R"doc(Add a type entry to the cursor-writer registry. Duplicate
+registrations for the same native type are rejected.)doc";
+
+static const char *__doc_sgl_cursor_utils_register_cursor_writers = R"doc(Register cursor writers for built-in SGL value types.)doc";
 
 static const char *__doc_sgl_cursor_utils_unwrap_array = R"doc()doc";
 
+static const char *__doc_sgl_cursor_utils_write_cursor_writer_signature =
+R"doc(Write the SlangPy cache signature for a registered cursor-writer
+value.)doc";
+
+static const char *__doc_sgl_cursor_utils_write_to_cursor = R"doc()doc";
+
 static const char *__doc_sgl_data_type_size = R"doc(Get the size of a type in bytes.)doc";
+
+static const char *__doc_sgl_detail_CursorWriterOwner = R"doc()doc";
 
 static const char *__doc_sgl_detail_HostTypeToFormat = R"doc()doc";
 
@@ -9600,6 +9775,8 @@ owned by that device is invalidated.)doc";
 
 static const char *__doc_sgl_detail_on_slang_wrapper_destroyed = R"doc()doc";
 
+static const char *__doc_sgl_detail_strip_class_key = R"doc(Remove MSVC's "class " / "struct " prefix from a type name fragment.)doc";
+
 static const char *__doc_sgl_detail_throw_exception = R"doc()doc";
 
 static const char *__doc_sgl_detail_throw_exception_2 = R"doc()doc";
@@ -9610,7 +9787,13 @@ static const char *__doc_sgl_detail_to_rhi_2 = R"doc()doc";
 
 static const char *__doc_sgl_detail_to_rhi_cooperative_vector_component_type = R"doc()doc";
 
+static const char *__doc_sgl_detail_type_name =
+R"doc(Best-effort default signature name used when T provides no explicit
+signature.)doc";
+
 static const char *__doc_sgl_detail_unused = R"doc()doc";
+
+static const char *__doc_sgl_detail_wrapped_type_name = R"doc(Return the compiler-specific spelling that contains T's name.)doc";
 
 static const char *__doc_sgl_div_round_up = R"doc(Divide a by b and round up to the next integer.)doc";
 
@@ -9776,6 +9959,8 @@ static const char *__doc_sgl_find_enum_info_adl_77 = R"doc()doc";
 
 static const char *__doc_sgl_find_enum_info_adl_78 = R"doc()doc";
 
+static const char *__doc_sgl_find_enum_info_adl_79 = R"doc()doc";
+
 static const char *__doc_sgl_flags_to_string_list = R"doc(Convert an flags enum value to a list of strings.)doc";
 
 static const char *__doc_sgl_flip_bit = R"doc()doc";
@@ -9859,6 +10044,142 @@ static const char *__doc_sgl_func_BaseStruct_shape = R"doc(Return the reflected 
 static const char *__doc_sgl_func_BaseStruct_to_string = R"doc(Return a debug string for this struct base.)doc";
 
 static const char *__doc_sgl_func_BaseStruct_type = R"doc(Return the reflected type for this struct.)doc";
+
+static const char *__doc_sgl_func_DiffTensorViewData = R"doc(CPU representation of Slang's DiffTensorView uniform payload.)doc";
+
+static const char *__doc_sgl_func_DiffTensorViewData_diff = R"doc()doc";
+
+static const char *__doc_sgl_func_DiffTensorViewData_primal = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor =
+R"doc(Native tensor runtime object.
+
+This class deliberately contains no language-binding dependency.
+Adapter conveniences such as NumPy/Torch conversion and indexing
+syntax live in the slangpy extension layer.)doc";
+
+static const char *__doc_sgl_func_TensorDesc =
+R"doc(Native Tensor descriptor shared by native code and the extension
+binding layer.)doc";
+
+static const char *__doc_sgl_func_TensorDesc_dtype = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorDesc_element_layout = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorDesc_memory_type = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorDesc_offset = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorDesc_shape = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorDesc_strides = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorDesc_usage = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorViewData = R"doc(CPU representation of Slang's TensorView uniform payload.)doc";
+
+static const char *__doc_sgl_func_TensorViewData_data = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorViewData_dimensionCount = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorViewData_sizes = R"doc()doc";
+
+static const char *__doc_sgl_func_TensorViewData_strides = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_Tensor = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_broadcast_to = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_broadcast_to_inplace = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_class_name = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_clear = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_cursor = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_desc = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_desc_2 = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_detach = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_device = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_dims = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_dtype = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_element_count = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_element_stride = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_grad = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_grad_in = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_grad_out = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_is_contiguous = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_m_desc = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_m_grad_in = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_m_grad_out = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_m_signature = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_m_storage = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_make_tensor_view_data = R"doc(Build the POD payload used by Slang TensorView fields.)doc";
+
+static const char *__doc_sgl_func_Tensor_memory_type = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_offset = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_point_to = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_set_grad_in = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_set_grad_out = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_shape = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_signature = R"doc(Signature fragment used by SlangPy's native call-data cache.)doc";
+
+static const char *__doc_sgl_func_Tensor_storage = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_strides = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_to_string = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_update_signature = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_usage = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_view = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_view_inplace = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_with_grads = R"doc()doc";
+
+static const char *__doc_sgl_func_Tensor_write_slangpy_signature = R"doc(Write the SlangPy cache signature used by functional dispatch.)doc";
+
+static const char *__doc_sgl_func_Tensor_write_to_cursor =
+R"doc(Write a tensor to a shader cursor.
+
+Plain Tensor/WTensor/RWTensor/PrimalTensor targets are handled by
+writing the cursor's tensor fields directly. Differentiable wrapper
+targets write the primal tensor plus any gradient fields that are
+present on the target type.)doc";
+
+static const char *__doc_sgl_func_Tensor_write_to_cursor_2 =
+R"doc(Write a tensor to buffer cursor storage for pointer-backed Tensor
+fields or TensorView payloads.
+
+Resource-backed tensor fields require a ShaderCursor and will throw
+when encountered.)doc";
 
 static const char *__doc_sgl_get_acceleration_structure_sizes =
 R"doc(Query the device for buffer sizes required for acceleration structure
@@ -12348,19 +12669,21 @@ static const char *__doc_sgl_slangpy_Shape_Shape = R"doc()doc";
 
 static const char *__doc_sgl_slangpy_Shape_Shape_2 = R"doc(Constructor from optional 'tuple'.)doc";
 
-static const char *__doc_sgl_slangpy_Shape_Shape_3 =
+static const char *__doc_sgl_slangpy_Shape_Shape_3 = R"doc(Constructor from a vector of dimensions.)doc";
+
+static const char *__doc_sgl_slangpy_Shape_Shape_4 =
 R"doc(Constructor that creates a Shape of a given size with uninitialized
 values Use this when you need to populate the shape manually)doc";
 
-static const char *__doc_sgl_slangpy_Shape_Shape_4 =
+static const char *__doc_sgl_slangpy_Shape_Shape_5 =
 R"doc(Constructor that creates a Shape of a given size with all elements set
 to a value)doc";
 
-static const char *__doc_sgl_slangpy_Shape_Shape_5 = R"doc(Constructor from initializer list)doc";
+static const char *__doc_sgl_slangpy_Shape_Shape_6 = R"doc(Constructor from initializer list)doc";
 
-static const char *__doc_sgl_slangpy_Shape_Shape_6 = R"doc(Copy constructor.)doc";
+static const char *__doc_sgl_slangpy_Shape_Shape_7 = R"doc(Copy constructor.)doc";
 
-static const char *__doc_sgl_slangpy_Shape_Shape_7 = R"doc(Move constructor.)doc";
+static const char *__doc_sgl_slangpy_Shape_Shape_8 = R"doc(Move constructor.)doc";
 
 static const char *__doc_sgl_slangpy_Shape_Storage = R"doc()doc";
 


### PR DESCRIPTION
- Update `slang-rhi` for timestamp calibration and query refactor support.
- Add CPU/GPU timestamp calibration APIs and Python bindings.
- Extend `QueryPool` with range reset and result readiness checks, with safer range validation.
- Remove obsolete acceleration structure serialization APIs and refresh generated docs.