### PR TITLE
Add error handling when reusing a finished command encoder

### DIFF
--- a/slangpy/tests/slangpy_tests/test_command_buffer.py
+++ b/slangpy/tests/slangpy_tests/test_command_buffer.py
@@ -163,5 +163,25 @@ def test_command_buffer(device_type: DeviceType, use_arg: bool):
     polynomial(a, b, _result=res, _append_to=None)
 
 
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_reuse_finished_command_encoder(device_type: DeviceType):
+    m = load_test_module(device_type)
+    assert m is not None
+
+    polynomial = m.polynomial.as_func()
+
+    a = Tensor.empty(m.device, (10,), dtype=float3)
+    b = Tensor.empty(m.device, (10,), dtype=float3)
+    res = Tensor.empty(m.device, (10,), dtype=float3)
+
+    command_encoder = m.device.create_command_encoder()
+    polynomial.append_to(command_encoder, a, b, _result=res)
+    m.device.submit_command_buffer(command_encoder.finish())
+
+    # Reusing a finished command encoder must raise a clean error rather than crash.
+    with pytest.raises(Exception, match="Command encoder is finished"):
+        polynomial.append_to(command_encoder, a, b, _result=res)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/src/sgl/device/command.cpp
+++ b/src/sgl/device/command.cpp
@@ -317,6 +317,8 @@ CommandEncoder::~CommandEncoder()
 
 ref<RenderPassEncoder> CommandEncoder::begin_render_pass(const RenderPassDesc& desc)
 {
+    SGL_CHECK(m_open, "Command encoder is finished");
+
     rhi::RenderPassDesc rhi_desc = {};
 
     short_vector<rhi::RenderPassColorAttachment, 16> rhi_color_attachments;
@@ -361,6 +363,8 @@ ref<RenderPassEncoder> CommandEncoder::begin_render_pass(const RenderPassDesc& d
 
 ref<ComputePassEncoder> CommandEncoder::begin_compute_pass()
 {
+    SGL_CHECK(m_open, "Command encoder is finished");
+
     if (!m_compute_pass_encoder) {
         m_compute_pass_encoder = make_ref<ComputePassEncoder>();
     }
@@ -373,6 +377,8 @@ ref<ComputePassEncoder> CommandEncoder::begin_compute_pass()
 
 ref<RayTracingPassEncoder> CommandEncoder::begin_ray_tracing_pass()
 {
+    SGL_CHECK(m_open, "Command encoder is finished");
+
     if (!m_ray_tracing_pass_encoder) {
         m_ray_tracing_pass_encoder = make_ref<RayTracingPassEncoder>();
     }


### PR DESCRIPTION
## Summary
- `CommandEncoder::begin_render_pass`, `begin_compute_pass` and `begin_ray_tracing_pass` dereferenced the underlying rhi command encoder without checking that the encoder was still open. Reusing a finished/closed encoder crashed with an opaque native backtrace (see #246) instead of a clean error.
- Added the same `SGL_CHECK(m_open, "Command encoder is finished")` guard that every other `CommandEncoder` method already uses.
- Added a regression test that finishes an encoder and asserts that reusing it raises a clean error.

Fixes #253

## Test plan
- [ ] CI: `pytest slangpy/tests/slangpy_tests/test_command_buffer.py::test_reuse_finished_command_encoder`