### PR TITLE
Fix SlangPy test runner labels for slang PR testing

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -78,8 +78,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: windows, platform: x86_64, compiler: msvc, config: Release, python: "3.10", flags: "unit-test,test-examples,crashpad", runs-on: { group: nvrgfx, labels: [Windows, X64] } }
-          - { os: linux, platform: x86_64, compiler: gcc, config: Release, python: "3.10", flags: "unit-test,test-examples,crashpad", runs-on: { group: nvrgfx, labels: [Linux, X64] } }
+          - { os: windows, platform: x86_64, compiler: msvc, config: Release, python: "3.10", flags: "unit-test,test-examples,crashpad", runs-on: { labels: [Windows, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: linux, platform: x86_64, compiler: gcc, config: Release, python: "3.10", flags: "unit-test,test-examples,crashpad", runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
 
     env:
       CI_OS: ${{ matrix.os }}


### PR DESCRIPTION
## Motivation

Every shader-slang/slang PR currently fails its "SlangPy Tests" check. The check is driven by the `build-pr` job in `.github/workflows/ci-latest-slang.yml`, which runs when a slang PR fires a `repository_dispatch` event at this repo.

PR #1038 ("Switch to vm based bridge") migrated the self-hosted runner targeting from the `nvrgfx` runner group to the `nvrgfx-kernelvm-bridge` labels, but only updated the nightly `build` job. The `build-pr` job was missed and still targets the old group, so slang PR test jobs are dispatched to runners that no longer serve them.

## Proposed solution

Update the `build-pr` matrix to use the same `runs-on` values as the nightly `build` job in the same workflow, completing the migration started in #1038.

## Change summary

- `.github/workflows/ci-latest-slang.yml:81-82` — the two `build-pr` matrix entries change from `runs-on: { group: nvrgfx, labels: [Windows/Linux, X64] }` to `runs-on: { labels: [Windows/Linux, X64, nvrgfx-kernelvm-bridge] }`, matching the `build` job entries at lines 38-41.

## Process report

The nightly `build` job (upper section of the workflow) and the PR-triggered `build-pr` job (lower section) are intended to run on the same self-hosted runner pool; they differ only in matrix breadth and slang checkout mode. After #1038 they diverged: `build` uses the `nvrgfx-kernelvm-bridge` labels while `build-pr` still uses the retired `nvrgfx` group. Since nightly runs succeed on the new labels while PR runs fail on the old group, aligning `build-pr` with `build` is the principled fix rather than a workaround.

Note: `wheels.yml:403` (`upload_artifactory`, nightly/release only) also still uses `group: nvrgfx`. It is left out of this PR since it may have different runner requirements (Artifactory access) and is not part of the slang PR test failure.
