### PR TITLE
Make bound-variable recursion and tensor marshalls safe for reference-typed fields

### DIFF
--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -256,6 +256,16 @@ void NativeBoundVariableRuntime::write_shader_cursor_pre_dispatch(
         // We have children, so generate call data for each child and
         // store in a dictionary, then store the dictionary as the call data.
         ShaderCursor child_field = cursor[m_variable_name.c_str()];
+        // A reference-typed field is a ConstantBuffer/ParameterBlock sub-object —
+        // e.g. Slang's CUDA target passes an entry-point uniform struct containing a
+        // fixed-size descriptor array by reference as an implicit ParameterBlock.
+        // Dereference before recursing so that children see a cursor whose
+        // shader_object() owns the offsets they extract: field lookups on a
+        // reference cursor auto-dereference (yielding sub-object-relative offsets),
+        // so a child that cached those offsets but wrote through the parent's
+        // shader object would silently corrupt memory.
+        if (child_field.is_reference())
+            child_field = child_field.dereference();
         for (const auto& [name, child_ref] : *m_children) {
             if (child_ref) {
                 nb::object child_value = value[name.c_str()];

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -256,7 +256,7 @@ void NativeBoundVariableRuntime::write_shader_cursor_pre_dispatch(
         // We have children, so generate call data for each child and
         // store in a dictionary, then store the dictionary as the call data.
         ShaderCursor child_field = cursor[m_variable_name.c_str()];
-        // A reference-typed field is a ConstantBuffer/ParameterBlock sub-object —
+        // A reference-typed field is a ConstantBuffer/ParameterBlock sub-object -
         // e.g. Slang's CUDA target passes an entry-point uniform struct containing a
         // fixed-size descriptor array by reference as an implicit ParameterBlock.
         // Dereference before recursing so that children see a cursor whose

--- a/src/slangpy_ext/utils/slangpytensor.cpp
+++ b/src/slangpy_ext/utils/slangpytensor.cpp
@@ -219,7 +219,7 @@ void TensorMarshall::ensure_binding_info_cached(ShaderCursor cursor, NativeBound
         // reference-typed field (a ConstantBuffer/ParameterBlock sub-object) breaks
         // that assumption: nested field lookups auto-dereference into the
         // sub-object, so the cached offsets would be sub-object-relative while the
-        // write targets the parent object — silent corruption. Tensor types are
+        // write targets the parent object - silent corruption. Tensor types are
         // never passed by reference themselves, and reference-typed *enclosing*
         // structs are dereferenced before recursion (see
         // NativeBoundVariableRuntime::write_shader_cursor_pre_dispatch), so fail

--- a/src/slangpy_ext/utils/slangpytensor.cpp
+++ b/src/slangpy_ext/utils/slangpytensor.cpp
@@ -214,6 +214,22 @@ void TensorMarshall::ensure_binding_info_cached(ShaderCursor cursor, NativeBound
 {
     if (!m_cached_binding_info.primal.is_valid) {
         ShaderCursor field = cursor[binding->variable_name()];
+        // The cached-offset fast path below assumes the tensor's fields live in
+        // `cursor.shader_object()` at offsets relative to that object. A
+        // reference-typed field (a ConstantBuffer/ParameterBlock sub-object) breaks
+        // that assumption: nested field lookups auto-dereference into the
+        // sub-object, so the cached offsets would be sub-object-relative while the
+        // write targets the parent object — silent corruption. Tensor types are
+        // never passed by reference themselves, and reference-typed *enclosing*
+        // structs are dereferenced before recursion (see
+        // NativeBoundVariableRuntime::write_shader_cursor_pre_dispatch), so fail
+        // loudly if one ever reaches this point.
+        SGL_CHECK(
+            !field.is_reference(),
+            "Tensor binding '{}' is reference-typed (a parameter-group sub-object); "
+            "the cached-offset writer does not support this shape",
+            binding->variable_name()
+        );
         m_cached_binding_info = extract_binding_info(field);
     }
 }

--- a/src/slangpy_ext/utils/slangpytorchtensor.cpp
+++ b/src/slangpy_ext/utils/slangpytorchtensor.cpp
@@ -222,6 +222,15 @@ void NativeTorchTensorMarshall::ensure_binding_info_cached(
 {
     if (!m_cached_binding_info.primal.is_valid) {
         ShaderCursor field = cursor[binding->variable_name()];
+        // See TensorMarshall::ensure_binding_info_cached: the cached-offset writer
+        // requires the field's offsets to be relative to `cursor.shader_object()`,
+        // which a reference-typed (parameter-group sub-object) field violates.
+        SGL_CHECK(
+            !field.is_reference(),
+            "Torch tensor binding '{}' is reference-typed (a parameter-group sub-object); "
+            "the cached-offset writer does not support this shape",
+            binding->variable_name()
+        );
         m_cached_binding_info = TensorMarshall::extract_binding_info(field);
 
         // Determine copy-back flags from the Slang uniform type name.

--- a/src/slangpy_ext/utils/slangpyvalue.cpp
+++ b/src/slangpy_ext/utils/slangpyvalue.cpp
@@ -16,8 +16,21 @@ void NativeValueMarshall::ensure_cached(ShaderCursor cursor, NativeBoundVariable
 {
     if (m_cached.is_valid)
         return;
-    ShaderCursor field
-        = binding->direct_bind() ? cursor[binding->variable_name()] : cursor[binding->variable_name()]["value"];
+    ShaderCursor field = cursor[binding->variable_name()];
+    // A reference-typed field is a ConstantBuffer/ParameterBlock sub-object — e.g.
+    // Slang's CUDA target passes an entry-point uniform struct carrying a fixed-size
+    // descriptor array (such as the vectorized-array wrapper Array1DValueType holding
+    // tensors) by reference. Nested lookups below auto-dereference into the
+    // sub-object, making every cached offset sub-object-relative, so the write must
+    // target the sub-object's ShaderObject (see write_shader_cursor_pre_dispatch);
+    // writing through the parent object with these offsets would corrupt memory.
+    m_cached.field_is_reference = field.is_reference();
+    if (m_cached.field_is_reference) {
+        m_cached.field_index = cursor.find_field_index(binding->variable_name());
+        field = field.dereference();
+    }
+    if (!binding->direct_bind())
+        field = field["value"];
     m_cached.value_offset = field.offset();
     m_cached.value_type_layout = field.slang_type_layout();
     m_cached.writer = get_shader_cursor_writer(m_cached.value_type_layout);
@@ -38,7 +51,13 @@ void NativeValueMarshall::write_shader_cursor_pre_dispatch(
     AccessType primal_access = binding->access().first;
     if (!value.is_none() && (primal_access == AccessType::read || primal_access == AccessType::readwrite)) {
         ensure_cached(cursor, binding);
-        ShaderCursor value_cursor(cursor.shader_object(), m_cached.value_type_layout, m_cached.value_offset);
+        // For a reference-typed field the cached offsets are relative to the
+        // sub-object; re-resolve it (cheap: cached field index + object lookup) and
+        // write there instead of into the parent object.
+        ShaderObject* target_object = cursor.shader_object();
+        if (m_cached.field_is_reference)
+            target_object = cursor.get_field_by_index(m_cached.field_index).dereference().shader_object();
+        ShaderCursor value_cursor(target_object, m_cached.value_type_layout, m_cached.value_offset);
         if (m_cached.writer) {
             m_cached.writer(value_cursor, value);
         } else {

--- a/src/slangpy_ext/utils/slangpyvalue.cpp
+++ b/src/slangpy_ext/utils/slangpyvalue.cpp
@@ -17,7 +17,7 @@ void NativeValueMarshall::ensure_cached(ShaderCursor cursor, NativeBoundVariable
     if (m_cached.is_valid)
         return;
     ShaderCursor field = cursor[binding->variable_name()];
-    // A reference-typed field is a ConstantBuffer/ParameterBlock sub-object — e.g.
+    // A reference-typed field is a ConstantBuffer/ParameterBlock sub-object - e.g.
     // Slang's CUDA target passes an entry-point uniform struct carrying a fixed-size
     // descriptor array (such as the vectorized-array wrapper Array1DValueType holding
     // tensors) by reference. Nested lookups below auto-dereference into the

--- a/src/slangpy_ext/utils/slangpyvalue.h
+++ b/src/slangpy_ext/utils/slangpyvalue.h
@@ -35,6 +35,12 @@ private:
         slang::TypeLayoutReflection* value_type_layout = nullptr; ///< Type layout for value field.
         std::function<void(ShaderCursor&, nb::object)> writer;    ///< Pre-resolved writer fn.
         bool direct_bind{false};                                  ///< direct_bind value used when populating cache.
+        /// True when the bound field is reference-typed (a ConstantBuffer/ParameterBlock
+        /// sub-object, e.g. Slang's CUDA by-reference ABI for descriptor-table-carrying
+        /// uniforms). value_offset is then relative to the sub-object, and writes must
+        /// target the sub-object's ShaderObject rather than the parent's.
+        bool field_is_reference{false};
+        int32_t field_index{-1}; ///< Cached field index for the per-dispatch dereference.
         bool is_valid = false;
     };
 


### PR DESCRIPTION
## Motivation

Slang's CUDA target is gaining a by-reference ABI for entry-point uniform structs that carry descriptor tables — fixed-size arrays of resources or pointer-backed tensors (shader-slang/slang#11774): such a parameter reflects as an implicit `ParameterBlock` sub-object occupying 8 bytes of kernel-argument space, with the payload in device global memory.

`NativeBoundVariableRuntime::write_shader_cursor_pre_dispatch` navigates into a bound struct argument with `cursor[name]` and passes the resulting cursor to children. For a reference-typed field, sgl field lookups auto-dereference into the sub-object (the shader-cursor "Just Work" path), so a child marshall extracts **sub-object-relative** offsets — while `cursor.shader_object()` still returns the **parent** object. A cached-offset writer like `TensorMarshall` (`reserve_data(field_offset, field_size)` + raw writes) would then silently corrupt the parent object's memory.

## Proposed solution

- **One fix point, at the recursion site** (`slangpy.cpp`): if the child field cursor `is_reference()`, dereference it before recursing — children always receive a cursor whose `shader_object()` owns the offsets they extract. This is the same pattern the `ParameterBlock<CallData>` fallback path already uses for `call_data`, and covers every leaf marshall at once.
- **Reference-aware `NativeValueMarshall`** (`slangpyvalue.cpp/h`): the vectorized-array path binds a generated `Array1DValueType<T,N>` struct wrapping the array; when `T` carries descriptors (tensors, buffers) the parameter converts, and `ensure_cached`'s `cursor[name]["value"]` navigation crossed the reference boundary — cached a sub-object-relative offset, then wrote through the **parent** object. This was the actual heap corruption observed on L40S in `test_vectorize_struct_with_tensor_array` / `test_vectorize_struct_with_resource_array` / `test_2d_mapped_vectorize_struct_with_tensor_array` (CUDA-only; Vulkan never converts). The marshall now dereferences explicitly, caches the field index, and targets the sub-object's `ShaderObject` at write time.
- **Loud guards in the cached-offset tensor writers** (`slangpytensor.cpp`, `slangpytorchtensor.cpp`): `SGL_CHECK(!field.is_reference(), ...)` in the offset-caching path. Tensor types themselves are never passed by reference, so the check never fires on supported shapes — it converts any unexpected future shape or compiler/host version skew from silent memory corruption into a hard error.

The change is compatible with current Slang (every `is_reference()` is simply false today, so behavior is unchanged) and **must land before slangpy bumps to a Slang containing the new ABI**.

## What was deliberately not changed

`estimate_entrypoint_arguments_size` still counts a convertible parameter at its by-value size. Correcting it to 8 bytes would require re-implementing the compiler's conversion predicate host-side — a second source of truth that can drift. The error direction is safe: over-estimation only pushes toward the `ParameterBlock<CallData>` fallback path.

## Follow-up (separate PR, after the slang bump)

Bump the pinned Slang, verify `test_benchmark_tensor.py::test_tensor_sum_indirect` reaches parity with the forced-PB numbers (≈0.026/≈0.195 ms count 16/32 on L40S), then retire the #1030 CUDA routing heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
