### PR TITLE
[DNI - DO NOT INTEGRATE] ci-benchmark: build against CUDA resource-array fix (slang#11747 + slang-rhi#779)

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -77,14 +77,16 @@ jobs:
       - name: Setup CMake/Ninja
         uses: lukka/get-cmake@latest
 
-      # Build latest Slang.
-      # - name: Build latest Slang
-      #   run: |
-      #     git clone --recursive https://github.com/shader-slang/slang.git
-      #     cd slang
-      #     mkdir build
-      #     cmake -B build --preset default
-      #     cmake --build build --config ${{ matrix.config }} --parallel
+      # DNI (do-not-integrate): build Slang from the F PR branch (shader-slang/slang#11747)
+      # so the benchmark exercises the runtime-indexed resource-array __constant__ hoist.
+      # Paired with external/slang-rhi bumped to the dispatch-routing PR (shader-slang/slang-rhi#779).
+      - name: Build Slang (F PR shader-slang/slang#11747 — DNI)
+        run: |
+          git clone --recursive -b haaggarwal/fix-cuda-resource-array https://github.com/shader-slang/slang.git
+          cd slang
+          mkdir build
+          cmake -B build --preset default
+          cmake --build build --config ${{ matrix.config }} --parallel
 
       # Setup.
       - name: Setup
@@ -106,9 +108,10 @@ jobs:
           key: vcpkg-cache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json', 'external/vcpkg-triplets/**') }}
 
       # Configure.
+      # DNI (do-not-integrate): point SlangPy at the locally-built F PR Slang
+      # (shader-slang/slang#11747) so the benchmark exercises the hoist.
       - name: Configure
-        # run: python tools/ci.py --cmake-args="-DSGL_LOCAL_SLANG=ON -DSGL_LOCAL_SLANG_DIR=slang -DSGL_LOCAL_SLANG_BUILD_DIR=build/${{ matrix.config }}" configure
-        run: python tools/ci.py configure
+        run: python tools/ci.py --cmake-args="-DSGL_LOCAL_SLANG=ON -DSGL_LOCAL_SLANG_DIR=slang -DSGL_LOCAL_SLANG_BUILD_DIR=build/${{ matrix.config }}" configure
 
       # Build.
       - name: Build


### PR DESCRIPTION
## ⚠️ DO NOT INTEGRATE (DNI)

Temporary, throwaway branch to run the scheduled CUDA benchmark against the **principled fix** for the runtime-indexed resource-array perf bug (`tensors[indices[i]]` compiling to serial `ld.param` chains, ~12–24× slower on CUDA than Vulkan). The goal is real CUDA-vs-Vulkan numbers on the `nvrgfx` perf runners **before** the upstream PRs merge. Not meant to land — close after the benchmark run.

## What it does

- **`.github/workflows/ci-benchmark.yml`** — clones + builds Slang from the F PR branch `haaggarwal/fix-cuda-resource-array` (the IR pass that hoists runtime-indexed resource-array compute entry-point uniforms into a module-scope `__constant__` `ConstantBuffer<GlobalParams>` on CUDA), then configures SlangPy with `-DSGL_LOCAL_SLANG=ON -DSGL_LOCAL_SLANG_DIR=slang -DSGL_LOCAL_SLANG_BUILD_DIR=build/<config>` to build against it.
- **`external/slang-rhi`** submodule bump `d755100 → 1f910dc` — the reflection-preserving CUDA dispatch routing the F pass depends on (binds the entry-point uniform blob into `SLANG_globalParams` when the hoist makes the params invisible to reflection).

## Linked PRs (the actual fix — these are what should land)

- shader-slang/slang#11747 — Slang IR pass (approach F)
- shader-slang/slang-rhi#779 — slang-rhi dispatch routing

## How to run

Trigger via **workflow_dispatch**: Actions → `ci-benchmark` → Run workflow → branch `haaggarwal/ci-benchmark-cuda-resource-array-dni`.

<sub>🤖 Generated by an automated SlangPy coworker — may be inaccurate. A human maintainer should verify.</sub>
