### PR TITLE
Update QueryPool interface

### DIFF
--- a/src/sgl/device/query.cpp
+++ b/src/sgl/device/query.cpp
@@ -32,19 +32,24 @@ void QueryPool::reset(uint32_t index, uint32_t count)
     SLANG_RHI_CALL(m_rhi_query_pool->reset(index, count), m_device);
 }
 
+QueryResultState QueryPool::get_result_state(uint32_t index, uint32_t count)
+{
+    SGL_CHECK(uint64_t(index) + count <= m_desc.count, "'index' / 'count' out of range");
+    rhi::QueryResultState rhi_state;
+    SLANG_RHI_CALL(m_rhi_query_pool->getResultState(index, count, &rhi_state), m_device);
+    return static_cast<QueryResultState>(rhi_state);
+}
+
+QueryResultState QueryPool::get_result_state(uint32_t index)
+{
+    return get_result_state(index, 1);
+}
+
 void QueryPool::get_results(uint32_t index, uint32_t count, std::span<uint64_t> result)
 {
     SGL_CHECK(uint64_t(index) + count <= m_desc.count, "'index' / 'count' out of range");
     SGL_CHECK(result.size() >= count, "'result' buffer too small");
     SLANG_RHI_CALL(m_rhi_query_pool->getResult(index, count, result.data()), m_device);
-}
-
-bool QueryPool::is_result_ready(uint32_t index, uint32_t count)
-{
-    SGL_CHECK(uint64_t(index) + count <= m_desc.count, "'index' / 'count' out of range");
-    bool ready;
-    SLANG_RHI_CALL(m_rhi_query_pool->isResultReady(index, count, &ready), m_device);
-    return ready;
 }
 
 std::vector<uint64_t> QueryPool::get_results(uint32_t index, uint32_t count)

--- a/src/sgl/device/query.h
+++ b/src/sgl/device/query.h
@@ -35,7 +35,8 @@ public:
     void reset();
     void reset(uint32_t index, uint32_t count);
 
-    bool is_result_ready(uint32_t index, uint32_t count);
+    QueryResultState get_result_state(uint32_t index, uint32_t count);
+    QueryResultState get_result_state(uint32_t index);
 
     void get_results(uint32_t index, uint32_t count, std::span<uint64_t> result);
     std::vector<uint64_t> get_results(uint32_t index, uint32_t count);

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -797,6 +797,22 @@ SGL_ENUM_INFO(
 );
 SGL_ENUM_REGISTER(QueryType);
 
+enum class QueryResultState : uint32_t {
+    reset = static_cast<uint32_t>(rhi::QueryResultState::Reset),
+    pending = static_cast<uint32_t>(rhi::QueryResultState::Pending),
+    resolved = static_cast<uint32_t>(rhi::QueryResultState::Resolved),
+};
+
+SGL_ENUM_INFO(
+    QueryResultState,
+    {
+        {QueryResultState::reset, "reset"},
+        {QueryResultState::pending, "pending"},
+        {QueryResultState::resolved, "resolved"},
+    }
+);
+SGL_ENUM_REGISTER(QueryResultState);
+
 enum class CpuTimestampDomain : uint32_t {
     unknown = static_cast<uint32_t>(rhi::CpuTimestampDomain::Unknown),
     query_performance_counter = static_cast<uint32_t>(rhi::CpuTimestampDomain::QueryPerformanceCounter),

--- a/src/slangpy_ext/device/query.cpp
+++ b/src/slangpy_ext/device/query.cpp
@@ -38,7 +38,19 @@ SGL_PY_EXPORT(device_query)
             "count"_a,
             D(QueryPool, reset, 2)
         )
-        .def("is_result_ready", &QueryPool::is_result_ready, "index"_a, "count"_a, D(QueryPool, is_result_ready))
+        .def(
+            "get_result_state",
+            nb::overload_cast<uint32_t, uint32_t>(&QueryPool::get_result_state),
+            "index"_a,
+            "count"_a,
+            D(QueryPool, get_result_state)
+        )
+        .def(
+            "get_result_state",
+            nb::overload_cast<uint32_t>(&QueryPool::get_result_state),
+            "index"_a,
+            D(QueryPool, get_result_state, 2)
+        )
         .def("get_result", &QueryPool::get_result, "index"_a, D(QueryPool, get_result))
         .def(
             "get_results",

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -6501,6 +6501,10 @@ static const char *__doc_sgl_QueryPool_desc = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_get_result = R"doc()doc";
 
+static const char *__doc_sgl_QueryPool_get_result_state = R"doc()doc";
+
+static const char *__doc_sgl_QueryPool_get_result_state_2 = R"doc()doc";
+
 static const char *__doc_sgl_QueryPool_get_results = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_get_results_2 = R"doc()doc";
@@ -6510,8 +6514,6 @@ static const char *__doc_sgl_QueryPool_get_timestamp_result = R"doc()doc";
 static const char *__doc_sgl_QueryPool_get_timestamp_results = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_get_timestamp_results_2 = R"doc()doc";
-
-static const char *__doc_sgl_QueryPool_is_result_ready = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_m_desc = R"doc()doc";
 
@@ -6526,6 +6528,16 @@ static const char *__doc_sgl_QueryPool_reset_2 = R"doc()doc";
 static const char *__doc_sgl_QueryPool_rhi_query_pool = R"doc()doc";
 
 static const char *__doc_sgl_QueryPool_to_string = R"doc()doc";
+
+static const char *__doc_sgl_QueryResultState = R"doc()doc";
+
+static const char *__doc_sgl_QueryResultState_info = R"doc()doc";
+
+static const char *__doc_sgl_QueryResultState_pending = R"doc()doc";
+
+static const char *__doc_sgl_QueryResultState_reset = R"doc()doc";
+
+static const char *__doc_sgl_QueryResultState_resolved = R"doc()doc";
 
 static const char *__doc_sgl_QueryType = R"doc()doc";
 
@@ -10058,6 +10070,8 @@ static const char *__doc_sgl_find_enum_info_adl_77 = R"doc()doc";
 static const char *__doc_sgl_find_enum_info_adl_78 = R"doc()doc";
 
 static const char *__doc_sgl_find_enum_info_adl_79 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_80 = R"doc()doc";
 
 static const char *__doc_sgl_flags_to_string_list = R"doc(Convert an flags enum value to a list of strings.)doc";
 


### PR DESCRIPTION
- Update to latest `slang-rhi`
- Update `QueryPool` interface to new API (replace `is_result_ready` with `get_result_state`)