### PR TITLE
Add CacheWriter

### DIFF
--- a/slangpy/tests/device/test_module_cache.py
+++ b/slangpy/tests/device/test_module_cache.py
@@ -27,7 +27,9 @@ def test_module_cache(device_type: spy.DeviceType, tmpdir: str):
     assert device.flush_print_to_string().strip() == "Hello module cache!"
     # Close device.
     device.close()
-    assert len(list(Path(cache_dir).rglob("test_module_cache.slang-module"))) == 1
+    module_cache_files = list(Path(cache_dir).rglob("test_module_cache.slang-module"))
+    assert len(module_cache_files) == 1
+    module_cache_mtime_ns = module_cache_files[0].stat().st_mtime_ns
 
     # Re-create device using same module cache location.
     device = spy.Device(
@@ -46,6 +48,7 @@ def test_module_cache(device_type: spy.DeviceType, tmpdir: str):
     assert device.flush_print_to_string().strip() == "Hello module cache!"
     # Close device.
     device.close()
+    assert module_cache_files[0].stat().st_mtime_ns == module_cache_mtime_ns
 
 
 if __name__ == "__main__":

--- a/slangpy/tests/device/test_module_cache.py
+++ b/slangpy/tests/device/test_module_cache.py
@@ -27,6 +27,7 @@ def test_module_cache(device_type: spy.DeviceType, tmpdir: str):
     assert device.flush_print_to_string().strip() == "Hello module cache!"
     # Close device.
     device.close()
+    assert len(list(Path(cache_dir).rglob("test_module_cache.slang-module"))) == 1
 
     # Re-create device using same module cache location.
     device = spy.Device(

--- a/src/sgl/CMakeLists.txt
+++ b/src/sgl/CMakeLists.txt
@@ -75,6 +75,8 @@ target_sources(sgl PRIVATE
     device/blit.slang
     device/buffer_cursor.cpp
     device/buffer_cursor.h
+    device/cache_writer.cpp
+    device/cache_writer.h
     device/callback_list.h
     device/command.cpp
     device/command.h

--- a/src/sgl/core/lmdb_cache.cpp
+++ b/src/sgl/core/lmdb_cache.cpp
@@ -176,13 +176,23 @@ void LMDBCache::set(const void* key_data, size_t key_size, const void* value_dat
 
 bool LMDBCache::get(const void* key_data, size_t key_size, WriteValueFunc write_value_func, void* user_data)
 {
+    return get_impl(key_data, key_size, write_value_func, user_data, true);
+}
+
+bool LMDBCache::get_readonly(const void* key_data, size_t key_size, WriteValueFunc write_value_func, void* user_data)
+{
+    return get_impl(key_data, key_size, write_value_func, user_data, false);
+}
+
+bool LMDBCache::touch(const void* key_data, size_t key_size)
+{
     SGL_CHECK(key_size > 0, "Key size must be greater than 0");
     SGL_CHECK(key_size <= m_max_key_size, "Key size exceeds maximum allowed size");
 
     ScopedTransaction txn(m_db.env);
 
     MDB_val mdb_key = {key_size, const_cast<void*>(key_data)};
-    MDB_val mdb_val;
+    MDB_val mdb_val = {};
 
     int result = mdb_get(txn, m_db.dbi_data, &mdb_key, &mdb_val);
     if (result == MDB_NOTFOUND)
@@ -196,9 +206,45 @@ bool LMDBCache::get(const void* key_data, size_t key_size, WriteValueFunc write_
     if (result != MDB_SUCCESS)
         LMDB_THROW("Failed to write metadata", result);
 
+    txn.commit();
+
+    return true;
+}
+
+bool LMDBCache::get_impl(
+    const void* key_data,
+    size_t key_size,
+    WriteValueFunc write_value_func,
+    void* user_data,
+    bool update_last_access
+)
+{
+    SGL_CHECK(key_size > 0, "Key size must be greater than 0");
+    SGL_CHECK(key_size <= m_max_key_size, "Key size exceeds maximum allowed size");
+
+    ScopedTransaction txn(m_db.env, update_last_access ? 0 : MDB_RDONLY);
+
+    MDB_val mdb_key = {key_size, const_cast<void*>(key_data)};
+    MDB_val mdb_val;
+
+    int result = mdb_get(txn, m_db.dbi_data, &mdb_key, &mdb_val);
+    if (result == MDB_NOTFOUND)
+        return false;
+    if (result != MDB_SUCCESS)
+        LMDB_THROW("Failed to read data", result);
+
+    if (update_last_access) {
+        MetaData meta_data{.last_access = get_current_time_ns()};
+        MDB_val mdb_val_meta = {sizeof(MetaData), &meta_data};
+        result = mdb_put(txn, m_db.dbi_meta, &mdb_key, &mdb_val_meta, 0);
+        if (result != MDB_SUCCESS)
+            LMDB_THROW("Failed to write metadata", result);
+    }
+
     write_value_func(mdb_val.mv_data, mdb_val.mv_size, user_data);
 
-    txn.commit();
+    if (update_last_access)
+        txn.commit();
 
     return true;
 }

--- a/src/sgl/core/lmdb_cache.h
+++ b/src/sgl/core/lmdb_cache.h
@@ -84,6 +84,9 @@ public:
     /// Destructor.
     ~LMDBCache() override;
 
+    /// Maximum key size supported by the database.
+    size_t max_key_size() const { return m_max_key_size; }
+
     /// Set a value in the cache.
     /// Throws on error.
     /// \param key_data Pointer to the key data.
@@ -100,6 +103,23 @@ public:
     /// \param user_data User data passed to the write_value_func.
     /// \return True if the key was found, false otherwise.
     bool get(const void* key_data, size_t key_size, WriteValueFunc write_value_func, void* user_data = nullptr);
+
+    /// Get a value from the cache without updating its last-access metadata.
+    /// Throws on error.
+    /// \param key_data Pointer to the key data.
+    /// \param key_size Size of the key data.
+    /// \param write_value_func Function to write the value data.
+    /// \param user_data User data passed to the write_value_func.
+    /// \return True if the key was found, false otherwise.
+    bool
+    get_readonly(const void* key_data, size_t key_size, WriteValueFunc write_value_func, void* user_data = nullptr);
+
+    /// Update an entry's last-access metadata without reading its value.
+    /// Throws on error.
+    /// \param key_data Pointer to the key data.
+    /// \param key_size Size of the key data.
+    /// \return True if the key was found and touched, false otherwise.
+    bool touch(const void* key_data, size_t key_size);
 
     /// Delete a value from the cache.
     /// Throws on error.
@@ -138,6 +158,33 @@ public:
         );
     }
 
+    /// Get a value from the cache without updating its last-access metadata.
+    /// Throws on error.
+    /// \param key Key.
+    /// \param value Vector to store the value.
+    /// \return True if the key was found, false otherwise.
+    inline bool get_readonly(std::span<const uint8_t> key, std::vector<uint8_t>& value)
+    {
+        return get_readonly(
+            key.data(),
+            key.size(),
+            [](const void* data, size_t size, void* user_data)
+            {
+                reinterpret_cast<std::vector<uint8_t>*>(user_data)->assign(
+                    static_cast<const uint8_t*>(data),
+                    static_cast<const uint8_t*>(data) + size
+                );
+            },
+            &value
+        );
+    }
+
+    /// Update an entry's last-access metadata.
+    /// Throws on error.
+    /// \param key Key.
+    /// \return True if the key was found and touched, false otherwise.
+    inline bool touch(std::span<const uint8_t> key) { return touch(key.data(), key.size()); }
+
     /// Delete a value from the cache.
     /// Throws on error.
     /// \param key Key.
@@ -169,6 +216,14 @@ private:
     using ForEachFunc
         = void (*)(const void* key, size_t key_size, const void* value, size_t value_size, void* user_data);
     void for_each_impl(ForEachFunc callback, void* user_data) const;
+
+    bool get_impl(
+        const void* key_data,
+        size_t key_size,
+        WriteValueFunc write_value_func,
+        void* user_data,
+        bool update_last_access
+    );
 
     void evict(bool force = false);
 

--- a/src/sgl/device/cache_writer.cpp
+++ b/src/sgl/device/cache_writer.cpp
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "cache_writer.h"
+
+#include "sgl/core/error.h"
+#include "sgl/core/logger.h"
+
+namespace sgl {
+
+CacheWriter::CacheWriter(size_t max_pending_bytes)
+    : m_max_pending_bytes(max_pending_bytes)
+{
+    SGL_CHECK(m_max_pending_bytes > 0, "Cache writer pending byte limit must be greater than zero.");
+    m_thread = std::thread(
+        [this]
+        {
+            run();
+        }
+    );
+}
+
+CacheWriter::~CacheWriter()
+{
+    {
+        std::lock_guard lock(m_mutex);
+        m_stop = true;
+    }
+    m_cv.notify_all();
+    m_space_cv.notify_all();
+
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+bool CacheWriter::enqueue(size_t byte_size, std::function<void()> job)
+{
+    return enqueue(byte_size, nullptr, std::move(job));
+}
+
+bool CacheWriter::enqueue(size_t byte_size, std::function<void()> prepare_job, std::function<void()> job)
+{
+    SGL_CHECK(static_cast<bool>(job), "Cannot enqueue an empty cache write job.");
+
+    if (!reserve(byte_size))
+        return false;
+
+    try {
+        if (prepare_job)
+            prepare_job();
+    } catch (...) {
+        release(byte_size);
+        throw;
+    }
+
+    try {
+        std::unique_lock lock(m_mutex);
+        if (m_stop) {
+            lock.unlock();
+            release(byte_size);
+            return false;
+        }
+
+        m_jobs.push_back(Job{byte_size, std::move(job)});
+    } catch (...) {
+        release(byte_size);
+        throw;
+    }
+
+    m_cv.notify_one();
+    return true;
+}
+
+void CacheWriter::flush() const
+{
+    std::unique_lock lock(m_mutex);
+    m_cv.wait(
+        lock,
+        [this]
+        {
+            return m_pending_jobs == 0;
+        }
+    );
+}
+
+bool CacheWriter::reserve(size_t byte_size)
+{
+    std::unique_lock lock(m_mutex);
+    if (byte_size > m_max_pending_bytes)
+        return false;
+
+    m_space_cv.wait(
+        lock,
+        [&]
+        {
+            return m_stop || byte_size <= m_max_pending_bytes - m_pending_bytes;
+        }
+    );
+
+    if (m_stop)
+        return false;
+
+    m_pending_bytes += byte_size;
+    m_pending_jobs++;
+    return true;
+}
+
+void CacheWriter::release(size_t byte_size)
+{
+    {
+        std::lock_guard lock(m_mutex);
+        SGL_ASSERT(m_pending_jobs > 0);
+        SGL_ASSERT(m_pending_bytes >= byte_size);
+        m_pending_jobs--;
+        m_pending_bytes -= byte_size;
+    }
+    m_space_cv.notify_all();
+    m_cv.notify_all();
+}
+
+void CacheWriter::run()
+{
+    while (true) {
+        Job job;
+        {
+            std::unique_lock lock(m_mutex);
+            m_cv.wait(
+                lock,
+                [this]
+                {
+                    return !m_jobs.empty() || (m_stop && m_pending_jobs == 0);
+                }
+            );
+
+            if (m_jobs.empty())
+                break;
+
+            job = std::move(m_jobs.front());
+            m_jobs.pop_front();
+        }
+
+        try {
+            job.func();
+        } catch (const std::exception& e) {
+            log_warn("Cache write job failed: {}", e.what());
+        } catch (...) {
+            log_warn("Cache write job failed with an unknown exception.");
+        }
+
+        release(job.byte_size);
+    }
+}
+
+} // namespace sgl

--- a/src/sgl/device/cache_writer.cpp
+++ b/src/sgl/device/cache_writer.cpp
@@ -143,7 +143,7 @@ void CacheWriter::run()
         } catch (const std::exception& e) {
             log_warn("Cache write job failed: {}", e.what());
         } catch (...) {
-            log_warn("Cache write job failed with an unknown exception.");
+            log_warn("Cache write job failed: unknown exception.");
         }
 
         release(job.byte_size);

--- a/src/sgl/device/cache_writer.h
+++ b/src/sgl/device/cache_writer.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "sgl/core/object.h"
+
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+namespace sgl {
+
+/// Background worker for best-effort cache write jobs.
+class SGL_API CacheWriter : public Object {
+    SGL_OBJECT(CacheWriter)
+public:
+    explicit CacheWriter(size_t max_pending_bytes = 64ull * 1024 * 1024);
+    ~CacheWriter() override;
+
+    bool enqueue(size_t byte_size, std::function<void()> job);
+    bool enqueue(size_t byte_size, std::function<void()> prepare_job, std::function<void()> job);
+    void flush() const;
+
+private:
+    struct Job {
+        size_t byte_size;
+        std::function<void()> func;
+    };
+
+    void run();
+    bool reserve(size_t byte_size);
+    void release(size_t byte_size);
+
+    size_t m_max_pending_bytes;
+
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_cv;
+    mutable std::condition_variable m_space_cv;
+    std::deque<Job> m_jobs;
+    size_t m_pending_bytes{0};
+    size_t m_pending_jobs{0};
+    bool m_stop{false};
+    std::thread m_thread;
+};
+
+} // namespace sgl

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -23,6 +23,7 @@
 #include "sgl/device/hot_reload.h"
 #include "sgl/device/debug_logger.h"
 #include "sgl/device/native_handle_traits.h"
+#include "sgl/device/cache_writer.h"
 #include "sgl/device/persistent_cache.h"
 
 #include "sgl/core/file_system_watcher.h"
@@ -92,7 +93,7 @@ Device::Device(const DeviceDesc& desc)
 #endif
     }
 
-    // Setup module cache.
+    // Setup module cache path.
     if (m_desc.module_cache_path) {
         m_module_cache_path = *m_desc.module_cache_path;
         if (m_module_cache_path.is_relative())
@@ -100,13 +101,22 @@ Device::Device(const DeviceDesc& desc)
         std::filesystem::create_directories(m_module_cache_path);
     }
 
-    // Setup shader cache.
+    // Setup shader cache path.
     if (m_desc.shader_cache_path) {
         m_shader_cache_path = *m_desc.shader_cache_path;
         if (m_shader_cache_path.is_relative())
             m_shader_cache_path = platform::app_data_directory() / m_shader_cache_path;
         std::filesystem::create_directories(m_shader_cache_path);
-        m_persistent_cache = make_ref<PersistentCache>(m_shader_cache_path / "rhi", m_desc.shader_cache_size);
+    }
+
+    // Setup shared cache writer.
+    if (!m_module_cache_path.empty() || !m_shader_cache_path.empty())
+        m_cache_writer = make_ref<CacheWriter>();
+
+    // Setup shader cache.
+    if (!m_shader_cache_path.empty()) {
+        m_persistent_cache
+            = make_ref<PersistentCache>(m_shader_cache_path / "rhi", m_desc.shader_cache_size, m_cache_writer);
     }
 
     // Invalidate CUDA interop if using CUDA
@@ -491,6 +501,10 @@ void Device::close()
     log_debug("Closing device {}", fmt::ptr(this));
 
     wait();
+
+    // Flush cache writer to ensure all pending writes are completed.
+    if (m_cache_writer)
+        m_cache_writer->flush();
 
     // Handle device close callbacks.
     m_device_close_callbacks.notify(this);

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -851,6 +851,7 @@ public:
 
     Blitter* _blitter();
     HotReload* _hot_reload() { return m_hot_reload; }
+    CacheWriter* _cache_writer() { return m_cache_writer.get(); }
 
     /// Called by hot reload system after reload occurs, to trigger the hooks.
     void _on_hot_reload();
@@ -874,6 +875,7 @@ private:
 
     std::filesystem::path m_module_cache_path;
     std::filesystem::path m_shader_cache_path;
+    ref<CacheWriter> m_cache_writer;
     ref<PersistentCache> m_persistent_cache;
 
     Slang::ComPtr<rhi::IDevice> m_rhi_device;

--- a/src/sgl/device/fwd.h
+++ b/src/sgl/device/fwd.h
@@ -96,6 +96,7 @@ class ComputeKernel;
 
 // persistent_cache.h
 
+class CacheWriter;
 class PersistentCache;
 
 // pipeline.h

--- a/src/sgl/device/persistent_cache.cpp
+++ b/src/sgl/device/persistent_cache.cpp
@@ -69,8 +69,7 @@ PersistentCacheStats PersistentCache::stats() const
 
 void PersistentCache::flush() const
 {
-    if (m_cache_writer)
-        m_cache_writer->flush();
+    m_cache_writer->flush();
 }
 
 SlangResult PersistentCache::queryInterface(const SlangUUID& uuid, void** outObject)
@@ -109,13 +108,15 @@ rhi::Result PersistentCache::writeCache(ISlangBlob* key, ISlangBlob* data)
                     try {
                         cache->set(state->key, state->value);
                     } catch (const std::exception& e) {
-                        log_error("Failed to write to cache in \"{}\": {}", path, e.what());
+                        log_warn("Failed to write to cache in \"{}\": {}", path, e.what());
                     } catch (...) {
-                        log_error("Failed to write to cache in \"{}\": unknown error", path);
+                        log_warn("Failed to write to cache in \"{}\": unknown exception", path);
                     }
                 }
-            ))
+            )) {
+            log_warn("Failed to enqueue cache write in \"{}\".", m_path);
             return SLANG_FAIL;
+        }
 
         return SLANG_OK;
     } catch (const std::exception& e) {
@@ -151,19 +152,21 @@ rhi::Result PersistentCache::queryCache(ISlangBlob* key, ISlangBlob** outData)
         if (success) {
             m_hit_count.fetch_add(1);
             const size_t touch_byte_size = key_data.size();
-            m_cache_writer->enqueue(
-                touch_byte_size,
-                [cache = m_cache, path = m_path, key_data = std::move(key_data)]
-                {
-                    try {
-                        cache->touch(key_data);
-                    } catch (const std::exception& e) {
-                        log_error("Failed to touch cache entry in \"{}\": {}", path, e.what());
-                    } catch (...) {
-                        log_error("Failed to touch cache entry in \"{}\": unknown error", path);
+            if (!m_cache_writer->enqueue(
+                    touch_byte_size,
+                    [cache = m_cache, path = m_path, key_data = std::move(key_data)]
+                    {
+                        try {
+                            cache->touch(key_data);
+                        } catch (const std::exception& e) {
+                            log_warn("Failed to touch cache entry in \"{}\": {}", path, e.what());
+                        } catch (...) {
+                            log_warn("Failed to touch cache entry in \"{}\": unknown exception", path);
+                        }
                     }
-                }
-            );
+                )) {
+                log_warn("Failed to enqueue cache entry touch in \"{}\".", m_path);
+            }
         } else {
             m_miss_count.fetch_add(1);
         }

--- a/src/sgl/device/persistent_cache.cpp
+++ b/src/sgl/device/persistent_cache.cpp
@@ -4,11 +4,27 @@
 
 #include "sgl/core/error.h"
 #include "sgl/core/logger.h"
+#include "sgl/core/lmdb_cache.h"
+#include "sgl/device/cache_writer.h"
+
+#include <cstring>
+#include <memory>
+#include <vector>
 
 namespace sgl {
 
-PersistentCache::PersistentCache(const std::filesystem::path& path, size_t max_size)
+static std::vector<uint8_t> copy_blob(ISlangBlob* blob)
+{
+    SGL_CHECK(blob, "Cannot copy a null cache blob.");
+    std::vector<uint8_t> result(blob->getBufferSize());
+    if (!result.empty())
+        std::memcpy(result.data(), blob->getBufferPointer(), result.size());
+    return result;
+}
+
+PersistentCache::PersistentCache(const std::filesystem::path& path, size_t max_size, ref<CacheWriter> cache_writer)
     : m_path(path)
+    , m_cache_writer(cache_writer ? std::move(cache_writer) : make_ref<CacheWriter>())
 {
     LMDBCache::Options options{
         .max_size = max_size,
@@ -37,16 +53,24 @@ PersistentCache::PersistentCache(const std::filesystem::path& path, size_t max_s
 
 PersistentCache::~PersistentCache()
 {
+    flush();
     m_cache.reset();
 }
 
 PersistentCacheStats PersistentCache::stats() const
 {
+    flush();
     return {
         .entry_count = m_cache->stats().entries,
         .hit_count = m_hit_count.load(),
         .miss_count = m_miss_count.load(),
     };
+}
+
+void PersistentCache::flush() const
+{
+    if (m_cache_writer)
+        m_cache_writer->flush();
 }
 
 SlangResult PersistentCache::queryInterface(const SlangUUID& uuid, void** outObject)
@@ -60,9 +84,41 @@ SlangResult PersistentCache::queryInterface(const SlangUUID& uuid, void** outObj
 rhi::Result PersistentCache::writeCache(ISlangBlob* key, ISlangBlob* data)
 {
     try {
-        m_cache->set(key->getBufferPointer(), key->getBufferSize(), data->getBufferPointer(), data->getBufferSize());
+        SGL_CHECK(key, "Cannot write a cache entry with a null key.");
+        SGL_CHECK(data, "Cannot write a cache entry with null data.");
+        SGL_CHECK(key->getBufferSize() > 0, "Cache key size must be greater than 0.");
+        SGL_CHECK(key->getBufferSize() <= m_cache->max_key_size(), "Cache key size exceeds maximum allowed size.");
+
+        struct WriteState {
+            std::vector<uint8_t> key;
+            std::vector<uint8_t> value;
+        };
+
+        auto state = std::make_shared<WriteState>();
+        const size_t byte_size = key->getBufferSize() + data->getBufferSize();
+
+        if (!m_cache_writer->enqueue(
+                byte_size,
+                [key, data, state]
+                {
+                    state->key = copy_blob(key);
+                    state->value = copy_blob(data);
+                },
+                [cache = m_cache, path = m_path, state]() mutable
+                {
+                    try {
+                        cache->set(state->key, state->value);
+                    } catch (const std::exception& e) {
+                        log_error("Failed to write to cache in \"{}\": {}", path, e.what());
+                    } catch (...) {
+                        log_error("Failed to write to cache in \"{}\": unknown error", path);
+                    }
+                }
+            ))
+            return SLANG_FAIL;
+
         return SLANG_OK;
-    } catch (const LMDBException& e) {
+    } catch (const std::exception& e) {
         log_error("Failed to write to cache in \"{}\": {}", m_path, e.what());
     }
     return SLANG_FAIL;
@@ -71,13 +127,19 @@ rhi::Result PersistentCache::writeCache(ISlangBlob* key, ISlangBlob* data)
 rhi::Result PersistentCache::queryCache(ISlangBlob* key, ISlangBlob** outData)
 {
     try {
+        SGL_CHECK(outData, "Cannot query cache with a null output blob pointer.");
+        *outData = nullptr;
+
+        std::vector<uint8_t> key_data = copy_blob(key);
+
         struct Context {
             Slang::ComPtr<ISlangBlob> value;
             rhi::Result result{SLANG_E_NOT_FOUND};
         } context;
-        bool success = m_cache->get(
-            key->getBufferPointer(),
-            key->getBufferSize(),
+
+        bool success = m_cache->get_readonly(
+            key_data.data(),
+            key_data.size(),
             [](const void* data, size_t size, void* user_data)
             {
                 Context* ctx = static_cast<Context*>(user_data);
@@ -86,16 +148,31 @@ rhi::Result PersistentCache::queryCache(ISlangBlob* key, ISlangBlob** outData)
             &context
         );
 
-        if (success)
+        if (success) {
             m_hit_count.fetch_add(1);
-        else
+            const size_t touch_byte_size = key_data.size();
+            m_cache_writer->enqueue(
+                touch_byte_size,
+                [cache = m_cache, path = m_path, key_data = std::move(key_data)]
+                {
+                    try {
+                        cache->touch(key_data);
+                    } catch (const std::exception& e) {
+                        log_error("Failed to touch cache entry in \"{}\": {}", path, e.what());
+                    } catch (...) {
+                        log_error("Failed to touch cache entry in \"{}\": unknown error", path);
+                    }
+                }
+            );
+        } else {
             m_miss_count.fetch_add(1);
+        }
 
         if (SLANG_SUCCEEDED(context.result))
             *outData = context.value.detach();
         return context.result;
-    } catch (const LMDBException& e) {
-        log_error("Failed to write to cache in \"{}\": {}", m_path, e.what());
+    } catch (const std::exception& e) {
+        log_error("Failed to query cache in \"{}\": {}", m_path, e.what());
     }
     return SLANG_FAIL;
 }

--- a/src/sgl/device/persistent_cache.h
+++ b/src/sgl/device/persistent_cache.h
@@ -2,7 +2,8 @@
 
 #pragma once
 
-#include "sgl/core/lmdb_cache.h"
+#include "sgl/core/fwd.h"
+#include "sgl/device/fwd.h"
 
 #include <slang-rhi.h>
 
@@ -20,10 +21,16 @@ struct PersistentCacheStats {
 class SGL_API PersistentCache : public Object, public rhi::IPersistentCache {
     SGL_OBJECT(PersistentCache)
 public:
-    PersistentCache(const std::filesystem::path& path, size_t max_size = 64ull * 1024 * 1024);
+    PersistentCache(
+        const std::filesystem::path& path,
+        size_t max_size = 64ull * 1024 * 1024,
+        ref<CacheWriter> cache_writer = nullptr
+    );
     ~PersistentCache() override;
 
     PersistentCacheStats stats() const;
+
+    void flush() const;
 
     // ISlangUnknown interface
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(const SlangUUID& uuid, void** outObject) override;
@@ -38,6 +45,7 @@ public:
 private:
     std::filesystem::path m_path;
     ref<LMDBCache> m_cache;
+    ref<CacheWriter> m_cache_writer;
 
     std::atomic<uint64_t> m_hit_count{0};
     std::atomic<uint64_t> m_miss_count{0};

--- a/src/sgl/device/shader.cpp
+++ b/src/sgl/device/shader.cpp
@@ -782,13 +782,13 @@ void SlangSession::update_module_cache_and_dependencies()
     }
 }
 
-bool SlangSession::write_module_to_cache(slang::IModule* module)
+void SlangSession::write_module_to_cache(slang::IModule* module)
 {
     std::filesystem::path path{module->getFilePath()};
 
     // Do not cache module if it was loaded from the cache.
     if (path.extension() == ".slang-module")
-        return false;
+        return;
 
     // Check if target path is within the specified root path.
     auto is_sub_path = [](const std::filesystem::path root, const std::filesystem::path& target)
@@ -807,7 +807,7 @@ bool SlangSession::write_module_to_cache(slang::IModule* module)
         }
     }
     if (include_index == size_t(-1))
-        return false;
+        return;
 
     // Determine path of the cached module.
     std::filesystem::path relative = std::filesystem::relative(path, m_data->include_paths[include_index]);
@@ -818,7 +818,7 @@ bool SlangSession::write_module_to_cache(slang::IModule* module)
     Slang::ComPtr<ISlangBlob> module_blob;
     if (!SLANG_SUCCEEDED(module->serialize(module_blob.writeRef())) || !module_blob) {
         log_warn("Failed to serialize cached slang module \"{}\"", module->getName());
-        return false;
+        return;
     }
 
     std::string module_name = module->getName();
@@ -836,21 +836,18 @@ bool SlangSession::write_module_to_cache(slang::IModule* module)
         state->blob = std::move(module_blob);
         const size_t byte_size = state->blob->getBufferSize();
 
-        if (!cache_writer->enqueue(
-                byte_size,
-                [state]() mutable
-                {
-                    write_module_bytes_to_cache(
-                        state->module_name,
-                        state->cache_path,
-                        state->blob->getBufferPointer(),
-                        state->blob->getBufferSize()
-                    );
-                    state->blob.setNull();
-                }
-            ))
-            return false;
-        log_debug("Queued slang module \"{}\" for caching to \"{}\"", module->getName(), cache_path);
+        cache_writer->enqueue(
+            byte_size,
+            [state]() mutable
+            {
+                write_module_bytes_to_cache(
+                    state->module_name,
+                    state->cache_path,
+                    state->blob->getBufferPointer(),
+                    state->blob->getBufferSize()
+                );
+            }
+        );
     } else {
         write_module_bytes_to_cache(
             module_name,
@@ -859,8 +856,6 @@ bool SlangSession::write_module_to_cache(slang::IModule* module)
             module_blob->getBufferSize()
         );
     }
-
-    return true;
 }
 
 std::string SlangSessionData::resolve_module_name(std::string_view module_name) const

--- a/src/sgl/device/shader.cpp
+++ b/src/sgl/device/shader.cpp
@@ -784,6 +784,9 @@ void SlangSession::update_module_cache_and_dependencies()
 
 void SlangSession::write_module_to_cache(slang::IModule* module)
 {
+    if (!module->getFilePath())
+        return;
+
     std::filesystem::path path{module->getFilePath()};
 
     // Do not cache module if it was loaded from the cache.
@@ -836,18 +839,39 @@ void SlangSession::write_module_to_cache(slang::IModule* module)
         state->blob = std::move(module_blob);
         const size_t byte_size = state->blob->getBufferSize();
 
-        cache_writer->enqueue(
-            byte_size,
-            [state]() mutable
-            {
-                write_module_bytes_to_cache(
-                    state->module_name,
-                    state->cache_path,
-                    state->blob->getBufferPointer(),
-                    state->blob->getBufferSize()
-                );
-            }
-        );
+        if (!cache_writer->enqueue(
+                byte_size,
+                [state]() mutable
+                {
+                    try {
+                        write_module_bytes_to_cache(
+                            state->module_name,
+                            state->cache_path,
+                            state->blob->getBufferPointer(),
+                            state->blob->getBufferSize()
+                        );
+                    } catch (const std::exception& e) {
+                        log_warn(
+                            "Failed to write cached slang module \"{}\" to \"{}\": {}",
+                            state->module_name,
+                            state->cache_path,
+                            e.what()
+                        );
+                    } catch (...) {
+                        log_warn(
+                            "Failed to write cached slang module \"{}\" to \"{}\": unknown exception",
+                            state->module_name,
+                            state->cache_path
+                        );
+                    }
+                }
+            )) {
+            log_warn(
+                "Failed to enqueue cache write for slang module \"{}\" to \"{}\".",
+                state->module_name,
+                state->cache_path
+            );
+        }
     } else {
         write_module_bytes_to_cache(
             module_name,

--- a/src/sgl/device/shader.cpp
+++ b/src/sgl/device/shader.cpp
@@ -10,6 +10,7 @@
 #include "sgl/device/slang_utils.h"
 #include "sgl/device/pipeline.h"
 #include "sgl/device/hot_reload.h"
+#include "sgl/device/cache_writer.h"
 
 #include "sgl/core/type_utils.h"
 #include "sgl/core/platform.h"
@@ -20,11 +21,68 @@
 
 #include <slang.h>
 
+#include <memory>
 #include <random>
 #include <regex>
 #include <set>
+#include <vector>
 
 namespace sgl {
+
+static bool write_module_bytes_to_cache(
+    const std::string& module_name,
+    const std::filesystem::path& cache_path,
+    const void* data,
+    size_t data_size
+)
+{
+    std::filesystem::path tmp_path = cache_path;
+    std::random_device rd;
+    uint64_t uid = rd();
+    tmp_path.replace_extension(".slang-module-" + string::hexlify(&uid, sizeof(uid)));
+
+    std::error_code ec;
+    try {
+        if (std::filesystem::exists(tmp_path, ec))
+            return false;
+        if (ec) {
+            log_warn("Failed to query temporary slang module cache path \"{}\" ({})", tmp_path, ec.message());
+            return false;
+        }
+
+        std::filesystem::create_directories(cache_path.parent_path(), ec);
+        if (ec) {
+            log_warn(
+                "Failed to create directory \"{}\" for slang module cache ({})",
+                cache_path.parent_path(),
+                ec.message()
+            );
+            return false;
+        }
+
+        {
+            FileStream stream(tmp_path, FileStream::Mode::write);
+            if (data_size > 0)
+                stream.write(data, data_size);
+            stream.flush();
+            stream.close();
+        }
+
+        std::filesystem::rename(tmp_path, cache_path, ec);
+        if (ec) {
+            log_warn("Failed to rename cached slang module \"{}\" to \"{}\" ({})", tmp_path, cache_path, ec.message());
+            std::filesystem::remove(tmp_path, ec);
+            return false;
+        }
+    } catch (const std::exception& e) {
+        log_warn("Failed to write cached slang module \"{}\" to \"{}\" ({})", module_name, cache_path, e.what());
+        std::filesystem::remove(tmp_path, ec);
+        return false;
+    }
+
+    log_debug("Cached slang module \"{}\" to \"{}\"", module_name, cache_path);
+    return true;
+}
 
 // ----------------------------------------------------------------------------
 // TypeConformance
@@ -756,39 +814,51 @@ bool SlangSession::write_module_to_cache(slang::IModule* module)
     std::filesystem::path cache_path = m_data->cache_include_paths[include_index] / relative;
     cache_path.replace_extension(".slang-module");
 
-    // Create directories to cache path.
-    std::error_code ec;
-    std::filesystem::create_directories(cache_path.parent_path(), ec);
-    if (ec) {
-        log_warn(
-            "Failed to create directory \"{}\" for slang module cache ({})",
-            cache_path.parent_path(),
-            ec.message()
+    // Serialize module on the caller thread so the queued write owns plain bytes only.
+    Slang::ComPtr<ISlangBlob> module_blob;
+    if (!SLANG_SUCCEEDED(module->serialize(module_blob.writeRef())) || !module_blob) {
+        log_warn("Failed to serialize cached slang module \"{}\"", module->getName());
+        return false;
+    }
+
+    std::string module_name = module->getName();
+
+    if (CacheWriter* cache_writer = m_device->_cache_writer()) {
+        struct WriteState {
+            std::string module_name;
+            std::filesystem::path cache_path;
+            Slang::ComPtr<ISlangBlob> blob;
+        };
+
+        auto state = std::make_shared<WriteState>();
+        state->module_name = std::move(module_name);
+        state->cache_path = cache_path;
+        state->blob = std::move(module_blob);
+        const size_t byte_size = state->blob->getBufferSize();
+
+        if (!cache_writer->enqueue(
+                byte_size,
+                [state]() mutable
+                {
+                    write_module_bytes_to_cache(
+                        state->module_name,
+                        state->cache_path,
+                        state->blob->getBufferPointer(),
+                        state->blob->getBufferSize()
+                    );
+                    state->blob.setNull();
+                }
+            ))
+            return false;
+        log_debug("Queued slang module \"{}\" for caching to \"{}\"", module->getName(), cache_path);
+    } else {
+        write_module_bytes_to_cache(
+            module_name,
+            cache_path,
+            module_blob->getBufferPointer(),
+            module_blob->getBufferSize()
         );
-        return false;
     }
-
-    // Write module to a temporary file.
-    std::filesystem::path tmp_path = cache_path;
-    std::random_device rd;
-    uint64_t uid = rd();
-    tmp_path.replace_extension(".slang-module-" + string::hexlify(&uid, sizeof(uid)));
-    if (std::filesystem::exists(tmp_path))
-        return false;
-    if (!SLANG_SUCCEEDED(module->writeToFile(tmp_path.string().c_str()))) {
-        log_warn("Failed to write cached slang module \"{}\" to \"{}\"", module->getName(), cache_path);
-        return false;
-    }
-
-    // Rename temporary file to cache path.
-    std::filesystem::rename(tmp_path, cache_path, ec);
-    if (ec) {
-        log_warn("Failed to rename cached slang module \"{}\" to \"{}\" ({})", tmp_path, cache_path, ec.message());
-        std::filesystem::remove(tmp_path, ec);
-        return false;
-    }
-
-    log_debug("Cached slang module \"{}\" to \"{}\"", module->getName(), cache_path);
 
     return true;
 }

--- a/src/sgl/device/shader.h
+++ b/src/sgl/device/shader.h
@@ -354,7 +354,7 @@ private:
     std::set<ShaderProgram*> m_registered_programs;
 
     void update_module_cache_and_dependencies();
-    bool write_module_to_cache(slang::IModule* module);
+    void write_module_to_cache(slang::IModule* module);
     void create_session(SlangSessionBuild& build);
 
     /// Helper to create a module, updating cache afterwards.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ if(SGL_BUILD_TESTS)
         sgl/device/test_hot_reload.cpp
         sgl/device/test_formats.cpp
         sgl/device/test_shader.cpp
+        sgl/device/test_persistent_cache.cpp
         sgl/func/test_base_objects.cpp
         sgl/func/test_tensor.cpp
         sgl/refl/test_lookup.cpp

--- a/tests/sgl/core/test_lmdb_cache.cpp
+++ b/tests/sgl/core/test_lmdb_cache.cpp
@@ -180,6 +180,40 @@ TEST_CASE("simple")
     CHECK(cache.del(key1) == false);
 }
 
+TEST_CASE("readonly_get_and_touch")
+{
+    auto cache_dir = testing::get_case_temp_directory() / "cache";
+    LMDBCache::Options options{.max_size = 8ull * 1024 * 1024};
+    LMDBCache cache(cache_dir, options);
+
+    Blob readonly_key{1};
+    Blob touched_key{2};
+    Blob trigger_key{255};
+    Blob value(128 * 1024, 42);
+    Blob trigger_value(128 * 1024, 43);
+    Blob missing_key = random_data(32);
+    std::vector<uint8_t> temp_value;
+
+    cache.set(readonly_key, value);
+    cache.set(touched_key, value);
+    const size_t eviction_threshold_size = (options.eviction_threshold * options.max_size) / 100;
+    uint8_t next_key = 3;
+    while (cache.usage().used_size <= eviction_threshold_size && next_key < 200)
+        cache.set(Blob{next_key++}, value);
+
+    CHECK(cache.touch(touched_key));
+    CHECK(cache.touch(missing_key) == false);
+    CHECK(cache.get_readonly(readonly_key, temp_value));
+    CHECK(temp_value == value);
+
+    cache.set(trigger_key, trigger_value);
+    CHECK(cache.stats().entries < next_key);
+
+    CHECK(cache.get_readonly(readonly_key, temp_value) == false);
+    CHECK(cache.get_readonly(touched_key, temp_value));
+    CHECK(temp_value == value);
+}
+
 TEST_CASE("persistence")
 {
     auto cache_dir = testing::get_case_temp_directory() / "cache";

--- a/tests/sgl/device/test_persistent_cache.cpp
+++ b/tests/sgl/device/test_persistent_cache.cpp
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "testing.h"
+#include "sgl/device/cache_writer.h"
+#include "sgl/device/persistent_cache.h"
+
+#include <slang-rhi.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <stdexcept>
+#include <vector>
+
+using namespace sgl;
+
+TEST_SUITE_BEGIN("persistent_cache");
+
+using ByteBlob = std::vector<uint8_t>;
+
+static Slang::ComPtr<ISlangBlob> make_blob(const ByteBlob& data)
+{
+    Slang::ComPtr<ISlangBlob> blob;
+    REQUIRE(SLANG_SUCCEEDED(rhi::getRHI()->createBlob(data.data(), data.size(), blob.writeRef())));
+    return blob;
+}
+
+static ByteBlob copy_blob(ISlangBlob* blob)
+{
+    REQUIRE(blob);
+    ByteBlob result(blob->getBufferSize());
+    if (!result.empty())
+        std::memcpy(result.data(), blob->getBufferPointer(), result.size());
+    return result;
+}
+
+TEST_CASE("cache_writer_flush")
+{
+    ref<CacheWriter> writer = make_ref<CacheWriter>();
+    std::atomic<int> value{0};
+
+    writer->enqueue(
+        1,
+        [&]
+        {
+            value.store(42);
+        }
+    );
+    writer->flush();
+
+    CHECK(value.load() == 42);
+}
+
+TEST_CASE("cache_writer_prepare_failure_releases_reservation")
+{
+    ref<CacheWriter> writer = make_ref<CacheWriter>(1);
+
+    CHECK_THROWS(writer->enqueue(
+        1,
+        []
+        {
+            throw std::runtime_error("prepare failed");
+        },
+        []
+        {
+        }
+    ));
+
+    std::atomic<bool> value{false};
+    CHECK(writer->enqueue(
+        1,
+        [&]
+        {
+            value.store(true);
+        }
+    ));
+    writer->flush();
+    CHECK(value.load());
+}
+
+TEST_CASE("cache_writer_oversized_job_is_rejected")
+{
+    ref<CacheWriter> writer = make_ref<CacheWriter>(1);
+    std::atomic<bool> value{false};
+
+    CHECK(
+        writer->enqueue(
+            2,
+            [&]
+            {
+                value.store(true);
+            }
+        )
+        == false
+    );
+    writer->flush();
+    CHECK(value.load() == false);
+
+    CHECK(writer->enqueue(
+        1,
+        [&]
+        {
+            value.store(true);
+        }
+    ));
+    writer->flush();
+    CHECK(value.load());
+}
+
+TEST_CASE("cache_writer_flush_waits_for_reserved_job")
+{
+    ref<CacheWriter> writer = make_ref<CacheWriter>();
+
+    std::promise<void> prepare_started;
+    std::promise<void> release_prepare;
+    auto prepare_started_future = prepare_started.get_future();
+    auto release_prepare_future = release_prepare.get_future().share();
+    std::atomic<bool> value{false};
+
+    auto enqueue_future = std::async(
+        std::launch::async,
+        [&]
+        {
+            return writer->enqueue(
+                1,
+                [&]
+                {
+                    prepare_started.set_value();
+                    release_prepare_future.wait();
+                },
+                [&]
+                {
+                    value.store(true);
+                }
+            );
+        }
+    );
+    prepare_started_future.wait();
+
+    auto flush_future = std::async(
+        std::launch::async,
+        [&]
+        {
+            writer->flush();
+        }
+    );
+    CHECK(flush_future.wait_for(std::chrono::seconds(1)) == std::future_status::timeout);
+
+    release_prepare.set_value();
+    CHECK(enqueue_future.get());
+    flush_future.get();
+    CHECK(value.load());
+}
+
+TEST_CASE("async_write_visible_after_flush_and_reopen")
+{
+    const std::filesystem::path cache_dir = testing::get_case_temp_directory() / "cache";
+    const ByteBlob key{1, 2, 3, 4};
+    const ByteBlob value{5, 6, 7, 8, 9};
+
+    {
+        ref<CacheWriter> writer = make_ref<CacheWriter>();
+        ref<PersistentCache> cache = make_ref<PersistentCache>(cache_dir, 1024 * 1024, writer);
+        Slang::ComPtr<ISlangBlob> key_blob = make_blob(key);
+        Slang::ComPtr<ISlangBlob> value_blob = make_blob(value);
+
+        std::promise<void> blocker_started;
+        std::promise<void> release_blocker;
+        auto blocker_started_future = blocker_started.get_future();
+        auto release_blocker_future = release_blocker.get_future().share();
+
+        REQUIRE(writer->enqueue(
+            1,
+            [&]
+            {
+                blocker_started.set_value();
+                release_blocker_future.wait();
+            }
+        ));
+        blocker_started_future.wait();
+
+        CHECK(cache->writeCache(key_blob, value_blob) == SLANG_OK);
+
+        Slang::ComPtr<ISlangBlob> queried;
+        rhi::Result query_result = cache->queryCache(key_blob, queried.writeRef());
+        CHECK(query_result != SLANG_OK);
+        CHECK(queried == nullptr);
+
+        release_blocker.set_value();
+        cache->flush();
+
+        query_result = cache->queryCache(key_blob, queried.writeRef());
+        REQUIRE(query_result == SLANG_OK);
+        CHECK(copy_blob(queried) == value);
+
+        PersistentCacheStats stats = cache->stats();
+        CHECK(stats.entry_count == 1);
+        CHECK(stats.hit_count == 1);
+        CHECK(stats.miss_count == 1);
+    }
+
+    {
+        ref<PersistentCache> cache = make_ref<PersistentCache>(cache_dir, 1024 * 1024);
+        Slang::ComPtr<ISlangBlob> key_blob = make_blob(key);
+        Slang::ComPtr<ISlangBlob> queried;
+
+        REQUIRE(cache->queryCache(key_blob, queried.writeRef()) == SLANG_OK);
+        CHECK(copy_blob(queried) == value);
+        cache->flush();
+    }
+}
+
+TEST_CASE("oversized_key_is_rejected_without_pending_entry")
+{
+    const std::filesystem::path cache_dir = testing::get_case_temp_directory() / "cache";
+    const ByteBlob key(4096, 1);
+    const ByteBlob value{2, 3, 4};
+
+    ref<CacheWriter> writer = make_ref<CacheWriter>();
+    ref<PersistentCache> cache = make_ref<PersistentCache>(cache_dir, 1024 * 1024, writer);
+    Slang::ComPtr<ISlangBlob> key_blob = make_blob(key);
+    Slang::ComPtr<ISlangBlob> value_blob = make_blob(value);
+
+    CHECK(cache->writeCache(key_blob, value_blob) == SLANG_FAIL);
+    cache->flush();
+
+    Slang::ComPtr<ISlangBlob> queried;
+    CHECK(cache->queryCache(key_blob, queried.writeRef()) != SLANG_OK);
+    CHECK(queried == nullptr);
+}
+
+TEST_CASE("query_null_out_data_returns_failure")
+{
+    const std::filesystem::path cache_dir = testing::get_case_temp_directory() / "cache";
+    const ByteBlob key{5, 6, 7, 8};
+
+    ref<PersistentCache> cache = make_ref<PersistentCache>(cache_dir, 1024 * 1024);
+    Slang::ComPtr<ISlangBlob> key_blob = make_blob(key);
+
+    CHECK(cache->queryCache(key_blob, nullptr) == SLANG_FAIL);
+}
+
+TEST_CASE("same_key_queued_writes_commit_latest_value")
+{
+    const std::filesystem::path cache_dir = testing::get_case_temp_directory() / "cache";
+    const ByteBlob key{20, 21, 22, 23};
+    const ByteBlob value1{24, 25, 26};
+    const ByteBlob value2{27, 28, 29, 30};
+
+    ref<CacheWriter> writer = make_ref<CacheWriter>();
+    ref<PersistentCache> cache = make_ref<PersistentCache>(cache_dir, 1024 * 1024, writer);
+    Slang::ComPtr<ISlangBlob> key_blob = make_blob(key);
+    Slang::ComPtr<ISlangBlob> value1_blob = make_blob(value1);
+    Slang::ComPtr<ISlangBlob> value2_blob = make_blob(value2);
+
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    auto blocker_started_future = blocker_started.get_future();
+    auto release_blocker_future = release_blocker.get_future().share();
+
+    REQUIRE(writer->enqueue(
+        1,
+        [&]
+        {
+            blocker_started.set_value();
+            release_blocker_future.wait();
+        }
+    ));
+    blocker_started_future.wait();
+
+    CHECK(cache->writeCache(key_blob, value1_blob) == SLANG_OK);
+    CHECK(cache->writeCache(key_blob, value2_blob) == SLANG_OK);
+
+    Slang::ComPtr<ISlangBlob> queried;
+    rhi::Result query_result = cache->queryCache(key_blob, queried.writeRef());
+    CHECK(query_result != SLANG_OK);
+    CHECK(queried == nullptr);
+
+    release_blocker.set_value();
+    cache->flush();
+
+    REQUIRE(cache->queryCache(key_blob, queried.writeRef()) == SLANG_OK);
+    CHECK(copy_blob(queried) == value2);
+}
+
+TEST_CASE("query_hit_updates_metadata_while_writer_is_busy")
+{
+    const std::filesystem::path cache_dir = testing::get_case_temp_directory() / "cache";
+    const ByteBlob queried_key{10};
+    const ByteBlob trigger_key{255};
+    const ByteBlob value(128 * 1024, 14);
+    const ByteBlob trigger_value(128 * 1024, 15);
+
+    ref<CacheWriter> writer = make_ref<CacheWriter>();
+    ref<PersistentCache> cache = make_ref<PersistentCache>(cache_dir, 8ull * 1024 * 1024, writer);
+
+    Slang::ComPtr<ISlangBlob> queried_key_blob = make_blob(queried_key);
+    Slang::ComPtr<ISlangBlob> trigger_key_blob = make_blob(trigger_key);
+    Slang::ComPtr<ISlangBlob> value_blob = make_blob(value);
+    Slang::ComPtr<ISlangBlob> trigger_value_blob = make_blob(trigger_value);
+
+    REQUIRE(cache->writeCache(queried_key_blob, value_blob) == SLANG_OK);
+    for (uint8_t i = 11; i < 54; ++i) {
+        Slang::ComPtr<ISlangBlob> key_blob = make_blob(ByteBlob{i});
+        REQUIRE(cache->writeCache(key_blob, value_blob) == SLANG_OK);
+    }
+    cache->flush();
+
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    auto blocker_started_future = blocker_started.get_future();
+    auto release_blocker_future = release_blocker.get_future().share();
+
+    REQUIRE(writer->enqueue(
+        1,
+        [&]
+        {
+            blocker_started.set_value();
+            release_blocker_future.wait();
+        }
+    ));
+    blocker_started_future.wait();
+
+    Slang::ComPtr<ISlangBlob> queried;
+    rhi::Result query_result = cache->queryCache(queried_key_blob, queried.writeRef());
+    CHECK(query_result == SLANG_OK);
+    if (query_result == SLANG_OK)
+        CHECK(copy_blob(queried) == value);
+
+    release_blocker.set_value();
+    cache->flush();
+
+    REQUIRE(cache->writeCache(trigger_key_blob, trigger_value_blob) == SLANG_OK);
+    cache->flush();
+    CHECK(cache->stats().entry_count < 45);
+
+    queried.setNull();
+    REQUIRE(cache->queryCache(queried_key_blob, queried.writeRef()) == SLANG_OK);
+    CHECK(copy_blob(queried) == value);
+}
+
+TEST_SUITE_END();

--- a/tests/sgl/device/test_persistent_cache.cpp
+++ b/tests/sgl/device/test_persistent_cache.cpp
@@ -288,7 +288,6 @@ TEST_CASE("query_hit_updates_metadata_while_writer_is_busy")
 {
     const std::filesystem::path cache_dir = testing::get_case_temp_directory() / "cache";
     const ByteBlob queried_key{10};
-    const ByteBlob trigger_key{255};
     const ByteBlob value(128 * 1024, 14);
     const ByteBlob trigger_value(128 * 1024, 15);
 
@@ -296,12 +295,11 @@ TEST_CASE("query_hit_updates_metadata_while_writer_is_busy")
     ref<PersistentCache> cache = make_ref<PersistentCache>(cache_dir, 8ull * 1024 * 1024, writer);
 
     Slang::ComPtr<ISlangBlob> queried_key_blob = make_blob(queried_key);
-    Slang::ComPtr<ISlangBlob> trigger_key_blob = make_blob(trigger_key);
     Slang::ComPtr<ISlangBlob> value_blob = make_blob(value);
     Slang::ComPtr<ISlangBlob> trigger_value_blob = make_blob(trigger_value);
 
     REQUIRE(cache->writeCache(queried_key_blob, value_blob) == SLANG_OK);
-    for (uint8_t i = 11; i < 54; ++i) {
+    for (uint8_t i = 11; i < 27; ++i) {
         Slang::ComPtr<ISlangBlob> key_blob = make_blob(ByteBlob{i});
         REQUIRE(cache->writeCache(key_blob, value_blob) == SLANG_OK);
     }
@@ -324,16 +322,25 @@ TEST_CASE("query_hit_updates_metadata_while_writer_is_busy")
 
     Slang::ComPtr<ISlangBlob> queried;
     rhi::Result query_result = cache->queryCache(queried_key_blob, queried.writeRef());
-    CHECK(query_result == SLANG_OK);
-    if (query_result == SLANG_OK)
-        CHECK(copy_blob(queried) == value);
+    REQUIRE(query_result == SLANG_OK);
+    CHECK(copy_blob(queried) == value);
 
     release_blocker.set_value();
     cache->flush();
 
-    REQUIRE(cache->writeCache(trigger_key_blob, trigger_value_blob) == SLANG_OK);
-    cache->flush();
-    CHECK(cache->stats().entry_count < 45);
+    bool eviction_observed = false;
+    uint64_t previous_entry_count = cache->stats().entry_count;
+    for (uint32_t i = 0; i < 200 && !eviction_observed; ++i) {
+        Slang::ComPtr<ISlangBlob> trigger_key_blob
+            = make_blob(ByteBlob{255, static_cast<uint8_t>(i), static_cast<uint8_t>(i >> 8)});
+        REQUIRE(cache->writeCache(trigger_key_blob, trigger_value_blob) == SLANG_OK);
+        cache->flush();
+
+        const uint64_t entry_count = cache->stats().entry_count;
+        eviction_observed = entry_count <= previous_entry_count;
+        previous_entry_count = entry_count;
+    }
+    REQUIRE(eviction_observed);
 
     queried.setNull();
     REQUIRE(cache->queryCache(queried_key_blob, queried.writeRef()) == SLANG_OK);


### PR DESCRIPTION
Adds `CacheWriter`, a background worker used to move persistent shader/cache writes off the foreground compilation path. Module cache file writes also use the shared writer, with cache bytes prepared only after queue capacity is reserved to keep pending memory bounded.
