### PR TITLE
Route CUDA kernels with runtime-indexed resource-array params through ParameterBlock

### DIFF
--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from slangpy.core.callsignature import *
 from slangpy.core.logging import bound_call_table, bound_exception_info, mismatch_info
@@ -34,6 +34,12 @@ from slangpy.bindings import (
 from slangpy.bindings.boundvariable import BoundCall, BoundVariable
 from slangpy.bindings.boundvariableruntime import BoundVariableRuntime
 from slangpy.reflection import SlangFunction, ITensorType, TensorAccess
+from slangpy.reflection.reflectiontypes import (
+    ArrayType,
+    ResourceType,
+    SlangType,
+    StructType,
+)
 
 if TYPE_CHECKING:
     from slangpy.core.function import FunctionNode, FunctionBuildInfo
@@ -68,6 +74,47 @@ _OPTIX_BUILTIN_INTERSECTION_SHADERS = frozenset(
 
 # Track if we've already warned about torch bridge fallback
 _torch_bridge_warned = False
+
+
+def _slang_type_is_or_contains_resource(t: Optional[SlangType], visited: set[int]) -> bool:
+    if t is None or id(t) in visited:
+        return False
+    visited.add(id(t))
+    if isinstance(t, (ResourceType, ITensorType)):
+        return True
+    if isinstance(t, StructType):
+        for f in t.fields.values():
+            if _slang_type_is_or_contains_resource(f.type, visited):
+                return True
+    if isinstance(t, ArrayType):
+        return _slang_type_is_or_contains_resource(t.element_type, visited)
+    return False
+
+
+def _slang_type_contains_resource_array(t: Optional[SlangType], visited: set[int]) -> bool:
+    if t is None or id(t) in visited:
+        return False
+    visited.add(id(t))
+    if isinstance(t, ArrayType):
+        if t.num_elements > 0 and _slang_type_is_or_contains_resource(t.element_type, set()):
+            return True
+        if _slang_type_contains_resource_array(t.element_type, visited):
+            return True
+    if isinstance(t, StructType):
+        for f in t.fields.values():
+            if _slang_type_contains_resource_array(f.type, visited):
+                return True
+    return False
+
+
+def _bindings_contain_resource_array(bindings: BoundCall) -> bool:
+    visited: set[int] = set()
+    # vector_type is the resolved Slang parameter type after vectorization;
+    # slang_type is cleared by _apply_implicit_vectorization, so check vector_type instead.
+    for b in bindings.values():
+        if _slang_type_contains_resource_array(b.vector_type, visited):
+            return True
+    return False
 
 
 def set_dump_generated_shaders(value: bool):
@@ -309,6 +356,28 @@ class CallData(NativeCallData):
             # Disable for Metal until I can figure out how entry point args work properly
             if build_info.module.device.info.type == DeviceType.metal:
                 use_entrypoint_args = False
+
+            # On CUDA, dynamic-address reads from .param memory (where entry-point
+            # uniforms live) produce a serial dependency chain in the generated PTX
+            # whenever the kernel indexes a fixed-size array of resources at a
+            # runtime-computed index. The same kernel routed through
+            # ParameterBlock<CallData> avoids the chain because Slang's CUDA backend
+            # lowers ParameterBlock<T> via __constant__ + global memory, and the
+            # resulting ld.global.nc reads do not serialize.
+            #
+            # This is a SHAPE heuristic: it detects the data layout that enables the
+            # pathological lowering, not whether the kernel actually performs runtime
+            # indexing. Static-indexed resource arrays pay a small one-time PB upload
+            # cost (~5us) but are not miscompiled.
+            if (
+                use_entrypoint_args
+                and build_info.module.device.info.type == DeviceType.cuda
+                and _bindings_contain_resource_array(bindings)
+            ):
+                use_entrypoint_args = False
+                self.log_debug(
+                    "  CUDA resource-array heuristic fired -> forcing ParameterBlock<CallData>"
+                )
 
             # Try building the shader. If direct args compilation fails (the
             # threshold is only an approximate heuristic), fall back to

--- a/slangpy/tests/slangpy_tests/test_code_gen.py
+++ b/slangpy/tests/slangpy_tests/test_code_gen.py
@@ -1468,7 +1468,8 @@ float sum_first<let N : int>(uint2 tid, RWTensor<float,2> tensors[N], uint i)
         # No CUDA-specific override on these targets, so behavior is purely
         # threshold-driven. Don't pin a specific value here, just assert the
         # call data built without errors.
-        assert cd is not None and threshold > 0
+        assert cd is not None
+        assert threshold > 0
 
 
 # 46c -----------------------------------------------------------------------

--- a/slangpy/tests/slangpy_tests/test_code_gen.py
+++ b/slangpy/tests/slangpy_tests/test_code_gen.py
@@ -1438,6 +1438,108 @@ def test_tensor_uses_entrypoint_args(device_type: spy.DeviceType):
     assert cd.use_entrypoint_args is True
 
 
+# 46b -----------------------------------------------------------------------
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_resource_array_forces_parameter_block_on_cuda(device_type: spy.DeviceType):
+    """A kernel param that is a fixed-size array of resources triggers the
+    ParameterBlock fallback on CUDA, even if its inline-uniform size is below
+    the EPA threshold. Other backends are unaffected by the heuristic.
+    """
+    if device_type == spy.DeviceType.metal:
+        pytest.skip("Metal doesn't support entry point params.")
+    device = helpers.get_device(device_type)
+    src = """
+float sum_first<let N : int>(uint2 tid, RWTensor<float,2> tensors[N], uint i)
+{
+    return tensors[i].load(tid);
+}
+"""
+    tensors = [Tensor.from_numpy(device, np.zeros((4, 4), dtype=np.float32)) for _ in range(4)]
+    out = Tensor.empty(device, shape=(4, 4), dtype=float)
+    func = helpers.create_function_from_module(device, "sum_first<4>", src)
+    cd = func.debug_build_call_data(tid=spy.call_id(), tensors=tensors, i=0, _result=out)
+    if device_type == spy.DeviceType.cuda:
+        # Heuristic fires: array of resources in binding -> PB.
+        assert cd.use_entrypoint_args is False
+    else:
+        # Other backends keep size-based selection (Vulkan small threshold may
+        # still force PB; D3D12 typically keeps EPA at this size).
+        threshold = device.info.limits.max_entry_point_uniform_size
+        # No CUDA-specific override on these targets, so behavior is purely
+        # threshold-driven. Don't pin a specific value here, just assert the
+        # call data built without errors.
+        assert cd is not None and threshold > 0
+
+
+# 46c -----------------------------------------------------------------------
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_nested_resource_array_forces_parameter_block_on_cuda(device_type: spy.DeviceType):
+    """A struct kernel param containing a fixed-size array of resources also
+    triggers the heuristic (the actual benchmark shape: TensorList<N>)."""
+    if device_type == spy.DeviceType.metal:
+        pytest.skip("Metal doesn't support entry point params.")
+    device = helpers.get_device(device_type)
+    src = """
+struct TList<let N : int>
+{
+    RWTensor<float,2> tensors[N];
+}
+float sum_first<let N : int>(uint2 tid, TList<N> list, uint i)
+{
+    return list.tensors[i].load(tid);
+}
+"""
+    tensors = [Tensor.from_numpy(device, np.zeros((4, 4), dtype=np.float32)) for _ in range(4)]
+    out = Tensor.empty(device, shape=(4, 4), dtype=float)
+    func = helpers.create_function_from_module(device, "sum_first<4>", src)
+    cd = func.debug_build_call_data(tid=spy.call_id(), list={"tensors": tensors}, i=0, _result=out)
+    if device_type == spy.DeviceType.cuda:
+        assert cd.use_entrypoint_args is False
+
+
+# 46d -----------------------------------------------------------------------
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_non_resource_array_keeps_entrypoint_args_on_cuda(device_type: spy.DeviceType):
+    """A fixed-size array of non-resource scalars must NOT trigger the
+    resource-array heuristic. Indices/value arrays should keep EPA on CUDA."""
+    if device_type == spy.DeviceType.metal:
+        pytest.skip("Metal doesn't support entry point params.")
+    device = helpers.get_device(device_type)
+    src = """
+float sum_uints<let N : int>(uint values[N])
+{
+    float r = 0;
+    for (int i = 0; i < N; i++) r += float(values[i]);
+    return r;
+}
+"""
+    func = helpers.create_function_from_module(device, "sum_uints<4>", src)
+    cd = func.debug_build_call_data(values=[1, 2, 3, 4])
+    if device_type == spy.DeviceType.cuda:
+        # Non-resource array: heuristic must not fire. Other constraints (size
+        # threshold) keep this small payload on EPA.
+        assert cd.use_entrypoint_args is True
+
+
+# 46e -----------------------------------------------------------------------
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_single_resource_keeps_entrypoint_args_on_cuda(device_type: spy.DeviceType):
+    """A single resource (not in an array) must NOT trigger the heuristic."""
+    if device_type == spy.DeviceType.metal:
+        pytest.skip("Metal doesn't support entry point params.")
+    device = helpers.get_device(device_type)
+    src = """
+float read_one(uint2 tid, RWTensor<float,2> t) { return t.load(tid); }
+"""
+    t = Tensor.from_numpy(device, np.zeros((4, 4), dtype=np.float32))
+    out = Tensor.empty(device, shape=(4, 4), dtype=float)
+    func = helpers.create_function_from_module(device, "read_one", src)
+    cd = func.debug_build_call_data(tid=spy.call_id(), t=t, _result=out)
+    if device_type == spy.DeviceType.cuda:
+        # No array of resources -> heuristic must not fire -> EPA preserved.
+        assert cd.use_entrypoint_args is True
+
+
 # ===========================================================================
 # Additional functional dispatch tests (47-49)
 # ===========================================================================


### PR DESCRIPTION
## Summary

On CUDA the functional API picks entry-point args (EPA) vs `ParameterBlock<CallData>` (PB) by inline-uniform size against the device `max_entry_point_uniform_size` (CUDA: 4096B), so on CUDA almost everything takes EPA. For a fixed-size resource/tensor array indexed at **runtime**, EPA packs it into the `.param` bank and the runtime index becomes a serial dynamic-address `ld.param` chain — 12–24× slower than the PB lowering (`__constant__` pointer + cached global).

This adds a targeted heuristic: when a binding's resolved type transitively contains a fixed-size array of resources/tensors, force `use_entrypoint_args=False` on CUDA.

## Measurements (NVIDIA L40S, `test_tensor_sum_indirect`, median ms)

| count | baseline | this PR | speedup |
|---|---:|---:|---|
| 16 | 0.744 | 0.031 | 24× |
| 32 | 2.585 | 0.199 | 13× |

Direct (compile-time-indexed) `test_tensor_sum` unaffected; `test_tensor_add_simple` unchanged. Tiny direct `sum<N>` regress ~5–9µs absolute (the heuristic keys on array *shape*, an accepted trade).

## Test plan
- [ ] New regression test `test_resource_array_forces_parameter_block_on_cuda` (`slangpy/tests/slangpy_tests/test_code_gen.py`)
- [ ] CI green

A principled compiler-side fix (a Slang auto-hoist pass + a slang-rhi binding change) is in progress upstream to cover user-written kernels too; this host heuristic is the immediate SlangPy win.

<sub>🤖 Generated by an automated SlangPy coworker — may be inaccurate. A human maintainer should verify.</sub>