### PR TITLE
Improve device close callback

### DIFF
--- a/slangpy/tests/device/test_device.py
+++ b/slangpy/tests/device/test_device.py
@@ -93,6 +93,27 @@ def test_device_close_handler(device_type: spy.DeviceType):
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_device_close_handler_reentrant_close(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type, use_cache=False)
+
+    count = 0
+
+    def on_close(cd: spy.Device) -> None:
+        nonlocal count
+        count += 1
+        cd.close()
+
+    close_callback_id = device.register_device_close_callback(on_close)
+    assert isinstance(close_callback_id, int)
+
+    device.close()
+    assert count == 1
+
+    device.close()
+    assert count == 1
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_execute_callback(device_type: spy.DeviceType):
     device = helpers.get_device(device_type)
     expected_handle_types: dict[spy.DeviceType, spy.NativeHandleType] = {

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -545,8 +545,8 @@ void Device::close()
 void Device::close_all_devices()
 {
     std::vector<ref<Device>> devices = get_created_devices();
-    for (const ref<Device>& device : devices)
-        device->close();
+    for (auto it = devices.rbegin(); it != devices.rend(); ++it)
+        (*it)->close();
 }
 
 void Device::_release_all_rhi_resources()

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -495,6 +495,10 @@ void Device::close()
     if (m_closed)
         return;
 
+    // Keep the device alive while callbacks and resource teardown may release
+    // the last external owner.
+    ref<Device> keep_alive(this);
+
     // Pop device from thread-local current device stack if it's the current device.
     if (!s_tls_current_device_stack.empty() && s_tls_current_device_stack.back() == this)
         pop_current_device();
@@ -507,13 +511,12 @@ void Device::close()
     if (m_cache_writer)
         m_cache_writer->flush();
 
+    // Mark the device closed before notifying callbacks so reentrant close()
+    // calls from callbacks are no-ops.
+    m_closed = true;
+
     // Handle device close callbacks.
     m_device_close_callbacks.notify(this);
-
-    // Make sure Device's ref count is not going to zero when releasing resources.
-    inc_ref();
-
-    m_closed = true;
 
     m_device_close_callbacks.clear();
     m_shader_hot_reload_callbacks.clear();
@@ -537,18 +540,12 @@ void Device::close()
         m_cuda_semaphore.reset();
     }
     m_cuda_device.reset();
-
-    dec_ref();
 }
 
 void Device::close_all_devices()
 {
-    std::vector<Device*> devices;
-    {
-        std::lock_guard lock(s_devices_mutex);
-        devices = s_devices;
-    }
-    for (Device* device : devices)
+    std::vector<ref<Device>> devices = get_created_devices();
+    for (const ref<Device>& device : devices)
         device->close();
 }
 

--- a/tests/sgl/device/test_device.cpp
+++ b/tests/sgl/device/test_device.cpp
@@ -56,6 +56,39 @@ TEST_CASE_GPU("init")
     CHECK(ctx.device);
 }
 
+TEST_CASE_GPU("close_all_devices_keeps_snapshot_alive")
+{
+    DeviceDesc desc = ctx.device->desc();
+    desc.label = "close-all-devices-snapshot-a";
+    ref<Device> device_a = Device::create(desc);
+    desc.label = "close-all-devices-snapshot-b";
+    ref<Device> device_b = Device::create(desc);
+
+    int close_count_a = 0;
+    int close_count_b = 0;
+
+    device_a->register_device_close_callback(
+        [&](Device*)
+        {
+            close_count_a++;
+            device_b->close();
+            device_b = nullptr;
+        }
+    );
+    device_b->register_device_close_callback(
+        [&](Device*)
+        {
+            close_count_b++;
+        }
+    );
+
+    Device::close_all_devices();
+    testing::release_cached_devices();
+
+    CHECK(close_count_a == 1);
+    CHECK(close_count_b == 1);
+}
+
 TEST_CASE_GPU("execute_callback_desc_native_handle")
 {
     ExecuteCallbackTestState state;

--- a/tests/sgl/device/test_device.cpp
+++ b/tests/sgl/device/test_device.cpp
@@ -71,14 +71,14 @@ TEST_CASE_GPU("close_all_devices_keeps_snapshot_alive")
         [&](Device*)
         {
             close_count_a++;
-            device_b->close();
-            device_b = nullptr;
         }
     );
     device_b->register_device_close_callback(
         [&](Device*)
         {
             close_count_b++;
+            device_a->close();
+            device_a = nullptr;
         }
     );
 
@@ -87,6 +87,7 @@ TEST_CASE_GPU("close_all_devices_keeps_snapshot_alive")
 
     CHECK(close_count_a == 1);
     CHECK(close_count_b == 1);
+    CHECK_THROWS(current_device());
 }
 
 TEST_CASE_GPU("execute_callback_desc_native_handle")

--- a/tests/sgl/testing.cpp
+++ b/tests/sgl/testing.cpp
@@ -111,4 +111,11 @@ void run_gpu_test(void (*func)(GpuTestContext&))
     }
 }
 
+void release_cached_devices()
+{
+    for (auto& [_, device] : g_cached_devices)
+        device->close();
+    g_cached_devices.clear();
+}
+
 } // namespace sgl::testing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device shutdown so close callbacks run reliably even when a callback triggers another close.
  * Prevented devices from being destroyed too early during shutdown and ensured all open devices are closed safely from a stable snapshot.
* **Tests**
  * Added coverage for reentrant device close behavior and for closing multiple devices without missing callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->