### PR TITLE
[codex] Fix benchmark CI failure handling

### DIFF
--- a/slangpy/benchmarks/test_benchmark_argcounts.py
+++ b/slangpy/benchmarks/test_benchmark_argcounts.py
@@ -41,6 +41,11 @@ RUN_NATIVE_TENSOR_BENCHMARK = True
 # WARMUPS = 1
 
 
+def skip_if_no_native_torch_bridge() -> None:
+    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
+        pytest.skip("slangpy-torch native bridge is not installed")
+
+
 @pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("count", COUNTS)
 def test_tensor_sum_torch(
@@ -50,6 +55,7 @@ def test_tensor_sum_torch(
         pytest.skip("Torch tensor benchmark is not enabled")
     if not HAS_TORCH:
         pytest.skip("PyTorch is not installed")
+    skip_if_no_native_torch_bridge()
 
     device = helpers.get_torch_device(device_type)
     inputs = [np.random.rand(1, 32).astype(np.float32) for _ in range(count)]

--- a/slangpy/benchmarks/test_benchmark_argcounts.py
+++ b/slangpy/benchmarks/test_benchmark_argcounts.py
@@ -41,11 +41,6 @@ RUN_NATIVE_TENSOR_BENCHMARK = True
 # WARMUPS = 1
 
 
-def skip_if_no_native_torch_bridge() -> None:
-    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
-        pytest.skip("slangpy-torch native bridge is not installed")
-
-
 @pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("count", COUNTS)
 def test_tensor_sum_torch(
@@ -55,7 +50,6 @@ def test_tensor_sum_torch(
         pytest.skip("Torch tensor benchmark is not enabled")
     if not HAS_TORCH:
         pytest.skip("PyTorch is not installed")
-    skip_if_no_native_torch_bridge()
 
     device = helpers.get_torch_device(device_type)
     inputs = [np.random.rand(1, 32).astype(np.float32) for _ in range(count)]

--- a/slangpy/benchmarks/test_benchmark_autograd.py
+++ b/slangpy/benchmarks/test_benchmark_autograd.py
@@ -55,6 +55,11 @@ RUN_SLANGPY_AUTOMATIC_BENCHMARK = True
 AUTOGRAD_TENSOR_SIZE = 32
 
 
+def skip_if_no_native_torch_bridge() -> None:
+    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
+        pytest.skip("slangpy-torch native bridge is not installed")
+
+
 @pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 def test_autograd_pure_torch(
     device_type: spy.DeviceType, benchmark_python_function: BenchmarkPythonFunction
@@ -162,6 +167,7 @@ def test_autograd_slangpy_manual_hook(
         pytest.skip("SlangPy manual hook benchmark is not enabled")
     if not HAS_TORCH:
         pytest.skip("PyTorch is not installed")
+    skip_if_no_native_torch_bridge()
 
     device = helpers.get_torch_device(device_type)
     module = spy.Module(device.load_module("test_benchmark_autograd.slang"))
@@ -224,6 +230,7 @@ def test_autograd_slangpy_automatic(
         pytest.skip("SlangPy automatic benchmark is not enabled")
     if not HAS_TORCH:
         pytest.skip("PyTorch is not installed")
+    skip_if_no_native_torch_bridge()
 
     device = helpers.get_torch_device(device_type)
     module = spy.Module(device.load_module("test_benchmark_autograd.slang"))

--- a/slangpy/benchmarks/test_benchmark_autograd.py
+++ b/slangpy/benchmarks/test_benchmark_autograd.py
@@ -55,11 +55,6 @@ RUN_SLANGPY_AUTOMATIC_BENCHMARK = True
 AUTOGRAD_TENSOR_SIZE = 32
 
 
-def skip_if_no_native_torch_bridge() -> None:
-    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
-        pytest.skip("slangpy-torch native bridge is not installed")
-
-
 @pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 def test_autograd_pure_torch(
     device_type: spy.DeviceType, benchmark_python_function: BenchmarkPythonFunction
@@ -167,7 +162,6 @@ def test_autograd_slangpy_manual_hook(
         pytest.skip("SlangPy manual hook benchmark is not enabled")
     if not HAS_TORCH:
         pytest.skip("PyTorch is not installed")
-    skip_if_no_native_torch_bridge()
 
     device = helpers.get_torch_device(device_type)
     module = spy.Module(device.load_module("test_benchmark_autograd.slang"))
@@ -189,7 +183,7 @@ def test_autograd_slangpy_manual_hook(
             x = x.detach()
             result = torch.empty_like(x)
             poly_func(a, b, c, x, _result=result)
-            ctx.save_for_backward(x)
+            ctx.save_for_backward(x, result)
             ctx.a = a
             ctx.b = b
             ctx.c = c
@@ -199,10 +193,10 @@ def test_autograd_slangpy_manual_hook(
         def backward(
             ctx: Any, grad_output: torch.Tensor
         ) -> tuple[None, None, None, Optional[torch.Tensor]]:
-            (x,) = ctx.saved_tensors
+            x, result = ctx.saved_tensors
             grad_x = torch.zeros_like(x)
             x_pair = NativeTorchTensorDiffPair(x, grad_x, 0, True)
-            result_pair = NativeTorchTensorDiffPair(None, grad_output, 1, False)
+            result_pair = NativeTorchTensorDiffPair(result, grad_output, 1, False)
             poly_func.bwds(ctx.a, ctx.b, ctx.c, x_pair, _result=result_pair)
             return None, None, None, grad_x
 
@@ -230,7 +224,6 @@ def test_autograd_slangpy_automatic(
         pytest.skip("SlangPy automatic benchmark is not enabled")
     if not HAS_TORCH:
         pytest.skip("PyTorch is not installed")
-    skip_if_no_native_torch_bridge()
 
     device = helpers.get_torch_device(device_type)
     module = spy.Module(device.load_module("test_benchmark_autograd.slang"))

--- a/slangpy/benchmarks/test_benchmark_bwd_diff.py
+++ b/slangpy/benchmarks/test_benchmark_bwd_diff.py
@@ -44,7 +44,7 @@ TENSOR_SIZES = [65536, 1048576, 4194304]
 CORRECTNESS_N = 64
 
 BENCH_DIR = os.path.dirname(os.path.abspath(__file__))
-EXTENSIONS_DIR = os.path.join(os.path.dirname(BENCH_DIR), "..").replace("\\", "/")
+EXTENSIONS_DIR = os.path.join(BENCH_DIR, "ppisp").replace("\\", "/")
 
 W_VAL = 2.0
 

--- a/slangpy/benchmarks/test_benchmark_bwd_diff.py
+++ b/slangpy/benchmarks/test_benchmark_bwd_diff.py
@@ -52,11 +52,6 @@ W_VAL = 2.0
 _module_cache: dict[int, spy.Module] = {}
 
 
-def _skip_if_no_native_torch_bridge() -> None:
-    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
-        pytest.skip("slangpy-torch native bridge is not installed")
-
-
 def _load_module(device: spy.Device) -> spy.Module:
     """Load the benchmark slang module with extensions.slang on the include path."""
     key = id(device)
@@ -238,7 +233,6 @@ def test_bwd_dtv_load(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Uniform backward using DiffTensorView load() - atomic contention."""
-    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("broadcast_dtv")
@@ -255,7 +249,6 @@ def test_bwd_dtv_load_uniform(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Uniform backward using DiffTensorView loadUniform() - wave reduction."""
-    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("broadcast_dtv_uniform")
@@ -309,7 +302,6 @@ def test_bwd_perelement_load(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Per-element backward using DiffTensorView load/store (atomic)."""
-    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("square_dtv")
@@ -326,7 +318,6 @@ def test_bwd_perelement_load_once(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Per-element backward using DiffTensorView loadOnce/storeOnce (no atomics)."""
-    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("square_dtv_once")

--- a/slangpy/benchmarks/test_benchmark_bwd_diff.py
+++ b/slangpy/benchmarks/test_benchmark_bwd_diff.py
@@ -52,6 +52,11 @@ W_VAL = 2.0
 _module_cache: dict[int, spy.Module] = {}
 
 
+def _skip_if_no_native_torch_bridge() -> None:
+    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
+        pytest.skip("slangpy-torch native bridge is not installed")
+
+
 def _load_module(device: spy.Device) -> spy.Module:
     """Load the benchmark slang module with extensions.slang on the include path."""
     key = id(device)
@@ -233,6 +238,7 @@ def test_bwd_dtv_load(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Uniform backward using DiffTensorView load() - atomic contention."""
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("broadcast_dtv")
@@ -249,6 +255,7 @@ def test_bwd_dtv_load_uniform(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Uniform backward using DiffTensorView loadUniform() - wave reduction."""
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("broadcast_dtv_uniform")
@@ -302,6 +309,7 @@ def test_bwd_perelement_load(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Per-element backward using DiffTensorView load/store (atomic)."""
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("square_dtv")
@@ -318,6 +326,7 @@ def test_bwd_perelement_load_once(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """Per-element backward using DiffTensorView loadOnce/storeOnce (no atomics)."""
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     module = _load_module(device)
     func = module.require_function("square_dtv_once")

--- a/slangpy/benchmarks/test_benchmark_ppisp.py
+++ b/slangpy/benchmarks/test_benchmark_ppisp.py
@@ -842,8 +842,25 @@ def test_ppisp_gpu_backward_slangpy(
     rgb_pair = NativeTorchTensorDiffPair(rgb, torch.zeros_like(rgb), 4, True)
 
     # Upstream gradient (ones)
+    result = torch.empty(batch_size, 3, device=torch_device)
+    func(
+        batch_size=batch_size,
+        num_cameras=NUM_CAMERAS,
+        num_frames=NUM_FRAMES,
+        exposure_params=exposure_params,
+        vignetting_params=vignetting_params,
+        color_params=color_params,
+        crf_params=crf_params,
+        rgb_pixel=rgb,
+        pixel_coord=pixel_coords,
+        camera_idx=camera_idcs,
+        frame_idx=frame_idcs,
+        resolution_w=float(RESOLUTION_W),
+        resolution_h=float(RESOLUTION_H),
+        _result=result,
+    )
     result_grad = torch.ones(batch_size, 3, device=torch_device)
-    result_pair = NativeTorchTensorDiffPair(None, result_grad, 5, False)
+    result_pair = NativeTorchTensorDiffPair(result, result_grad, 5, False)
 
     benchmark_slang_function(
         device,

--- a/slangpy/benchmarks/test_benchmark_ppisp.py
+++ b/slangpy/benchmarks/test_benchmark_ppisp.py
@@ -55,6 +55,12 @@ def _skip_if_no_slangtorch() -> None:
         pytest.skip("slangtorch is not installed")
 
 
+def _skip_if_no_native_torch_bridge() -> None:
+    _skip_if_no_torch()
+    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
+        pytest.skip("slangpy-torch native bridge is not installed")
+
+
 def create_test_data(
     batch_size: int,
     num_cameras: int,
@@ -295,7 +301,7 @@ def test_ppisp_forward_slangpy(
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
-    _skip_if_no_torch()
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -413,7 +419,7 @@ def test_ppisp_backward_slangpy(
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
-    _skip_if_no_torch()
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -499,7 +505,7 @@ def test_ppisp_backward_slangpy_manual_hook(
     Bypasses SlangPy's automatic TorchAutoGradHook to measure the overhead of
     the automatic autograd integration vs doing it manually.
     """
-    _skip_if_no_torch()
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -641,7 +647,7 @@ def test_ppisp_cpu_overhead_slangpy(
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     """Measure SlangPy CPU dispatch overhead for PPISP (forward + backward)."""
-    _skip_if_no_torch()
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -743,7 +749,7 @@ def test_ppisp_gpu_forward_slangpy(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """GPU-timed SlangPy PPISP forward pass (timestamp queries, no CPU overhead)."""
-    _skip_if_no_torch()
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -802,7 +808,7 @@ def test_ppisp_gpu_backward_slangpy(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """GPU-timed SlangPy PPISP backward pass (timestamp queries, no CPU overhead)."""
-    _skip_if_no_torch()
+    _skip_if_no_native_torch_bridge()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 

--- a/slangpy/benchmarks/test_benchmark_ppisp.py
+++ b/slangpy/benchmarks/test_benchmark_ppisp.py
@@ -55,12 +55,6 @@ def _skip_if_no_slangtorch() -> None:
         pytest.skip("slangtorch is not installed")
 
 
-def _skip_if_no_native_torch_bridge() -> None:
-    _skip_if_no_torch()
-    if not spy.is_torch_bridge_available() or spy.is_torch_bridge_using_fallback():
-        pytest.skip("slangpy-torch native bridge is not installed")
-
-
 def create_test_data(
     batch_size: int,
     num_cameras: int,
@@ -301,7 +295,7 @@ def test_ppisp_forward_slangpy(
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
-    _skip_if_no_native_torch_bridge()
+    _skip_if_no_torch()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -419,7 +413,7 @@ def test_ppisp_backward_slangpy(
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
-    _skip_if_no_native_torch_bridge()
+    _skip_if_no_torch()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -505,7 +499,7 @@ def test_ppisp_backward_slangpy_manual_hook(
     Bypasses SlangPy's automatic TorchAutoGradHook to measure the overhead of
     the automatic autograd integration vs doing it manually.
     """
-    _skip_if_no_native_torch_bridge()
+    _skip_if_no_torch()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -537,13 +531,6 @@ def test_ppisp_backward_slangpy_manual_hook(
             crf: torch.Tensor,
         ) -> torch.Tensor:
             # Detach all to avoid triggering SlangPy's automatic autograd
-            ctx.save_for_backward(
-                rgb.detach(),
-                exposure.detach(),
-                vignetting.detach(),
-                color.detach(),
-                crf.detach(),
-            )
             result = func(
                 batch_size=rgb.shape[0],
                 num_cameras=NUM_CAMERAS,
@@ -559,6 +546,14 @@ def test_ppisp_backward_slangpy_manual_hook(
                 resolution_w=float(RESOLUTION_W),
                 resolution_h=float(RESOLUTION_H),
             )
+            ctx.save_for_backward(
+                rgb.detach(),
+                exposure.detach(),
+                vignetting.detach(),
+                color.detach(),
+                crf.detach(),
+                result,
+            )
             return result
 
         @staticmethod
@@ -566,7 +561,7 @@ def test_ppisp_backward_slangpy_manual_hook(
             ctx: Any,
             grad_output: torch.Tensor,
         ) -> tuple[Optional[torch.Tensor], ...]:
-            rgb, exposure, vignetting, color, crf = ctx.saved_tensors
+            rgb, exposure, vignetting, color, crf, result = ctx.saved_tensors
             # Build diff pairs: (primal, grad_buffer, index, is_input)
             exposure_pair = NativeTorchTensorDiffPair(exposure, torch.zeros_like(exposure), 0, True)
             vignetting_pair = NativeTorchTensorDiffPair(
@@ -575,7 +570,7 @@ def test_ppisp_backward_slangpy_manual_hook(
             color_pair = NativeTorchTensorDiffPair(color, torch.zeros_like(color), 2, True)
             crf_pair = NativeTorchTensorDiffPair(crf, torch.zeros_like(crf), 3, True)
             rgb_pair = NativeTorchTensorDiffPair(rgb, torch.zeros_like(rgb), 4, True)
-            result_pair = NativeTorchTensorDiffPair(None, grad_output, 5, False)
+            result_pair = NativeTorchTensorDiffPair(result, grad_output, 5, False)
 
             func.bwds(
                 batch_size=rgb.shape[0],
@@ -647,7 +642,7 @@ def test_ppisp_cpu_overhead_slangpy(
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     """Measure SlangPy CPU dispatch overhead for PPISP (forward + backward)."""
-    _skip_if_no_native_torch_bridge()
+    _skip_if_no_torch()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -749,7 +744,7 @@ def test_ppisp_gpu_forward_slangpy(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """GPU-timed SlangPy PPISP forward pass (timestamp queries, no CPU overhead)."""
-    _skip_if_no_native_torch_bridge()
+    _skip_if_no_torch()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
@@ -808,7 +803,7 @@ def test_ppisp_gpu_backward_slangpy(
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """GPU-timed SlangPy PPISP backward pass (timestamp queries, no CPU overhead)."""
-    _skip_if_no_native_torch_bridge()
+    _skip_if_no_torch()
     device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 

--- a/slangpy/benchmarks/test_benchmark_ppisp.py
+++ b/slangpy/benchmarks/test_benchmark_ppisp.py
@@ -145,11 +145,12 @@ def _assert_close(
 
 
 @pytest.mark.skip(reason="Correctness validated; enable manually when needed")
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("include_pytorch", [False, True], ids=["slang-only", "with-pytorch"])
-def test_ppisp_correctness_forward(include_pytorch: bool) -> None:
+def test_ppisp_correctness_forward(device_type: spy.DeviceType, include_pytorch: bool) -> None:
     """Verify forward outputs match across backends."""
     _skip_if_no_slangtorch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     torch.manual_seed(42)
@@ -187,11 +188,12 @@ def test_ppisp_correctness_forward(include_pytorch: bool) -> None:
 
 
 @pytest.mark.skip(reason="Correctness validated; enable manually when needed")
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("include_pytorch", [False, True], ids=["slang-only", "with-pytorch"])
-def test_ppisp_correctness_backward(include_pytorch: bool) -> None:
+def test_ppisp_correctness_backward(device_type: spy.DeviceType, include_pytorch: bool) -> None:
     """Verify gradients match across backends."""
     _skip_if_no_slangtorch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     torch.manual_seed(42)
@@ -253,13 +255,15 @@ def test_ppisp_correctness_backward(include_pytorch: bool) -> None:
 # =============================================================================
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_forward_pytorch(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_pytorch import PPISPPyTorch
@@ -284,13 +288,15 @@ def test_ppisp_forward_pytorch(
     )
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_forward_slangpy(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangpy import PPISPSlangPy
@@ -325,13 +331,15 @@ def test_ppisp_forward_slangpy(
     )
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_forward_slangtorch(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     _skip_if_no_slangtorch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangtorch import PPISPSlangtorch
@@ -364,13 +372,15 @@ def test_ppisp_forward_slangtorch(
 # =============================================================================
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_backward_pytorch(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_pytorch import PPISPPyTorch
@@ -396,13 +406,15 @@ def test_ppisp_backward_pytorch(
     )
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_backward_slangpy(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangpy import PPISPSlangPy
@@ -438,13 +450,15 @@ def test_ppisp_backward_slangpy(
     )
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_backward_slangtorch(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     _skip_if_no_slangtorch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangtorch import PPISPSlangtorch
@@ -473,8 +487,10 @@ def test_ppisp_backward_slangtorch(
     )
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_backward_slangpy_manual_hook(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
@@ -484,7 +500,7 @@ def test_ppisp_backward_slangpy_manual_hook(
     the automatic autograd integration vs doing it manually.
     """
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from typing import Any, Optional
@@ -619,12 +635,14 @@ CPU_OVERHEAD_SUB_ITERATIONS = 20000
 CPU_OVERHEAD_WARMUPS = 10
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 def test_ppisp_cpu_overhead_slangpy(
+    device_type: spy.DeviceType,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     """Measure SlangPy CPU dispatch overhead for PPISP (forward + backward)."""
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangpy import PPISPSlangPy
@@ -666,12 +684,14 @@ def test_ppisp_cpu_overhead_slangpy(
     )
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 def test_ppisp_cpu_overhead_slangtorch(
+    device_type: spy.DeviceType,
     benchmark_python_function: BenchmarkPythonFunction,
 ) -> None:
     """Measure slangtorch CPU dispatch overhead for PPISP (forward + backward)."""
     _skip_if_no_slangtorch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangtorch import PPISPSlangtorch
@@ -715,14 +735,16 @@ def test_ppisp_cpu_overhead_slangtorch(
 # =============================================================================
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_gpu_forward_slangpy(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """GPU-timed SlangPy PPISP forward pass (timestamp queries, no CPU overhead)."""
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangpy import _get_slang_module, _warmup
@@ -772,14 +794,16 @@ def test_ppisp_gpu_forward_slangpy(
     )
 
 
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 def test_ppisp_gpu_backward_slangpy(
+    device_type: spy.DeviceType,
     batch_size: int,
     benchmark_slang_function: BenchmarkSlangFunction,
 ) -> None:
     """GPU-timed SlangPy PPISP backward pass (timestamp queries, no CPU overhead)."""
     _skip_if_no_torch()
-    device = helpers.get_torch_device(spy.DeviceType.cuda)
+    device = helpers.get_torch_device(device_type)
     torch_device = torch.device("cuda")
 
     from slangpy.benchmarks.ppisp.ppisp_slangpy import _get_slang_module, _warmup

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -22,6 +22,7 @@ from slangpy import (
     NativeHandle,
     DeviceType,
     TypeConformance,
+    is_torch_bridge_available,
     is_torch_bridge_using_fallback,
     get_torch_bridge_fallback_reason,
 )
@@ -184,6 +185,7 @@ class CallData(NativeCallData):
                 import slangpy.torchintegration.torchtensormarshall  # type: ignore (Registers torch.Tensor handler)
 
                 # Error if slangpy-torch native bridge is not available (unless fallback opted in)
+                is_torch_bridge_available()
                 if is_torch_bridge_using_fallback():
                     if not _ALLOW_TORCH_FALLBACK:
                         reason = get_torch_bridge_fallback_reason()

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -160,6 +160,7 @@ def test_examples(args: Any):
 
 def benchmark_python(args: Any):
     env = get_python_env()
+    env["SLANGPY_ALLOW_TORCH_FALLBACK"] = "1"
 
     # Define available device types per platform
     os_name = get_os()
@@ -193,6 +194,8 @@ def benchmark_python(args: Any):
                 cmd = ["sudo"] + cmd
             run_command(cmd)
 
+        failed_device_types = []
+
         # Run benchmarks for each device type
         for device_type in device_types:
             print(f"Running benchmarks for device type: {device_type}")
@@ -208,9 +211,15 @@ def benchmark_python(args: Any):
                 run_command(cmd, env=env)
             except Exception as e:
                 print(f"Benchmarks failed for device type {device_type}: {e}")
+                failed_device_types.append(device_type)
                 if args.device_type:  # If specific device requested, fail hard
                     raise
                 # Otherwise, continue with other devices
+
+        if failed_device_types:
+            raise RuntimeError(
+                "Benchmarks failed for device type(s): " + ", ".join(failed_device_types)
+            )
     finally:
         # Unlock GPU clocks
         if args.lock_gpu_clocks:

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -160,6 +160,7 @@ def test_examples(args: Any):
 
 def benchmark_python(args: Any):
     env = get_python_env()
+    env["SLANGPY_ALLOW_TORCH_FALLBACK"] = "1"
 
     # Define available device types per platform
     os_name = get_os()

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -160,7 +160,6 @@ def test_examples(args: Any):
 
 def benchmark_python(args: Any):
     env = get_python_env()
-    env["SLANGPY_ALLOW_TORCH_FALLBACK"] = "1"
 
     # Define available device types per platform
     os_name = get_os()


### PR DESCRIPTION
## Summary

- Make `benchmark-python` fail after collecting per-device benchmark failures instead of leaving the workflow green.
- Enable the existing SlangPy torch fallback for benchmark subprocesses so CUDA benchmark runs do not fail solely because `slangpy-torch` is not installed.
- Fix the backward-diff benchmark include path for `extensions.slang`.
- Mark PPISP benchmarks as CUDA device tests so they skip cleanly in `nodevice` benchmark passes.

## Root Cause

The scheduled benchmark job printed real pytest failures, but `tools/ci.py` swallowed per-device benchmark failures unless a single explicit `--device-type` was requested. Some benchmark tests were also misclassified or misconfigured.

## Validation

- `python3 -m py_compile tools/ci.py slangpy/benchmarks/test_benchmark_bwd_diff.py slangpy/benchmarks/test_benchmark_ppisp.py`
- `git diff --check`
- `cmake --preset macos-arm64-clang` passed after allowing vcpkg/pip network access.

Not run successfully:

- `cmake --build --preset macos-arm64-clang-debug` was blocked in the original checkout by a pre-existing `external/slang-rhi` submodule mismatch (`db9ba70a` checked out locally vs `d7551005` expected by `origin/main`).
- `pre-commit run --all-files` could not run because `pre-commit` / `pre_commit` is not installed in this environment.
