### PR TITLE
Profiler

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,7 @@ If you use SlangPy in a research project leading to a publication, please cite t
     :hidden:
 
     src/developer_guide
+    src/profiling
 
 .. toctree::
     :maxdepth: 1

--- a/docs/src/profiling.rst
+++ b/docs/src/profiling.rst
@@ -17,10 +17,11 @@ profilers do not replace it; use the ``Profiler`` context manager to select one 
 free-standing ``profile_zone`` and ``profile_function`` contexts use this current profiler, while
 ``profile_frame`` establishes its frame boundaries. These profiling contexts never change the
 current profiler and become no-ops when none is current, so instrumented functions do not need to
-receive or look up a profiler. Supplying a command encoder to a zone or function adds GPU
-timestamps. A frame establishes both the frame timeline and the explicit boundaries used by live
-frame statistics. Zones outside a frame remain available in traces but do not contribute to frame
-statistics.
+receive or look up a profiler. They also become no-ops while the current profiler is disabled, so
+no zones are recorded until it is enabled again. Supplying a command encoder to a zone or function
+adds GPU timestamps. A frame establishes both the frame timeline and the explicit boundaries used
+by live frame statistics. Zones outside a frame remain available in traces but do not contribute to
+frame statistics.
 
 Default activation is thread-local. An automatically installed profiler must be destroyed on its
 constructing thread after temporary profiler contexts on that thread have exited. Its destructor
@@ -42,9 +43,9 @@ submission, command-buffer discard, or device close operations associated with r
     profiler.tick()
 
 ``tick()`` does not deliberately wait for profiled submissions or unresolved timestamp queries.
-Refreshing the mapping between CPU and GPU timestamp clocks can nevertheless synchronize queued
-GPU work on some backends, notably CUDA. Calibration is cached per device queue and refreshed at
-most once every two seconds when resolved timestamp data actually needs conversion.
+On CUDA, refreshing the mapping between CPU and GPU timestamp clocks synchronizes queued GPU work.
+Calibration is cached per device queue and refreshed at most once every two seconds when resolved
+timestamp data actually needs conversion.
 
 ``profile_function`` derives its zone name and profiling-site metadata from its Python caller:
 

--- a/docs/src/profiling.rst
+++ b/docs/src/profiling.rst
@@ -1,0 +1,180 @@
+.. _sec-profiling:
+
+CPU and GPU profiling
+=====================
+
+SlangPy includes a bounded instrumentation profiler for CPU work, command-buffer GPU work,
+and functional SlangPy dispatches. It is intended for continuously running shader and
+hot-reload applications: live history defaults to 120 frames and 100,000 zones, and producer
+queues never block when full.
+
+Basic use
+---------
+
+Activate a profiler around code whose automatic functional dispatches should be measured.
+The first ``Profiler`` created on a thread becomes that thread's default current profiler. Later
+profilers do not replace it; use the ``Profiler`` context manager to select one temporarily. The
+free-standing ``profile_zone`` and ``profile_function`` contexts use this current profiler, while
+``profile_frame`` establishes its frame boundaries. These profiling contexts never change the
+current profiler and become no-ops when none is current, so instrumented functions do not need to
+receive or look up a profiler. Supplying a command encoder to a zone or function adds GPU
+timestamps. A frame establishes both the frame timeline and the explicit boundaries used by live
+frame statistics. Zones outside a frame remain available in traces but do not contribute to frame
+statistics.
+
+Default activation is thread-local. An automatically installed profiler must be destroyed on its
+constructing thread after temporary profiler contexts on that thread have exited. Its destructor
+removes the default entry when it is the only remaining stack entry. Worker threads can select an
+existing profiler temporarily with ``with profiler:``. Profiler destruction must not race device
+submission, command-buffer discard, or device close operations associated with recorded GPU zones.
+
+.. code-block:: python
+
+    profiler = spy.Profiler()
+
+    with spy.profile_frame("frame"):
+        command_encoder = device.create_command_encoder()
+        with spy.profile_zone("simulation", command_encoder):
+            module.simulate(_append_to=command_encoder)
+        device.submit_command_buffer(command_encoder.finish())
+
+    # Poll submitted timestamp queries once per application frame.
+    profiler.tick()
+
+``tick()`` does not deliberately wait for profiled submissions or unresolved timestamp queries.
+Refreshing the mapping between CPU and GPU timestamp clocks can nevertheless synchronize queued
+GPU work on some backends, notably CUDA. Calibration is cached per device queue and refreshed at
+most once every two seconds when resolved timestamp data actually needs conversion.
+
+``profile_function`` derives its zone name and profiling-site metadata from its Python caller:
+
+.. code-block:: python
+
+    def render(command_encoder: spy.CommandEncoder) -> None:
+        with spy.profile_function(command_encoder):
+            module.render(_append_to=command_encoder)
+
+The profiler UI must be rendered inside an active ImGui frame. It shows cached, frame-aligned
+numeric statistics; rendering it does not poll GPU work or copy an active capture. Detailed
+event timelines are exported to Perfetto rather than rendered in the embedded window.
+
+.. code-block:: python
+
+    spy.ui.render_profiler_window(profiler)
+
+See ``examples/window/window.py`` for an interactive integration.
+
+Bounded captures and GPU completion
+-----------------------------------
+
+Captures have a 256 MiB default memory limit. A capture stops automatically before exceeding
+its limit and reports ``truncated=True`` with the ``memory_limit`` stop reason. Producer-ring
+overflow and GPU-query exhaustion drop complete measurements instead of blocking. The trace
+and frame statistics expose these counters through their ``diagnostics`` property:
+
+* ``diagnostics.producer_drop_count`` counts events dropped because a per-thread event queue or zone stack
+  was full.
+* ``diagnostics.thread_event_queue_high_water_mark`` is the maximum number of unread events observed in any
+  per-thread producer queue.
+* ``diagnostics.hierarchy_loss_count`` counts statistics nodes promoted to roots because their parent event
+  was unavailable when the worker finalized orphaned events.
+* ``diagnostics.gpu_query_exhaustion_count`` counts GPU zones that retained CPU timing but could not allocate
+  a GPU timestamp-query pair.
+
+``stop_capture`` performs one ``tick`` and flushes CPU producer queues, but it does not deliberately
+wait for submitted GPU work or unresolved timestamp queries. The tick can still synchronize during
+a backend timestamp-calibration refresh as described above. To require every submitted GPU
+measurement in a capture, use this order:
+
+.. code-block:: python
+
+    device.wait()
+    profiler.tick()
+    trace = profiler.stop_capture()
+
+Otherwise unresolved GPU zones are omitted and reported by ``diagnostics.pending_gpu_zone_count``.
+
+GPU timestamp calibration is cached independently for each device queue and refreshed at most
+once every two seconds when resolved timestamp data actually needs conversion. GPU durations are
+calculated directly from timestamp differences; calibration only aligns their start times with
+the CPU timeline.
+
+Frame statistics
+----------------
+
+``frame_stats_snapshot()`` returns immutable statistics for one global frame stream. At most one
+frame can be open or closing at a time, and zones from any CPU thread are attached to that frame.
+The frame name remains trace metadata rather than selecting a separate statistics history. The
+snapshot retains at most ``ProfilerDesc.frame_stats_window_size`` completed frames.
+Frames with allocated GPU timestamps remain pending until those timestamps resolve; a bounded
+fallback reports missing GPU data rather than allowing an abandoned command buffer to stall the
+history indefinitely.
+
+Repeated occurrences of the same hierarchical zone path are summed within each frame. A zone
+that does not run contributes zero CPU time and zero calls to that frame, so parent and child
+rows always describe the same frame window. Per-call summaries retain exact count, total,
+minimum, maximum, mean, and standard deviation without retaining every call duration.
+
+Per-path frame time is the sum of inclusive occurrence durations at that path. Parent and child
+rows are therefore not additive. Summed GPU duration can also exceed elapsed frame time when GPU
+work overlaps. GPU frame statistics omit unavailable and incomplete measurements. Coverage is
+derived from the entry-aligned GPU-status matrix rather than duplicated on each entry.
+
+``ProfilerFrameStats`` exposes retained history as zero-copy, read-only NumPy arrays.
+``sample_frame_index`` and ``sample_frame_time_ms`` have shape ``(sample_count,)``. The call-count,
+CPU-time, GPU-time, and GPU-status arrays have row-major shape ``(sample_count, entry_count)``.
+GPU status distinguishes absent zones, zones without requested GPU timing, complete measurements,
+and incomplete requested measurements. Call-frequency summaries likewise derive from
+``sample_call_count`` rather than being stored redundantly on each entry.
+
+.. code-block:: python
+
+    stats = profiler.frame_stats_snapshot()
+    print(stats.frame_time.mean_ms, stats.frame_time.p95_ms)
+    for entry in stats.entries:
+        print(entry.name, entry.cpu_time_per_frame.mean_ms)
+    print(stats.sample_cpu_time_ms.shape)
+
+    profiler.clear_frame_stats()
+
+Queries and export
+------------------
+
+Queries run natively over immutable 4,096-zone column chunks. Chunking bounds individual
+allocations and lets queries and trace export stream through large captures without first
+flattening every zone. Names match exactly, and frame and timestamp ranges are half-open.
+Column properties are zero-copy, read-only NumPy arrays; retaining an array also retains its
+native chunk.
+
+Profiler-site filenames, compact function names, and labels are interned once in process-lifetime
+storage. Native compiler signatures are shortened to qualified function names for display, while
+their full signatures remain internal identity keys. Site snapshots therefore copy stable string
+views rather than owning duplicate metadata strings.
+
+Python profiling contexts additionally cache their resolved native site IDs in a bounded cache.
+The cache distinguishes the caller's code object, exact bytecode call expression, and requested
+name. Repeated scopes therefore avoid rebuilding filename and qualified-function
+strings or entering the process-global site registry. Calls with identical filename, line,
+function, and name metadata resolve to the same native profiling site.
+
+.. code-block:: python
+
+    selection = trace.query_zones(
+        name="simulation",
+        timeline_type=spy.ProfilerTimelineType.gpu,
+        frame_begin=10,
+        frame_end=20,
+    )
+    print(selection.statistics().p95_ms)
+    print(profiler.frame_stats_snapshot())
+    trace.write_to_json("capture.json")
+
+The frame-statistics string contains diagnostic counters followed by the global frame stream's
+indented CPU/GPU timing hierarchy, which is suitable for terminal logs and coding agents.
+
+The JSON writer streams Chrome trace-event JSON suitable for Perfetto without flattening the
+chunks first. Profiler timestamps are nanoseconds from a monotonic steady clock and have no
+wall-clock meaning. GPU timestamps are calibrated into that clock domain.
+
+CPU sampling is not part of this profiler version. It is planned as a separate sampling track
+that will reuse the trace, query, and export model.

--- a/docs/src/profiling.rst
+++ b/docs/src/profiling.rst
@@ -62,7 +62,7 @@ event timelines are exported to Perfetto rather than rendered in the embedded wi
 
     spy.ui.render_profiler_window(profiler)
 
-See ``examples/window/window.py`` for an interactive integration.
+See ``examples/pathtracer/pathtracer.py`` and ``examples/pathtracer/pathtracer.cpp`` for interactive integrations.
 
 Bounded captures and GPU completion
 -----------------------------------

--- a/examples/pathtracer/pathtracer.cpp
+++ b/examples/pathtracer/pathtracer.cpp
@@ -773,7 +773,6 @@ struct App {
             .resizable = true,
         });
         device = Device::create({
-            .type = DeviceType::cuda,
             .enable_debug_layers = true,
             .compiler_options = {
                 .include_paths = {EXAMPLE_DIR},

--- a/examples/pathtracer/pathtracer.cpp
+++ b/examples/pathtracer/pathtracer.cpp
@@ -21,6 +21,10 @@
 #include "sgl/device/surface.h"
 #include "sgl/device/agility_sdk.h"
 
+#include "sgl/ui/ui.h"
+
+#include "sgl/utils/profiler.h"
+#include "sgl/utils/profiler_ui.h"
 #include "sgl/utils/tev.h"
 
 #include <map>
@@ -652,6 +656,7 @@ struct PathTracer {
 
     void execute(ref<CommandEncoder> command_encoder, ref<Texture> output, uint32_t frame)
     {
+        SGL_PROFILE_FUNCTION(command_encoder);
         if (USE_RAYTRACING_PIPELINE) {
             ref<RayTracingPassEncoder> pass_encoder = command_encoder->begin_ray_tracing_pass();
             ShaderObject* shader_object = pass_encoder->bind_pipeline(rt_pipeline, shader_table);
@@ -689,6 +694,7 @@ struct Accumulator {
 
     void execute(ref<CommandEncoder> command_encoder, ref<Texture> input, ref<Texture> output, bool reset = false)
     {
+        SGL_PROFILE_FUNCTION(command_encoder);
         if (!accumulator || accumulator->width() != input->width() || accumulator->height() != input->height()) {
             accumulator = device->create_texture({
                 .format = Format::rgba32_float,
@@ -727,6 +733,7 @@ struct ToneMapper {
 
     void execute(ref<CommandEncoder> command_encoder, ref<Texture> input, ref<Texture> output)
     {
+        SGL_PROFILE_FUNCTION(command_encoder);
         kernel->dispatch(
             uint3(input->width(), input->height(), 1),
             [&](ShaderCursor cursor)
@@ -753,6 +760,9 @@ struct App {
     std::unique_ptr<PathTracer> path_tracer;
     std::unique_ptr<Accumulator> accumulator;
     std::unique_ptr<ToneMapper> tone_mapper;
+    ref<ui::Context> ui_context;
+    ref<Profiler> profiler;
+    bool show_profiler{false};
 
     App()
     {
@@ -763,7 +773,7 @@ struct App {
             .resizable = true,
         });
         device = Device::create({
-            // .type = DeviceType::cuda,
+            .type = DeviceType::cuda,
             .enable_debug_layers = true,
             .compiler_options = {
                 .include_paths = {EXAMPLE_DIR},
@@ -775,6 +785,10 @@ struct App {
             .height = window->height(),
             .vsync = false,
         });
+
+        ui_context = make_ref<ui::Context>(device);
+        profiler = make_ref<Profiler>();
+        profiler->set_enabled(false);
 
         window->set_on_keyboard_event(
             [this](const KeyboardEvent& event)
@@ -807,6 +821,9 @@ struct App {
 
     void on_keyboard_event(const KeyboardEvent& event)
     {
+        if (ui_context->handle_keyboard_event(event))
+            return;
+
         if (event.type == KeyboardEventType::key_press) {
             if (event.key == KeyCode::escape) {
                 window->close();
@@ -819,12 +836,22 @@ struct App {
                     bitmap->convert(Bitmap::PixelFormat::rgb, Bitmap::ComponentType::uint8, true)
                         ->write_async("screenshot.png");
                 }
+            } else if (event.key == KeyCode::p) {
+                show_profiler = !show_profiler;
+                if (show_profiler && !profiler->enabled())
+                    profiler->set_enabled(true);
             }
         }
         camera_controller->on_keyboard_event(event);
     }
 
-    void on_mouse_event(const MouseEvent& event) { camera_controller->on_mouse_event(event); }
+    void on_mouse_event(const MouseEvent& event)
+    {
+        if (ui_context->handle_mouse_event(event))
+            return;
+
+        camera_controller->on_mouse_event(event);
+    }
 
     void on_resize(uint32_t width, uint32_t height)
     {
@@ -859,50 +886,64 @@ struct App {
             if (!surface_texture)
                 continue;
 
-            if (!output_texture || output_texture->width() != surface_texture->width()
-                || output_texture->height() != surface_texture->height()) {
-                output_texture = device->create_texture({
-                    .format = Format::rgba32_float,
-                    .width = surface_texture->width(),
-                    .height = surface_texture->height(),
-                    .usage = TextureUsage::shader_resource | TextureUsage::unordered_access,
-                    .label = "output_texture",
-                });
-                render_texture = device->create_texture({
-                    .format = Format::rgba32_float,
-                    .width = surface_texture->width(),
-                    .height = surface_texture->height(),
-                    .usage = TextureUsage::shader_resource | TextureUsage::unordered_access,
-                    .label = "render_texture",
-                });
-                accum_texture = device->create_texture({
-                    .format = Format::rgba32_float,
-                    .width = surface_texture->width(),
-                    .height = surface_texture->height(),
-                    .usage = TextureUsage::shader_resource | TextureUsage::unordered_access,
-                    .label = "accum_texture",
-                });
-            }
-
-            stage->camera.width = surface_texture->width();
-            stage->camera.height = surface_texture->height();
-            stage->camera.recompute();
-
-            ref<CommandEncoder> command_encoder = device->create_command_encoder();
             {
-                path_tracer->execute(command_encoder, render_texture, frame);
-                accumulator->execute(command_encoder, render_texture, accum_texture, frame == 0);
-                tone_mapper->execute(command_encoder, accum_texture, output_texture);
+                SGL_PROFILE_FRAME("pathtracer frame");
+
+                ui_context->begin_frame(surface_texture->width(), surface_texture->height(), window);
+                if (show_profiler)
+                    ui::render_profiler_window(profiler);
+
+                if (!output_texture || output_texture->width() != surface_texture->width()
+                    || output_texture->height() != surface_texture->height()) {
+                    output_texture = device->create_texture({
+                        .format = Format::rgba32_float,
+                        .width = surface_texture->width(),
+                        .height = surface_texture->height(),
+                        .usage = TextureUsage::shader_resource | TextureUsage::unordered_access,
+                        .label = "output_texture",
+                    });
+                    render_texture = device->create_texture({
+                        .format = Format::rgba32_float,
+                        .width = surface_texture->width(),
+                        .height = surface_texture->height(),
+                        .usage = TextureUsage::shader_resource | TextureUsage::unordered_access,
+                        .label = "render_texture",
+                    });
+                    accum_texture = device->create_texture({
+                        .format = Format::rgba32_float,
+                        .width = surface_texture->width(),
+                        .height = surface_texture->height(),
+                        .usage = TextureUsage::shader_resource | TextureUsage::unordered_access,
+                        .label = "accum_texture",
+                    });
+                }
+
+                stage->camera.width = surface_texture->width();
+                stage->camera.height = surface_texture->height();
+                stage->camera.recompute();
+
+                ref<CommandEncoder> command_encoder = device->create_command_encoder();
+                {
+                    SGL_PROFILE_ZONE("render", command_encoder);
+                    path_tracer->execute(command_encoder, render_texture, frame);
+                    accumulator->execute(command_encoder, render_texture, accum_texture, frame == 0);
+                    tone_mapper->execute(command_encoder, accum_texture, output_texture);
+                }
 
                 command_encoder->blit(surface_texture, output_texture);
+                ui_context->end_frame(surface_texture, command_encoder);
+                device->submit_command_buffer(command_encoder->finish());
             }
-            device->submit_command_buffer(command_encoder->finish());
+
+            profiler->tick();
 
             surface->present();
 
             frame++;
         }
 
+        device->wait();
+        profiler->tick();
         device->close();
     }
 };

--- a/examples/pathtracer/pathtracer.py
+++ b/examples/pathtracer/pathtracer.py
@@ -588,29 +588,30 @@ class PathTracer:
             self.pipeline = self.device.create_compute_pipeline(self.program)
 
     def execute(self, command_encoder: spy.CommandEncoder, output: spy.Texture, frame: int):
-        w = output.width
-        h = output.height
+        with spy.profile_function(command_encoder):
+            w = output.width
+            h = output.height
 
-        self.scene.camera.width = w
-        self.scene.camera.height = h
-        self.scene.camera.recompute()
+            self.scene.camera.width = w
+            self.scene.camera.height = h
+            self.scene.camera.recompute()
 
-        if USE_RAYTRACING_PIPELINE:
-            with command_encoder.begin_ray_tracing_pass() as pass_encoder:
-                shader_object = pass_encoder.bind_pipeline(self.rt_pipeline, self.shader_table)
-                cursor = spy.ShaderCursor(shader_object)
-                cursor.g_output = output
-                cursor.g_frame = frame
-                self.scene.bind(cursor.g_scene)
-                pass_encoder.dispatch_rays(0, [w, h, 1])
-        else:
-            with command_encoder.begin_compute_pass() as pass_encoder:
-                shader_object = pass_encoder.bind_pipeline(self.pipeline)
-                cursor = spy.ShaderCursor(shader_object)
-                cursor.g_output = output
-                cursor.g_frame = frame
-                self.scene.bind(cursor.g_scene)
-                pass_encoder.dispatch(thread_count=[w, h, 1])
+            if USE_RAYTRACING_PIPELINE:
+                with command_encoder.begin_ray_tracing_pass() as pass_encoder:
+                    shader_object = pass_encoder.bind_pipeline(self.rt_pipeline, self.shader_table)
+                    cursor = spy.ShaderCursor(shader_object)
+                    cursor.g_output = output
+                    cursor.g_frame = frame
+                    self.scene.bind(cursor.g_scene)
+                    pass_encoder.dispatch_rays(0, [w, h, 1])
+            else:
+                with command_encoder.begin_compute_pass() as pass_encoder:
+                    shader_object = pass_encoder.bind_pipeline(self.pipeline)
+                    cursor = spy.ShaderCursor(shader_object)
+                    cursor.g_output = output
+                    cursor.g_frame = frame
+                    self.scene.bind(cursor.g_scene)
+                    pass_encoder.dispatch(thread_count=[w, h, 1])
 
 
 class Accumulator:
@@ -628,30 +629,31 @@ class Accumulator:
         output: spy.Texture,
         reset: bool = False,
     ):
-        if (
-            self.accumulator == None
-            or self.accumulator.width != input.width
-            or self.accumulator.height != input.height
-        ):
-            self.accumulator = self.device.create_texture(
-                format=spy.Format.rgba32_float,
-                width=input.width,
-                height=input.height,
-                usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
-                label="accumulator",
+        with spy.profile_function(command_encoder):
+            if (
+                self.accumulator == None
+                or self.accumulator.width != input.width
+                or self.accumulator.height != input.height
+            ):
+                self.accumulator = self.device.create_texture(
+                    format=spy.Format.rgba32_float,
+                    width=input.width,
+                    height=input.height,
+                    usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+                    label="accumulator",
+                )
+            self.kernel.dispatch(
+                thread_count=[input.width, input.height, 1],
+                vars={
+                    "g_accumulator": {
+                        "input": input,
+                        "output": output,
+                        "accumulator": self.accumulator,
+                        "reset": reset,
+                    }
+                },
+                command_encoder=command_encoder,
             )
-        self.kernel.dispatch(
-            thread_count=[input.width, input.height, 1],
-            vars={
-                "g_accumulator": {
-                    "input": input,
-                    "output": output,
-                    "accumulator": self.accumulator,
-                    "reset": reset,
-                }
-            },
-            command_encoder=command_encoder,
-        )
 
 
 class ToneMapper:
@@ -667,16 +669,17 @@ class ToneMapper:
         input: spy.Texture,
         output: spy.Texture,
     ):
-        self.kernel.dispatch(
-            thread_count=[input.width, input.height, 1],
-            vars={
-                "g_tone_mapper": {
-                    "input": input,
-                    "output": output,
-                }
-            },
-            command_encoder=command_encoder,
-        )
+        with spy.profile_function(command_encoder):
+            self.kernel.dispatch(
+                thread_count=[input.width, input.height, 1],
+                vars={
+                    "g_tone_mapper": {
+                        "input": input,
+                        "output": output,
+                    }
+                },
+                command_encoder=command_encoder,
+            )
 
 
 class App:
@@ -691,6 +694,11 @@ class App:
         )
         self.surface = self.device.create_surface(self.window)
         self.surface.configure(width=self.window.width, height=self.window.height, vsync=False)
+
+        self.ui = spy.ui.Context(self.device)
+        self.profiler = spy.Profiler()
+        self.profiler.enabled = False
+        self.show_profiler = False
 
         self.render_texture: spy.Texture = None  # type: ignore (will be set immediately)
         self.accum_texture: spy.Texture = None  # type: ignore (will be set immediately)
@@ -710,6 +718,9 @@ class App:
         self.tone_mapper = ToneMapper(self.device)
 
     def on_keyboard_event(self, event: spy.KeyboardEvent):
+        if self.ui.handle_keyboard_event(event):
+            return
+
         if event.type == spy.KeyboardEventType.key_press:
             if event.key == spy.KeyCode.escape:
                 self.window.close()
@@ -724,10 +735,17 @@ class App:
                         spy.Bitmap.ComponentType.uint8,
                         srgb_gamma=True,
                     ).write_async("screenshot.png")
+            elif event.key == spy.KeyCode.p:
+                self.show_profiler = not self.show_profiler
+                if self.show_profiler and not self.profiler.enabled:
+                    self.profiler.enabled = True
 
         self.camera_controller.on_keyboard_event(event)
 
     def on_mouse_event(self, event: spy.MouseEvent):
+        if self.ui.handle_mouse_event(event):
+            return
+
         self.camera_controller.on_mouse_event(event)
 
     def on_resize(self, width: int, height: int):
@@ -755,43 +773,59 @@ class App:
             if not surface_texture:
                 continue
 
-            if (
-                self.output_texture == None
-                or self.output_texture.width != surface_texture.width
-                or self.output_texture.height != surface_texture.height
-            ):
-                self.output_texture = self.device.create_texture(
-                    format=spy.Format.rgba32_float,
-                    width=surface_texture.width,
-                    height=surface_texture.height,
-                    usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
-                    label="output_texture",
-                )
-                self.render_texture = self.device.create_texture(
-                    format=spy.Format.rgba32_float,
-                    width=surface_texture.width,
-                    height=surface_texture.height,
-                    usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
-                    label="render_texture",
-                )
-                self.accum_texture = self.device.create_texture(
-                    format=spy.Format.rgba32_float,
-                    width=surface_texture.width,
-                    height=surface_texture.height,
-                    usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
-                    label="accum_texture",
-                )
+            with spy.profile_frame("pathtracer frame"):
+                self.ui.begin_frame(surface_texture.width, surface_texture.height)
+                if self.show_profiler:
+                    spy.ui.render_profiler_window(self.profiler)
 
-            command_encoder = self.device.create_command_encoder()
+                if (
+                    self.output_texture == None
+                    or self.output_texture.width != surface_texture.width
+                    or self.output_texture.height != surface_texture.height
+                ):
+                    self.output_texture = self.device.create_texture(
+                        format=spy.Format.rgba32_float,
+                        width=surface_texture.width,
+                        height=surface_texture.height,
+                        usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+                        label="output_texture",
+                    )
+                    self.render_texture = self.device.create_texture(
+                        format=spy.Format.rgba32_float,
+                        width=surface_texture.width,
+                        height=surface_texture.height,
+                        usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+                        label="render_texture",
+                    )
+                    self.accum_texture = self.device.create_texture(
+                        format=spy.Format.rgba32_float,
+                        width=surface_texture.width,
+                        height=surface_texture.height,
+                        usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+                        label="accum_texture",
+                    )
 
-            self.path_tracer.execute(command_encoder, self.render_texture, frame)
-            self.accumulator.execute(
-                command_encoder, self.render_texture, self.accum_texture, frame == 0
-            )
-            self.tone_mapper.execute(command_encoder, self.accum_texture, self.output_texture)
+                command_encoder = self.device.create_command_encoder()
 
-            command_encoder.blit(surface_texture, self.output_texture)
-            self.device.submit_command_buffer(command_encoder.finish())
+                with spy.profile_zone("render", command_encoder):
+                    self.path_tracer.execute(command_encoder, self.render_texture, frame)
+                    self.accumulator.execute(
+                        command_encoder,
+                        self.render_texture,
+                        self.accum_texture,
+                        frame == 0,
+                    )
+                    self.tone_mapper.execute(
+                        command_encoder,
+                        self.accum_texture,
+                        self.output_texture,
+                    )
+
+                command_encoder.blit(surface_texture, self.output_texture)
+                self.ui.end_frame(surface_texture, command_encoder)
+                self.device.submit_command_buffer(command_encoder.finish())
+
+            self.profiler.tick()
             del surface_texture
 
             self.surface.present()
@@ -799,6 +833,7 @@ class App:
             frame += 1
 
         self.device.wait()
+        self.profiler.tick()
 
 
 app = App()

--- a/slangpy/tests/slangpy_tests/test_profiler.py
+++ b/slangpy/tests/slangpy_tests/test_profiler.py
@@ -58,31 +58,31 @@ def test_profiler_configuration() -> None:
 
 
 def test_current_profiler_stack_and_thread_locality() -> None:
-    profiler = spy.Profiler()
-    assert spy.current_profiler() is profiler
-
-    explicit_profiler = spy.Profiler()
-    assert spy.current_profiler() is profiler
-    with explicit_profiler:
-        assert spy.current_profiler() is explicit_profiler
-        with spy.profile_frame("selected frame"):
-            with spy.profile_zone("selected zone"):
-                assert spy.current_profiler() is explicit_profiler
-    assert spy.current_profiler() is profiler
-
-    seen: list[object | None] = []
-    worker = threading.Thread(target=lambda: seen.append(spy.current_profiler_or_null()))
-    worker.start()
-    worker.join()
-    assert seen == [None]
-
-    with spy.profile_zone("default zone"):
-        assert spy.current_profiler() is profiler
-    with spy.profile_frame("default frame"):
+    def exercise_profiler_stack() -> None:
+        profiler = spy.Profiler()
         assert spy.current_profiler() is profiler
 
-    del explicit_profiler
-    del profiler
+        explicit_profiler = spy.Profiler()
+        assert spy.current_profiler() is profiler
+        with explicit_profiler:
+            assert spy.current_profiler() is explicit_profiler
+            with spy.profile_frame("selected frame"):
+                with spy.profile_zone("selected zone"):
+                    assert spy.current_profiler() is explicit_profiler
+        assert spy.current_profiler() is profiler
+
+        seen: list[object | None] = []
+        worker = threading.Thread(target=lambda: seen.append(spy.current_profiler_or_null()))
+        worker.start()
+        worker.join()
+        assert seen == [None]
+
+        with spy.profile_zone("default zone"):
+            assert spy.current_profiler() is profiler
+        with spy.profile_frame("default frame"):
+            assert spy.current_profiler() is profiler
+
+    exercise_profiler_stack()
     assert spy.current_profiler_or_null() is None
 
 

--- a/slangpy/tests/slangpy_tests/test_profiler.py
+++ b/slangpy/tests/slangpy_tests/test_profiler.py
@@ -146,6 +146,7 @@ def test_python_sites_use_visible_callsite_metadata() -> None:
     assert len(set(same_line_site_ids)) == 1
     assert len(trace.frames) == 2
     assert trace.frames[0].site_id == trace.frames[1].site_id
+    assert trace.timelines[0].thread_id == threading.get_native_id()
 
 
 def test_capture_hierarchy_queries_and_statistics() -> None:

--- a/slangpy/tests/slangpy_tests/test_profiler.py
+++ b/slangpy/tests/slangpy_tests/test_profiler.py
@@ -177,6 +177,8 @@ def test_capture_hierarchy_queries_and_statistics() -> None:
     assert chunk.duration_ns.dtype == np.uint64
     assert chunk.timeline_id.dtype == np.uint32
     assert chunk.parent_index.dtype == np.int32
+    assert chunk.frame_index.dtype == np.uint32
+    assert np.all(chunk.frame_index != np.iinfo(np.uint32).max)
     assert not chunk.start_ns.flags.writeable
     assert sorted(chunk.parent_index.tolist()) == [-1, 1]
 
@@ -310,9 +312,16 @@ def test_disabled_profiler_does_not_record() -> None:
     profiler = spy.Profiler()
     profiler.enabled = False
     profiler.start_capture()
-    with spy.profile_zone("disabled"):
-        pass
-    assert profiler.stop_capture().zone_count == 0
+    with spy.profile_frame("disabled frame"):
+        with spy.profile_zone("disabled zone"):
+            with spy.profile_function():
+                pass
+    trace = profiler.stop_capture()
+    assert trace.zone_count == 0
+    assert all(site.name not in {"disabled frame", "disabled zone"} for site in trace.sites)
+    assert all(
+        not site.name.endswith("test_disabled_profiler_does_not_record") for site in trace.sites
+    )
 
 
 def test_nested_frames_are_rejected() -> None:
@@ -329,6 +338,8 @@ def test_json_export_and_array_ownership(tmp_path: Path) -> None:
     with spy.profile_zone('json "escape"'):
         pass
     trace = profiler.stop_capture()
+    assert trace.zone_chunks[0].frame_index[0] == np.iinfo(np.uint32).max
+    assert trace.query_zones(frame_begin=0).count == 0
     values = trace.zone_chunks[0].duration_ns
     output = tmp_path / "trace.json"
     trace.write_to_json(output)

--- a/slangpy/tests/slangpy_tests/test_profiler.py
+++ b/slangpy/tests/slangpy_tests/test_profiler.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import threading
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import slangpy as spy
+from slangpy.testing import helpers
+
+
+def record_nested_zones() -> None:
+    with spy.profile_frame("frame"):
+        with spy.profile_zone("outer"):
+            with spy.profile_zone("inner"):
+                pass
+
+
+def record_ambient_profile_function() -> None:
+    with spy.profile_function():
+        pass
+
+
+class AmbientProfileOwner:
+    def record(self) -> None:
+        with spy.profile_function():
+            pass
+
+
+def record_named_zone(name: str) -> None:
+    with spy.profile_zone(name):
+        pass
+
+
+def record_same_line_zones() -> None:
+    with spy.profile_zone("same-line"), spy.profile_zone("same-line"):
+        pass
+
+
+def test_profiler_configuration() -> None:
+    desc = spy.ProfilerDesc(
+        frame_stats_window_size=17,
+        enable_auto_zones=False,
+        enable_debug_groups=True,
+    )
+    assert desc.frame_stats_window_size == 17
+    assert not desc.enable_auto_zones
+    assert desc.enable_debug_groups
+
+    profiler = spy.Profiler(desc)
+    assert not profiler.enable_auto_zones
+    assert profiler.enable_debug_groups
+    profiler.enable_auto_zones = True
+    profiler.enable_debug_groups = False
+    assert profiler.enable_auto_zones
+    assert not profiler.enable_debug_groups
+
+
+def test_current_profiler_stack_and_thread_locality() -> None:
+    profiler = spy.Profiler()
+    assert spy.current_profiler() is profiler
+
+    explicit_profiler = spy.Profiler()
+    assert spy.current_profiler() is profiler
+    with explicit_profiler:
+        assert spy.current_profiler() is explicit_profiler
+        with spy.profile_frame("selected frame"):
+            with spy.profile_zone("selected zone"):
+                assert spy.current_profiler() is explicit_profiler
+    assert spy.current_profiler() is profiler
+
+    seen: list[object | None] = []
+    worker = threading.Thread(target=lambda: seen.append(spy.current_profiler_or_null()))
+    worker.start()
+    worker.join()
+    assert seen == [None]
+
+    with spy.profile_zone("default zone"):
+        assert spy.current_profiler() is profiler
+    with spy.profile_frame("default frame"):
+        assert spy.current_profiler() is profiler
+
+    del explicit_profiler
+    del profiler
+    assert spy.current_profiler_or_null() is None
+
+
+def test_ambient_profile_contexts() -> None:
+    profiler = spy.Profiler()
+    profiler.start_capture()
+
+    def record_without_current_profiler() -> None:
+        with spy.profile_frame("inactive frame"):
+            with spy.profile_zone("inactive"):
+                record_ambient_profile_function()
+
+    worker = threading.Thread(target=record_without_current_profiler)
+    worker.start()
+    worker.join()
+
+    with spy.profile_frame("ambient frame"):
+        with spy.profile_zone("ambient zone"):
+            record_ambient_profile_function()
+            AmbientProfileOwner().record()
+
+    trace = profiler.stop_capture()
+    assert len(trace.frames) == 1
+    assert trace.query_zones(name="inactive").count == 0
+    assert trace.query_zones(name="ambient zone").count == 1
+    assert trace.query_zones(name="record_ambient_profile_function").count == 1
+    assert trace.query_zones(name="AmbientProfileOwner.record").count == 1
+
+    function_site = next(
+        site for site in trace.sites if site.name == "record_ambient_profile_function"
+    )
+    assert Path(function_site.file).name == "test_profiler.py"
+    assert function_site.function.endswith("record_ambient_profile_function")
+
+
+def test_python_sites_use_visible_callsite_metadata() -> None:
+    profiler = spy.Profiler()
+    profiler.start_capture()
+
+    for _ in range(3):
+        record_named_zone("repeated zone")
+    record_same_line_zones()
+
+    for _ in range(2):
+        with spy.profile_frame("repeated frame"):
+            pass
+
+    trace = profiler.stop_capture()
+    sites = {site.id: site for site in trace.sites}
+    zone_site_ids = [site_id for chunk in trace.zone_chunks for site_id in chunk.site_id.tolist()]
+    repeated_site_ids = [
+        site_id for site_id in zone_site_ids if sites[site_id].name == "repeated zone"
+    ]
+    same_line_site_ids = [
+        site_id for site_id in zone_site_ids if sites[site_id].name == "same-line"
+    ]
+
+    assert len(repeated_site_ids) == 3
+    assert len(set(repeated_site_ids)) == 1
+    assert len(same_line_site_ids) == 2
+    assert len(set(same_line_site_ids)) == 1
+    assert len(trace.frames) == 2
+    assert trace.frames[0].site_id == trace.frames[1].site_id
+
+
+def test_capture_hierarchy_queries_and_statistics() -> None:
+    profiler = spy.Profiler()
+    profiler.start_capture()
+    record_nested_zones()
+    trace = profiler.stop_capture()
+
+    assert trace.zone_count == 2
+    assert len(trace.frames) == 1
+    assert trace.stop_reason == spy.ProfilerCaptureStopReason.user
+    assert not trace.truncated
+    assert trace.diagnostics.producer_drop_count == 0
+    assert trace.diagnostics.thread_event_queue_high_water_mark >= 1
+
+    inner = trace.query_zones(name="inner")
+    assert inner.count == 1
+    statistics = inner.statistics()
+    assert statistics.count == 1
+    assert statistics.total_ms >= 0.0
+    assert statistics.minimum_ms == statistics.maximum_ms
+    assert statistics.p50_ms == statistics.mean_ms
+
+    chunks = trace.zone_chunks
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.start_ns.dtype == np.uint64
+    assert chunk.duration_ns.dtype == np.uint64
+    assert chunk.timeline_id.dtype == np.uint32
+    assert chunk.parent_index.dtype == np.int32
+    assert not chunk.start_ns.flags.writeable
+    assert sorted(chunk.parent_index.tolist()) == [-1, 1]
+
+
+def test_live_and_frame_stats_snapshots_are_immutable() -> None:
+    profiler = spy.Profiler()
+    with spy.profile_frame():
+        with spy.profile_zone("first"):
+            pass
+    profiler.flush()
+    first = profiler.live_snapshot()
+    assert first.zone_count == 1
+    first_stats = profiler.frame_stats_snapshot()
+    assert [entry.name for entry in first_stats.entries] == ["first"]
+    assert first_stats.sample_count == 1
+    first_sample_index = first_stats.sample_frame_index[0]
+    assert first_stats.sample_call_count.tolist() == [[1]]
+
+    with spy.profile_frame():
+        with spy.profile_zone("second"):
+            pass
+    profiler.flush()
+    second = profiler.live_snapshot()
+    assert first.zone_count == 1
+    assert second.zone_count == 2
+    second_stats = profiler.frame_stats_snapshot()
+    assert [entry.name for entry in first_stats.entries] == ["first"]
+    assert first_stats.sample_frame_index[0] == first_sample_index
+    assert first_stats.sample_call_count.tolist() == [[1]]
+    assert {entry.name for entry in second_stats.entries} == {"first", "second"}
+    profiler.clear_frame_stats()
+    assert profiler.frame_stats_snapshot().sample_count == 0
+    assert first_stats.sample_call_count.tolist() == [[1]]
+
+
+def test_statistics_are_keyed_by_hierarchical_site_path() -> None:
+    profiler = spy.Profiler()
+    with spy.profile_frame():
+        for parent in ("parent a", "parent b"):
+            with spy.profile_zone(parent):
+                with spy.profile_zone("shared child"):
+                    pass
+    profiler.flush()
+    stats = profiler.frame_stats_snapshot()
+    entries = stats.entries
+    shared = [entry for entry in entries if entry.name == "shared child"]
+    assert len(shared) == 2
+    assert {entries[entry.parent_index].name for entry in shared} == {
+        "parent a",
+        "parent b",
+    }
+    text = str(stats)
+    assert text.startswith("ProfilerFrameStats(pending_frame_count=0")
+    assert "parent a: calls/frame mean=1" in text
+    assert "shared child: calls/frame mean=1" in text
+    assert "gpu/frame=n/a" in text
+
+
+def test_frame_statistics_aggregate_repeated_and_absent_zones() -> None:
+    profiler = spy.Profiler(spy.ProfilerDesc(frame_stats_window_size=2))
+    with spy.profile_frame():
+        for _ in range(4):
+            with spy.profile_zone("dispatch"):
+                pass
+    with spy.profile_frame():
+        pass
+    profiler.flush()
+
+    stats = profiler.frame_stats_snapshot()
+    assert stats.sample_count == 2
+    assert len(stats.entries) == 1
+    dispatch = stats.entries[0]
+    assert dispatch.cpu_time_per_frame.count == 2
+    assert dispatch.cpu_time_per_call.count == 4
+    assert dispatch.gpu_time_per_frame.count == 0
+    assert stats.sample_frame_index.shape == (2,)
+    assert stats.sample_frame_time_ms.shape == (2,)
+    assert stats.sample_call_count.shape == (2, 1)
+    assert stats.sample_cpu_time_ms.shape == (2, 1)
+    assert stats.sample_gpu_time_ms.shape == (2, 1)
+    assert stats.sample_gpu_status.shape == (2, 1)
+    assert stats.sample_frame_index[0] < stats.sample_frame_index[1]
+    assert stats.sample_call_count.tolist() == [[4], [0]]
+    assert stats.sample_cpu_time_ms[0, 0] >= 0.0
+    assert stats.sample_cpu_time_ms[1, 0] == 0.0
+    assert stats.sample_gpu_time_ms[:, 0].tolist() == [0.0, 0.0]
+    assert stats.sample_gpu_status[0, 0] == spy.ProfilerFrameGpuStatus.unavailable.value
+    assert stats.sample_gpu_status[1, 0] == spy.ProfilerFrameGpuStatus.absent.value
+    assert not stats.sample_call_count.flags.writeable
+    assert not stats.sample_gpu_status.flags.writeable
+
+
+def test_empty_frame_statistics_have_well_formed_matrices() -> None:
+    profiler = spy.Profiler()
+    with spy.profile_frame("empty"):
+        pass
+    profiler.flush()
+
+    stats = profiler.frame_stats_snapshot()
+    assert stats.sample_count == 1
+    assert stats.entry_count == 0
+    assert stats.sample_frame_index.shape == (1,)
+    assert stats.sample_call_count.shape == (1, 0)
+    assert stats.sample_cpu_time_ms.shape == (1, 0)
+    assert stats.sample_gpu_time_ms.shape == (1, 0)
+    assert stats.sample_gpu_status.shape == (1, 0)
+
+
+def test_capture_state_errors_and_memory_limit() -> None:
+    profiler = spy.Profiler()
+    with pytest.raises(RuntimeError, match="No active"):
+        profiler.stop_capture()
+    with pytest.raises(RuntimeError, match="No active"):
+        profiler.discard_capture()
+
+    profiler.start_capture(spy.ProfilerCaptureDesc(max_memory_bytes=64))
+    with pytest.raises(RuntimeError, match="already active"):
+        profiler.start_capture()
+    for _ in range(32):
+        with spy.profile_zone("limited"):
+            pass
+    profiler.flush()
+    assert not profiler.capture_active
+    trace = profiler.stop_capture()
+    assert trace.truncated
+    assert trace.stop_reason == spy.ProfilerCaptureStopReason.memory_limit
+    assert trace.memory_bytes <= 64
+
+
+def test_disabled_profiler_does_not_record() -> None:
+    profiler = spy.Profiler()
+    profiler.enabled = False
+    profiler.start_capture()
+    with spy.profile_zone("disabled"):
+        pass
+    assert profiler.stop_capture().zone_count == 0
+
+
+def test_nested_frames_are_rejected() -> None:
+    profiler = spy.Profiler()
+    with spy.profile_frame():
+        with pytest.raises(RuntimeError, match="already active"):
+            with spy.profile_frame("nested"):
+                pass
+
+
+def test_json_export_and_array_ownership(tmp_path: Path) -> None:
+    profiler = spy.Profiler()
+    profiler.start_capture()
+    with spy.profile_zone('json "escape"'):
+        pass
+    trace = profiler.stop_capture()
+    values = trace.zone_chunks[0].duration_ns
+    output = tmp_path / "trace.json"
+    trace.write_to_json(output)
+    text = output.read_text(encoding="utf-8")
+    assert 'json \\"escape\\"' in text
+    assert '"ph":"X"' in text
+
+    del trace
+    del profiler
+    assert values.shape == (1,)
+    assert int(values[0]) >= 0
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_manual_gpu_zone_and_automatic_functional_zone(device_type: spy.DeviceType) -> None:
+    device = helpers.get_device(device_type)
+    profiler = spy.Profiler()
+    profiler.start_capture()
+
+    command_encoder = device.create_command_encoder()
+    with spy.profile_zone("manual gpu", command_encoder):
+        pass
+    device.submit_command_buffer(command_encoder.finish())
+
+    module = spy.Module(
+        device.load_module_from_source(
+            "test_profiler_functional",
+            "int add(int a, int b) { return a + b; }",
+        )
+    )
+    assert module.add(1, 2) == 3
+
+    device.wait()
+    profiler.tick()
+    trace = profiler.stop_capture()
+    assert (
+        trace.query_zones(name="manual gpu", timeline_type=spy.ProfilerTimelineType.cpu).count == 1
+    )
+    assert (
+        trace.query_zones(
+            name="test_profiler_functional::add",
+            timeline_type=spy.ProfilerTimelineType.cpu,
+        ).count
+        == 1
+    )
+    if device.has_feature(spy.Feature.timestamp_query) and device.has_feature(
+        spy.Feature.timestamp_calibration
+    ):
+        assert (
+            trace.query_zones(name="manual gpu", timeline_type=spy.ProfilerTimelineType.gpu).count
+            == 1
+        )
+        assert trace.diagnostics.pending_gpu_zone_count == 0

--- a/src/sgl/CMakeLists.txt
+++ b/src/sgl/CMakeLists.txt
@@ -228,6 +228,7 @@ target_compile_options(sgl
         $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:
             /MP                             # enable multi-processor compilation
             /Zi                             # generate debug symbols
+            /Zc:preprocessor                # enable the conforming preprocessor required by C++20 __VA_OPT__
             # Configure warnings
             $<$<BOOL:${SGL_WARNINGS_AS_ERRORS}>:/WX>    # warnings as errors
             /W4                             # increase warning level

--- a/src/sgl/CMakeLists.txt
+++ b/src/sgl/CMakeLists.txt
@@ -183,6 +183,10 @@ target_sources(sgl PRIVATE
     utils/crashpad.h
     utils/renderdoc.cpp
     utils/renderdoc.h
+    utils/profiler.cpp
+    utils/profiler.h
+    utils/profiler_ui.cpp
+    utils/profiler_ui.h
     utils/slangpy.cpp
     utils/slangpy.h
     utils/tev.cpp

--- a/src/sgl/core/platform.h
+++ b/src/sgl/core/platform.h
@@ -4,6 +4,7 @@
 
 #include "sgl/core/macros.h"
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <optional>
@@ -37,6 +38,7 @@ struct WindowHandle {
 using SharedLibraryHandle = void*;
 
 using ProcessID = int;
+using ThreadID = uint64_t;
 
 } // namespace sgl
 
@@ -175,6 +177,9 @@ save_file_dialog(std::span<const FileDialogFilter> filters = {});
 /// Set the name of the current thread for debuggers and profilers.
 /// \return True if the platform accepted the name.
 SGL_API bool set_current_thread_name(std::string_view name);
+
+/// Get the native platform identifier of the current thread.
+[[nodiscard]] SGL_API ThreadID current_thread_id();
 
 // -------------------------------------------------------------------------------------------------
 // Memory

--- a/src/sgl/core/platform_linux.cpp
+++ b/src/sgl/core/platform_linux.cpp
@@ -12,6 +12,7 @@
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <signal.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <pthread.h>
 #include <pwd.h>
@@ -203,6 +204,11 @@ ProcessID current_process_id()
 // -------------------------------------------------------------------------------------------------
 // Threads
 // -------------------------------------------------------------------------------------------------
+
+ThreadID current_thread_id()
+{
+    return static_cast<ThreadID>(::syscall(SYS_gettid));
+}
 
 bool set_current_thread_name(std::string_view name)
 {

--- a/src/sgl/core/platform_macos.mm
+++ b/src/sgl/core/platform_macos.mm
@@ -340,6 +340,14 @@ ProcessID current_process_id()
 // Threads
 // -------------------------------------------------------------------------------------------------
 
+ThreadID current_thread_id()
+{
+    uint64_t thread_id{0};
+    const int result = pthread_threadid_np(nullptr, &thread_id);
+    SGL_ASSERT(result == 0);
+    return thread_id;
+}
+
 bool set_current_thread_name(std::string_view name)
 {
     std::string truncated_name(name.substr(0, 15));

--- a/src/sgl/core/platform_windows.cpp
+++ b/src/sgl/core/platform_windows.cpp
@@ -444,6 +444,11 @@ ProcessID current_process_id()
 // Threads
 // -------------------------------------------------------------------------------------------------
 
+ThreadID current_thread_id()
+{
+    return static_cast<ThreadID>(GetCurrentThreadId());
+}
+
 using SetThreadDescriptionProc = HRESULT(WINAPI*)(HANDLE, PCWSTR);
 
 static SetThreadDescriptionProc get_set_thread_description_proc()

--- a/src/sgl/utils/profiler.cpp
+++ b/src/sgl/utils/profiler.cpp
@@ -552,7 +552,7 @@ struct ProfilerImpl {
         }
 
         auto data = std::make_unique<ThreadData>(desc.thread_event_capacity);
-        const uint64_t thread_id = std::hash<std::thread::id>()(std::this_thread::get_id());
+        const ThreadID thread_id = platform::current_thread_id();
         ThreadData* result = data.get();
         {
             std::lock_guard lock(thread_mutex);

--- a/src/sgl/utils/profiler.cpp
+++ b/src/sgl/utils/profiler.cpp
@@ -1,0 +1,2220 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "profiler.h"
+
+#include "sgl/core/error.h"
+#include "sgl/core/platform.h"
+#include "sgl/core/thread.h"
+#include "sgl/device/command.h"
+#include "sgl/device/device.h"
+#include "sgl/device/query.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <deque>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <numeric>
+#include <sstream>
+#include <thread>
+#include <unordered_map>
+
+namespace sgl {
+
+namespace {
+
+    constexpr uint32_t ZONE_CHUNK_SIZE = 4096;
+    constexpr uint32_t MAX_ZONE_DEPTH = 64;
+    constexpr uint32_t GPU_ZONES_PER_CHUNK = 16;
+    constexpr uint32_t INVALID_INDEX = ~0u;
+    constexpr uint64_t GPU_CALIBRATION_INTERVAL_NS = 2'000'000'000ull;
+
+    uint64_t now_ns() noexcept
+    {
+        return uint64_t(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+                .count()
+        );
+    }
+
+    struct SiteKey {
+        uint32_t file_id{0};
+        uint32_t line{0};
+        uint32_t function_signature_id{0};
+        uint32_t name_id{0};
+        bool operator==(const SiteKey&) const = default;
+    };
+
+    struct SiteKeyHash {
+        size_t operator()(const SiteKey& value) const noexcept
+        {
+            size_t h = std::hash<uint32_t>()(value.file_id);
+            h ^= std::hash<uint32_t>()(value.line) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            h ^= std::hash<uint32_t>()(value.function_signature_id) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            h ^= std::hash<uint32_t>()(value.name_id) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            return h;
+        }
+    };
+
+    std::string_view trim(std::string_view value)
+    {
+        while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+            value.remove_prefix(1);
+        while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+            value.remove_suffix(1);
+        return value;
+    }
+
+    std::string compact_function_name(std::string_view signature)
+    {
+        signature = trim(signature);
+        if (const size_t with = signature.find(" [with "); with != std::string_view::npos)
+            signature = trim(signature.substr(0, with));
+
+        size_t parameter_open = std::string_view::npos;
+        size_t open = std::string_view::npos;
+        uint32_t depth = 0;
+        for (size_t i = 0; i < signature.size(); ++i) {
+            if (signature[i] == '(') {
+                if (depth == 0)
+                    open = i;
+                ++depth;
+            } else if (signature[i] == ')' && depth > 0) {
+                --depth;
+                if (depth == 0)
+                    parameter_open = open;
+            }
+        }
+        if (parameter_open == std::string_view::npos)
+            return std::string(signature);
+
+        const std::string_view prefix = trim(signature.substr(0, parameter_open));
+        if (prefix.empty())
+            return std::string(signature);
+
+        const size_t operator_pos = prefix.rfind("operator");
+        size_t start = operator_pos == std::string_view::npos ? prefix.size() : operator_pos;
+        uint32_t template_depth = 0;
+        uint32_t group_depth = 0;
+        while (start > 0) {
+            const char c = prefix[start - 1];
+            if (c == '>') {
+                ++template_depth;
+            } else if (c == '<' && template_depth > 0) {
+                --template_depth;
+            } else if (c == ')' || c == ']') {
+                ++group_depth;
+            } else if ((c == '(' || c == '[') && group_depth > 0) {
+                --group_depth;
+            } else if (std::isspace(static_cast<unsigned char>(c)) && template_depth == 0 && group_depth == 0) {
+                break;
+            }
+            --start;
+        }
+        return std::string(prefix.substr(start));
+    }
+
+    struct StringInterner {
+        uint32_t intern(std::string_view value)
+        {
+            if (auto it = ids.find(value); it != ids.end())
+                return it->second;
+            const uint32_t id = uint32_t(strings.size());
+            strings.emplace_back(value);
+            ids.emplace(std::string_view(strings.back()), id);
+            return id;
+        }
+
+        std::string_view get(uint32_t id) const
+        {
+            SGL_ASSERT(id < strings.size());
+            return strings[id];
+        }
+
+        std::deque<std::string> strings;
+        std::unordered_map<std::string_view, uint32_t> ids;
+    };
+
+    struct SiteRegistry {
+        uint32_t compact_function_id(uint32_t signature_id)
+        {
+            if (auto it = compact_function_ids.find(signature_id); it != compact_function_ids.end())
+                return it->second;
+            const uint32_t id = strings.intern(compact_function_name(strings.get(signature_id)));
+            compact_function_ids.emplace(signature_id, id);
+            return id;
+        }
+
+        std::mutex mutex;
+        StringInterner strings;
+        std::unordered_map<uint32_t, uint32_t> compact_function_ids;
+        std::unordered_map<SiteKey, uint32_t, SiteKeyHash> ids;
+        std::vector<ProfilerSite> sites;
+    };
+
+    SiteRegistry& site_registry()
+    {
+        static SiteRegistry registry;
+        return registry;
+    }
+
+    std::vector<ProfilerSite> site_snapshot()
+    {
+        SiteRegistry& registry = site_registry();
+        std::lock_guard lock(registry.mutex);
+        return registry.sites;
+    }
+
+    std::string_view site_name(uint32_t id)
+    {
+        SiteRegistry& registry = site_registry();
+        std::lock_guard lock(registry.mutex);
+        if (id == 0 || id > registry.sites.size())
+            return {};
+        return registry.sites[id - 1].name;
+    }
+
+    const ProfilerSite* find_site(const std::vector<ProfilerSite>& sites, uint32_t id)
+    {
+        if (id == 0 || id > sites.size())
+            return nullptr;
+        return &sites[id - 1];
+    }
+
+    template<typename T>
+    ProfilerDurationStatistics calculate_statistics(std::vector<T> durations, double unit_to_ms)
+    {
+        ProfilerDurationStatistics result;
+        result.count = durations.size();
+        if (durations.empty())
+            return result;
+
+        std::sort(durations.begin(), durations.end());
+        const long double total = std::accumulate(durations.begin(), durations.end(), 0.0L);
+        const long double mean = total / durations.size();
+        long double variance = 0.0;
+        for (T value : durations) {
+            const long double delta = value - mean;
+            variance += delta * delta;
+        }
+        variance /= durations.size();
+
+        auto percentile = [&](double p)
+        {
+            const double position = p * double(durations.size() - 1);
+            const size_t lo = size_t(position);
+            const size_t hi = std::min(lo + 1, durations.size() - 1);
+            return double(durations[lo]) + (double(durations[hi]) - double(durations[lo])) * (position - lo);
+        };
+        result.total_ms = double(total) * unit_to_ms;
+        result.minimum_ms = double(durations.front()) * unit_to_ms;
+        result.maximum_ms = double(durations.back()) * unit_to_ms;
+        result.mean_ms = double(mean) * unit_to_ms;
+        result.standard_deviation_ms = std::sqrt(double(variance)) * unit_to_ms;
+        result.p50_ms = percentile(0.50) * unit_to_ms;
+        result.p90_ms = percentile(0.90) * unit_to_ms;
+        result.p95_ms = percentile(0.95) * unit_to_ms;
+        result.p99_ms = percentile(0.99) * unit_to_ms;
+        return result;
+    }
+
+    ProfilerDurationStatistics calculate_statistics(std::vector<uint64_t> durations)
+    {
+        return calculate_statistics(std::move(durations), 1e-6);
+    }
+
+    ProfilerDurationStatistics calculate_statistics_ms(std::vector<double> durations)
+    {
+        return calculate_statistics(std::move(durations), 1.0);
+    }
+
+    void write_json_string(std::ostream& stream, std::string_view value)
+    {
+        stream << '"';
+        for (unsigned char c : value) {
+            switch (c) {
+            case '"':
+                stream << "\\\"";
+                break;
+            case '\\':
+                stream << "\\\\";
+                break;
+            case '\b':
+                stream << "\\b";
+                break;
+            case '\f':
+                stream << "\\f";
+                break;
+            case '\n':
+                stream << "\\n";
+                break;
+            case '\r':
+                stream << "\\r";
+                break;
+            case '\t':
+                stream << "\\t";
+                break;
+            default:
+                if (c < 0x20)
+                    stream << "\\u" << std::hex << std::setw(4) << std::setfill('0') << unsigned(c) << std::dec;
+                else
+                    stream << char(c);
+            }
+        }
+        stream << '"';
+    }
+
+    enum class GpuTimingStatus : uint8_t {
+        unavailable,
+        pending,
+        complete,
+        missing,
+    };
+
+    struct CpuEvent {
+        enum class Type : uint8_t { zone, frame } type{Type::zone};
+        uint64_t start_ns{0};
+        uint64_t duration_ns{0};
+        uint64_t correlation_id{0};
+        uint64_t parent_correlation_id{0};
+        uint32_t timeline_id{0};
+        uint32_t site_id{0};
+        uint32_t frame_index{INVALID_INDEX};
+        GpuTimingStatus gpu_timing_status{GpuTimingStatus::unavailable};
+    };
+
+    struct StoredZone {
+        uint64_t start_ns{0};
+        uint64_t duration_ns{0};
+        uint64_t correlation_id{0};
+        uint64_t parent_correlation_id{0};
+        uint32_t timeline_id{0};
+        uint32_t site_id{0};
+        int32_t frame_index{-1};
+    };
+
+#if SGL_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4324)
+#endif
+    struct alignas(64) RingIndex {
+        std::atomic<uint64_t> value{0};
+    };
+
+    struct ThreadData {
+        explicit ThreadData(uint32_t capacity)
+            : events(capacity)
+            , mask(capacity - 1)
+        {
+        }
+
+        bool push(const CpuEvent& event) noexcept
+        {
+            const uint64_t write = write_index.value.load(std::memory_order_relaxed);
+            const uint64_t read = read_index.value.load(std::memory_order_acquire);
+            if (write - read >= events.size()) {
+                drop_count.fetch_add(1, std::memory_order_relaxed);
+                return false;
+            }
+            events[write & mask] = event;
+            write_index.value.store(write + 1, std::memory_order_release);
+            uint64_t high = write + 1 - read;
+            uint64_t old = high_water_mark.load(std::memory_order_relaxed);
+            while (old < high && !high_water_mark.compare_exchange_weak(old, high, std::memory_order_relaxed)) { }
+            return true;
+        }
+
+        std::vector<CpuEvent> events;
+        uint64_t mask{0};
+        RingIndex write_index;
+        RingIndex read_index;
+        std::array<uint64_t, MAX_ZONE_DEPTH> zone_stack{};
+        std::array<uint64_t, MAX_ZONE_DEPTH> zone_gpu_recording_stack{};
+        uint32_t zone_depth{0};
+        uint32_t local_sequence{0};
+        uint32_t timeline_id{0};
+        uint64_t gpu_recording_id{0};
+        void* gpu_context{nullptr};
+        void* gpu_recording{nullptr};
+        std::atomic<uint64_t> drop_count{0};
+        std::atomic<uint64_t> stack_overflow_count{0};
+        std::atomic<uint64_t> high_water_mark{0};
+    };
+#if SGL_MSVC
+#pragma warning(pop)
+#endif
+
+    struct TlsCacheEntry {
+        Profiler* profiler{nullptr};
+        uint64_t instance_id{0};
+        ThreadData* thread_data{nullptr};
+        std::weak_ptr<void> lifetime;
+    };
+
+    thread_local std::vector<Profiler*> tls_profiler_stack;
+    thread_local std::vector<TlsCacheEntry> tls_thread_cache;
+    std::atomic<uint64_t> next_profiler_instance_id{1};
+
+} // namespace
+
+struct ProfilerImpl {
+    enum class CaptureState : uint8_t {
+        idle,
+        recording,
+        ready,
+    };
+
+    struct CallAccumulator {
+        uint64_t count{0};
+        long double total_ns{0.0};
+        long double squared_total_ns{0.0};
+        uint64_t minimum_ns{~0ull};
+        uint64_t maximum_ns{0};
+
+        void add(uint64_t duration_ns)
+        {
+            ++count;
+            total_ns += duration_ns;
+            squared_total_ns += static_cast<long double>(duration_ns) * duration_ns;
+            minimum_ns = std::min(minimum_ns, duration_ns);
+            maximum_ns = std::max(maximum_ns, duration_ns);
+        }
+
+        void merge(const CallAccumulator& other)
+        {
+            count += other.count;
+            total_ns += other.total_ns;
+            squared_total_ns += other.squared_total_ns;
+            minimum_ns = std::min(minimum_ns, other.minimum_ns);
+            maximum_ns = std::max(maximum_ns, other.maximum_ns);
+        }
+
+        ProfilerCallStatistics statistics() const
+        {
+            ProfilerCallStatistics result;
+            result.count = count;
+            if (count == 0)
+                return result;
+            constexpr double ns_to_ms = 1e-6;
+            const long double mean = total_ns / count;
+            const long double variance = std::max(0.0L, squared_total_ns / count - mean * mean);
+            result.total_ms = double(total_ns) * ns_to_ms;
+            result.minimum_ms = double(minimum_ns) * ns_to_ms;
+            result.maximum_ms = double(maximum_ns) * ns_to_ms;
+            result.mean_ms = double(mean) * ns_to_ms;
+            result.standard_deviation_ms = std::sqrt(double(variance)) * ns_to_ms;
+            return result;
+        }
+    };
+
+    struct PendingFrameZone {
+        uint32_t site_id{0};
+        uint64_t duration_ns{0};
+        uint64_t parent_correlation_id{0};
+        GpuTimingStatus gpu_timing_status{GpuTimingStatus::unavailable};
+        uint64_t gpu_duration_ns{0};
+    };
+
+    struct FrameNodeData {
+        int32_t parent_index{-1};
+        uint32_t site_id{0};
+        CallAccumulator cpu;
+        CallAccumulator gpu;
+        uint64_t gpu_requested_count{0};
+        uint64_t missing_gpu_call_count{0};
+    };
+
+    struct FrameRecord {
+        ProfilerFrame frame;
+        std::vector<FrameNodeData> nodes;
+    };
+
+    struct PendingFrameData {
+        ProfilerFrame frame;
+        bool ended{false};
+        uint64_t pending_gpu_count{0};
+        std::unordered_map<uint64_t, PendingFrameZone> zones;
+    };
+
+    struct GpuResult {
+        StoredZone zone;
+        bool missing{false};
+    };
+
+    struct GpuSlot {
+        uint64_t correlation_id{0};
+        uint64_t parent_correlation_id{0};
+        uint32_t site_id{0};
+        uint32_t frame_index{INVALID_INDEX};
+        bool ended{false};
+    };
+
+    struct GpuRecording {
+        std::vector<uint32_t> chunks;
+        uint32_t current_chunk{INVALID_INDEX};
+        uint32_t chunk_cursor{GPU_ZONES_PER_CHUNK};
+        uint64_t submit_id{0};
+        bool submitted{false};
+    };
+
+    struct GpuCalibration {
+        TimestampCalibration value;
+        uint64_t anchor_ns{0};
+        uint64_t refreshed_ns{0};
+        bool valid{false};
+    };
+
+    struct GpuContext {
+        ref<Device> device;
+        CommandQueueType queue{CommandQueueType::graphics};
+        ref<QueryPool> query_pool;
+        std::vector<GpuSlot> slots;
+        std::vector<uint32_t> free_chunks;
+        std::unordered_map<uint64_t, std::unique_ptr<GpuRecording>> recordings;
+        uint32_t timeline_id{0};
+        DeviceCallbackID close_callback{0};
+        DeviceCallbackID submitted_callback{0};
+        DeviceCallbackID discarded_callback{0};
+        GpuCalibration calibration;
+        std::atomic<bool> closed{false};
+
+        uint32_t chunk_capacity(uint32_t chunk) const
+        {
+            const uint32_t first_slot = chunk * GPU_ZONES_PER_CHUNK;
+            return std::min<uint32_t>(GPU_ZONES_PER_CHUNK, uint32_t(slots.size()) - first_slot);
+        }
+
+        uint64_t recording_zone_count(const GpuRecording& recording) const
+        {
+            if (recording.chunks.empty())
+                return 0;
+            uint64_t result = 0;
+            for (uint32_t chunk : recording.chunks)
+                result += chunk == recording.current_chunk ? recording.chunk_cursor : chunk_capacity(chunk);
+            return result;
+        }
+
+        void recycle_recording(const GpuRecording& recording)
+        {
+            for (uint32_t chunk : recording.chunks)
+                free_chunks.push_back(chunk);
+        }
+    };
+
+    explicit ProfilerImpl(Profiler* owner, const ProfilerDesc& desc)
+        : owner(owner)
+        , desc(desc)
+        , instance_id(next_profiler_instance_id.fetch_add(1, std::memory_order_relaxed))
+    {
+        live_published = ref<ProfilerTrace>(new ProfilerTrace());
+        frame_stats_published = ref<ProfilerFrameStats>(new ProfilerFrameStats());
+        worker = std::thread(
+            [this]
+            {
+                worker_main();
+            }
+        );
+    }
+
+    ~ProfilerImpl()
+    {
+        shutdown_gpu();
+        {
+            std::lock_guard lock(control_mutex);
+            stopping = true;
+        }
+        control_cv.notify_all();
+        if (worker.joinable())
+            worker.join();
+    }
+
+    ThreadData* thread_data()
+    {
+        for (auto it = tls_thread_cache.begin(); it != tls_thread_cache.end();) {
+            if (it->profiler == owner && it->instance_id == instance_id)
+                return it->thread_data;
+            if (it->lifetime.expired()) {
+                it = tls_thread_cache.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        auto data = std::make_unique<ThreadData>(desc.thread_event_capacity);
+        const uint64_t thread_id = std::hash<std::thread::id>()(std::this_thread::get_id());
+        ThreadData* result = data.get();
+        {
+            std::lock_guard lock(thread_mutex);
+            data->timeline_id = uint32_t(timelines.size());
+            ProfilerTimeline timeline;
+            timeline.type = ProfilerTimelineType::cpu;
+            timeline.thread_id = thread_id;
+            timeline.name = fmt::format("CPU thread {}", thread_id);
+            timelines.push_back(std::move(timeline));
+            threads.push_back(std::move(data));
+        }
+        tls_thread_cache.push_back({owner, instance_id, result, lifetime});
+        return result;
+    }
+
+    uint64_t producer_drop_count() const
+    {
+        uint64_t result = 0;
+        std::lock_guard lock(thread_mutex);
+        for (const auto& thread : threads)
+            result += thread->drop_count.load(std::memory_order_relaxed)
+                + thread->stack_overflow_count.load(std::memory_order_relaxed);
+        return result;
+    }
+
+    uint64_t thread_event_queue_high_water_mark() const
+    {
+        uint64_t result = 0;
+        std::lock_guard lock(thread_mutex);
+        for (const auto& thread : threads)
+            result = std::max(result, thread->high_water_mark.load(std::memory_order_relaxed));
+        return result;
+    }
+
+    ProfilerDiagnostics make_diagnostics() const
+    {
+        ProfilerDiagnostics result;
+        result.producer_drop_count = producer_drop_count();
+        result.thread_event_queue_high_water_mark = thread_event_queue_high_water_mark();
+        result.hierarchy_loss_count = hierarchy_loss_count;
+        result.gpu_query_exhaustion_count = gpu_query_exhaustion_count.load(std::memory_order_relaxed);
+        result.pending_gpu_zone_count = pending_gpu_zone_count.load(std::memory_order_relaxed);
+        return result;
+    }
+
+    enum class GlobalFrameStatus : uint64_t {
+        inactive = 0,
+        open = 1,
+        closed = 2,
+        finalizing = 3,
+    };
+
+    static constexpr uint64_t GLOBAL_FRAME_STATUS_MASK = 3;
+    static constexpr uint64_t GLOBAL_FRAME_ZONE_COUNT_INCREMENT = 1ull << 2;
+    static constexpr uint64_t GLOBAL_FRAME_ZONE_COUNT_MASK = 0x3fffffffull << 2;
+
+    static uint64_t global_frame_state(uint32_t frame_index, GlobalFrameStatus status, uint32_t zone_count = 0)
+    {
+        return uint64_t(frame_index) << 32 | uint64_t(zone_count) << 2 | uint64_t(status);
+    }
+
+    static GlobalFrameStatus global_frame_status(uint64_t state)
+    {
+        return GlobalFrameStatus(state & GLOBAL_FRAME_STATUS_MASK);
+    }
+
+    static uint32_t global_frame_index(uint64_t state) { return uint32_t(state >> 32); }
+
+    static uint32_t global_frame_zone_count(uint64_t state)
+    {
+        return uint32_t((state & GLOBAL_FRAME_ZONE_COUNT_MASK) >> 2);
+    }
+
+    bool begin_global_frame(ProfilerFrameToken& token, ThreadData* data, uint32_t site_id, uint64_t start_ns)
+    {
+        std::lock_guard lock(global_frame_mutex);
+        if (global_frame.load(std::memory_order_acquire) != uint64_t(GlobalFrameStatus::inactive))
+            return false;
+        const uint32_t frame_index = next_frame_index.fetch_add(1, std::memory_order_relaxed);
+        global_frame_event = {};
+        global_frame_event.type = CpuEvent::Type::frame;
+        global_frame_event.start_ns = start_ns;
+        global_frame_event.timeline_id = data->timeline_id;
+        global_frame_event.site_id = site_id;
+        global_frame_event.frame_index = frame_index;
+        global_frame.store(global_frame_state(frame_index, GlobalFrameStatus::open), std::memory_order_release);
+        token.profiler = owner;
+        token.start_ns = start_ns;
+        token.frame_index = frame_index;
+        return true;
+    }
+
+    void attach_zone_to_global_frame(ProfilerZoneToken& token)
+    {
+        uint64_t state = global_frame.load(std::memory_order_acquire);
+        while (global_frame_status(state) == GlobalFrameStatus::open) {
+            if (global_frame_zone_count(state) == 0x3fffffffu)
+                return;
+            if (global_frame.compare_exchange_weak(
+                    state,
+                    state + GLOBAL_FRAME_ZONE_COUNT_INCREMENT,
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire
+                )) {
+                token.frame_index = global_frame_index(state);
+                return;
+            }
+        }
+    }
+
+    void end_global_frame(const ProfilerFrameToken& token, uint64_t end_ns)
+    {
+        {
+            std::lock_guard lock(global_frame_mutex);
+            uint64_t state = global_frame.load(std::memory_order_acquire);
+            for (;;) {
+                if (global_frame_status(state) != GlobalFrameStatus::open
+                    || global_frame_index(state) != token.frame_index)
+                    return;
+                const uint64_t closed_state = state & ~GLOBAL_FRAME_STATUS_MASK | uint64_t(GlobalFrameStatus::closed);
+                if (global_frame.compare_exchange_weak(
+                        state,
+                        closed_state,
+                        std::memory_order_acq_rel,
+                        std::memory_order_acquire
+                    ))
+                    break;
+            }
+            global_frame_event.duration_ns = end_ns - token.start_ns;
+        }
+        try_finalize_global_frame(token.frame_index);
+    }
+
+    void release_zone_from_global_frame(uint32_t frame_index)
+    {
+        const uint64_t previous = global_frame.fetch_sub(GLOBAL_FRAME_ZONE_COUNT_INCREMENT, std::memory_order_acq_rel);
+        SGL_ASSERT(global_frame_index(previous) == frame_index && global_frame_zone_count(previous) > 0);
+        if (global_frame_status(previous) == GlobalFrameStatus::closed && global_frame_zone_count(previous) == 1)
+            try_finalize_global_frame(frame_index);
+    }
+
+    void try_finalize_global_frame(uint32_t frame_index)
+    {
+        uint64_t expected = global_frame_state(frame_index, GlobalFrameStatus::closed);
+        if (!global_frame.compare_exchange_strong(
+                expected,
+                global_frame_state(frame_index, GlobalFrameStatus::finalizing),
+                std::memory_order_acq_rel
+            ))
+            return;
+        CpuEvent event;
+        {
+            std::lock_guard lock(global_frame_mutex);
+            event = global_frame_event;
+        }
+        {
+            std::lock_guard lock(sealed_frame_mutex);
+            sealed_frame_events.push_back(event);
+        }
+        global_frame.store(uint64_t(GlobalFrameStatus::inactive), std::memory_order_release);
+        control_cv.notify_all();
+    }
+
+    bool drain()
+    {
+        bool dirty = false;
+        drained_cpu_events.clear();
+        {
+            std::lock_guard thread_lock(thread_mutex);
+            for (const auto& thread : threads) {
+                uint64_t read = thread->read_index.value.load(std::memory_order_relaxed);
+                const uint64_t write = thread->write_index.value.load(std::memory_order_acquire);
+                while (read < write) {
+                    drained_cpu_events.push_back(thread->events[read & thread->mask]);
+                    ++read;
+                }
+                thread->read_index.value.store(read, std::memory_order_release);
+            }
+        }
+        for (const CpuEvent& event : drained_cpu_events) {
+            consume(event);
+            dirty = true;
+        }
+        std::vector<CpuEvent> frame_events;
+        {
+            std::lock_guard lock(sealed_frame_mutex);
+            frame_events.swap(sealed_frame_events);
+        }
+        for (const CpuEvent& event : frame_events) {
+            consume(event);
+            dirty = true;
+        }
+        std::vector<GpuResult> gpu_results;
+        {
+            std::lock_guard lock(gpu_result_mutex);
+            gpu_results.swap(pending_gpu_results);
+        }
+        for (const GpuResult& result : gpu_results) {
+            consume_gpu(result);
+            dirty = true;
+        }
+        return dirty;
+    }
+
+    FrameRecord build_frame_record(PendingFrameData&& pending)
+    {
+        FrameRecord result;
+        result.frame = pending.frame;
+        std::unordered_map<uint64_t, uint32_t> path_nodes;
+        std::unordered_map<uint64_t, uint32_t> correlation_nodes;
+        auto resolve = [&](auto&& self, uint64_t correlation_id) -> int32_t
+        {
+            if (auto it = correlation_nodes.find(correlation_id); it != correlation_nodes.end())
+                return int32_t(it->second);
+            auto zone_it = pending.zones.find(correlation_id);
+            if (zone_it == pending.zones.end())
+                return -1;
+            PendingFrameZone& zone = zone_it->second;
+            int32_t parent_index = -1;
+            if (zone.parent_correlation_id != 0) {
+                if (pending.zones.find(zone.parent_correlation_id) != pending.zones.end())
+                    parent_index = self(self, zone.parent_correlation_id);
+                else
+                    ++hierarchy_loss_count;
+            }
+            const uint64_t path_key = (uint64_t(uint32_t(parent_index + 1)) << 32) | zone.site_id;
+            uint32_t node_index;
+            if (auto path_it = path_nodes.find(path_key); path_it != path_nodes.end()) {
+                node_index = path_it->second;
+            } else {
+                node_index = uint32_t(result.nodes.size());
+                result.nodes.push_back({parent_index, zone.site_id});
+                path_nodes.emplace(path_key, node_index);
+            }
+            FrameNodeData& node = result.nodes[node_index];
+            node.cpu.add(zone.duration_ns);
+            if (zone.gpu_timing_status != GpuTimingStatus::unavailable) {
+                ++node.gpu_requested_count;
+                if (zone.gpu_timing_status == GpuTimingStatus::complete)
+                    node.gpu.add(zone.gpu_duration_ns);
+                else
+                    ++node.missing_gpu_call_count;
+            }
+            correlation_nodes.emplace(correlation_id, node_index);
+            return int32_t(node_index);
+        };
+        for (const auto& [correlation_id, zone] : pending.zones) {
+            SGL_UNUSED(zone);
+            resolve(resolve, correlation_id);
+        }
+        return result;
+    }
+
+    void finalize_ready_frames()
+    {
+        while (!frame_stats_pending_frames.empty()) {
+            const uint32_t frame_index = frame_stats_pending_frames.front();
+            auto pending_it = pending_frames.find(frame_index);
+            if (pending_it == pending_frames.end()) {
+                frame_stats_pending_frames.pop_front();
+                continue;
+            }
+            if (pending_it->second.pending_gpu_count != 0)
+                break;
+            frame_stats_completed_frames.push_back(build_frame_record(std::move(pending_it->second)));
+            pending_frames.erase(pending_it);
+            frame_stats_pending_frames.pop_front();
+            while (frame_stats_completed_frames.size() > desc.frame_stats_window_size)
+                frame_stats_completed_frames.pop_front();
+        }
+    }
+
+    void bound_pending_frames()
+    {
+        if (frame_stats_pending_frames.size() <= desc.frame_stats_window_size)
+            return;
+        auto pending_it = pending_frames.find(frame_stats_pending_frames.front());
+        if (pending_it != pending_frames.end()) {
+            for (auto& [correlation_id, zone] : pending_it->second.zones) {
+                SGL_UNUSED(correlation_id);
+                if (zone.gpu_timing_status == GpuTimingStatus::pending)
+                    zone.gpu_timing_status = GpuTimingStatus::missing;
+            }
+            pending_it->second.pending_gpu_count = 0;
+        }
+        finalize_ready_frames();
+    }
+
+    void retain_zone(const StoredZone& zone)
+    {
+        live_zones.push_back(zone);
+        while (live_zones.size() > desc.live_event_capacity)
+            live_zones.pop_front();
+
+        std::lock_guard capture_lock(capture_mutex);
+        if (capture_state == CaptureState::recording && zone.start_ns >= capture_start_ns)
+            append_capture_zone(zone);
+    }
+
+    void consume(const CpuEvent& event)
+    {
+        if (event.type == CpuEvent::Type::frame) {
+            ProfilerFrame frame;
+            frame.index = event.frame_index;
+            frame.site_id = event.site_id;
+            frame.timeline_id = event.timeline_id;
+            frame.start_ns = event.start_ns;
+            frame.duration_ns = event.duration_ns;
+            live_frames.push_back(frame);
+            {
+                std::lock_guard capture_lock(capture_mutex);
+                if (capture_state == CaptureState::recording && frame.start_ns >= capture_start_ns)
+                    append_capture_frame(frame);
+            }
+            if (live_frames.size() > desc.live_frame_count)
+                live_frames.erase(
+                    live_frames.begin(),
+                    live_frames.begin() + (live_frames.size() - desc.live_frame_count)
+                );
+            if (event.frame_index >= frame_stats_min_index) {
+                for (auto it = pending_frames.begin(); it != pending_frames.end();) {
+                    if (!it->second.ended && it->first < event.frame_index
+                        && it->second.frame.timeline_id == event.timeline_id) {
+                        it = pending_frames.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+                PendingFrameData& pending = pending_frames[event.frame_index];
+                pending.frame = frame;
+                pending.ended = true;
+                frame_stats_pending_frames.push_back(event.frame_index);
+                finalize_ready_frames();
+                bound_pending_frames();
+            }
+            return;
+        }
+
+        StoredZone zone;
+        zone.start_ns = event.start_ns;
+        zone.duration_ns = event.duration_ns;
+        zone.correlation_id = event.correlation_id;
+        zone.parent_correlation_id = event.parent_correlation_id;
+        zone.timeline_id = event.timeline_id;
+        zone.site_id = event.site_id;
+        zone.frame_index = event.frame_index == INVALID_INDEX ? -1 : int32_t(event.frame_index);
+        retain_zone(zone);
+
+        if (event.frame_index != INVALID_INDEX && event.frame_index >= frame_stats_min_index) {
+            PendingFrameData& pending = pending_frames[event.frame_index];
+            pending.frame.index = event.frame_index;
+            pending.frame.timeline_id = event.timeline_id;
+            PendingFrameZone& pending_zone = pending.zones[event.correlation_id];
+            pending_zone.site_id = event.site_id;
+            pending_zone.duration_ns = event.duration_ns;
+            pending_zone.parent_correlation_id = event.parent_correlation_id;
+            pending_zone.gpu_timing_status = event.gpu_timing_status;
+            if (event.gpu_timing_status == GpuTimingStatus::pending)
+                ++pending.pending_gpu_count;
+        }
+    }
+
+    void consume_gpu(const GpuResult& result)
+    {
+        const StoredZone& zone = result.zone;
+        if (!result.missing)
+            retain_zone(zone);
+        if (zone.frame_index < 0 || uint32_t(zone.frame_index) < frame_stats_min_index)
+            return;
+        auto pending_it = pending_frames.find(uint32_t(zone.frame_index));
+        if (pending_it == pending_frames.end())
+            return;
+        auto zone_it = pending_it->second.zones.find(zone.correlation_id);
+        if (zone_it == pending_it->second.zones.end())
+            return;
+        PendingFrameZone& pending_zone = zone_it->second;
+        if (pending_zone.gpu_timing_status != GpuTimingStatus::pending)
+            return;
+        pending_zone.gpu_timing_status = result.missing ? GpuTimingStatus::missing : GpuTimingStatus::complete;
+        pending_zone.gpu_duration_ns = zone.duration_ns;
+        if (pending_it->second.pending_gpu_count > 0)
+            --pending_it->second.pending_gpu_count;
+        if (pending_it->second.ended) {
+            finalize_ready_frames();
+        }
+    }
+
+    uint64_t capture_storage_bytes() const
+    {
+        return capture_zones.capacity() * sizeof(StoredZone) + capture_frames.capacity() * sizeof(ProfilerFrame);
+    }
+
+    void clear_capture_storage()
+    {
+        std::vector<StoredZone>().swap(capture_zones);
+        std::vector<ProfilerFrame>().swap(capture_frames);
+    }
+
+    void stop_capture_at_memory_limit()
+    {
+        capture_state = CaptureState::ready;
+        capture_reason = ProfilerCaptureStopReason::memory_limit;
+        capture_stop_ns = now_ns();
+    }
+
+    void append_capture_zone(const StoredZone& zone)
+    {
+        if (capture_zones.size() == capture_zones.capacity()) {
+            const uint64_t frame_bytes = capture_frames.capacity() * sizeof(ProfilerFrame);
+            const uint64_t available_bytes
+                = capture_desc.max_memory_bytes > frame_bytes ? capture_desc.max_memory_bytes - frame_bytes : 0;
+            const size_t max_capacity = size_t(available_bytes / sizeof(StoredZone));
+            if (capture_zones.size() >= max_capacity) {
+                stop_capture_at_memory_limit();
+                return;
+            }
+            const size_t next_capacity = std::min(
+                max_capacity,
+                std::max<size_t>(capture_zones.capacity() * 2, std::min<size_t>(4096, max_capacity))
+            );
+            capture_zones.reserve(next_capacity);
+        }
+        capture_zones.push_back(zone);
+    }
+
+    void append_capture_frame(const ProfilerFrame& frame)
+    {
+        if (capture_frames.size() == capture_frames.capacity()) {
+            const uint64_t zone_bytes = capture_zones.capacity() * sizeof(StoredZone);
+            const uint64_t available_bytes
+                = capture_desc.max_memory_bytes > zone_bytes ? capture_desc.max_memory_bytes - zone_bytes : 0;
+            const size_t max_capacity = size_t(available_bytes / sizeof(ProfilerFrame));
+            if (capture_frames.size() >= max_capacity) {
+                stop_capture_at_memory_limit();
+                return;
+            }
+            const size_t next_capacity = std::min(max_capacity, std::max<size_t>(capture_frames.capacity() * 2, 16));
+            capture_frames.reserve(next_capacity);
+        }
+        capture_frames.push_back(frame);
+    }
+
+    void queue_missing_gpu_results(const GpuContext& context, const GpuRecording& recording)
+    {
+        std::vector<GpuResult> results;
+        for (uint32_t chunk : recording.chunks) {
+            const uint32_t zone_count
+                = chunk == recording.current_chunk ? recording.chunk_cursor : context.chunk_capacity(chunk);
+            const uint32_t first_slot = chunk * GPU_ZONES_PER_CHUNK;
+            for (uint32_t i = 0; i < zone_count; ++i) {
+                const GpuSlot& slot = context.slots[first_slot + i];
+                StoredZone zone;
+                zone.correlation_id = slot.correlation_id;
+                zone.parent_correlation_id = slot.parent_correlation_id;
+                zone.timeline_id = context.timeline_id;
+                zone.site_id = slot.site_id;
+                zone.frame_index = slot.frame_index == INVALID_INDEX ? -1 : int32_t(slot.frame_index);
+                results.push_back({zone, true});
+            }
+        }
+        if (!results.empty()) {
+            std::lock_guard result_lock(gpu_result_mutex);
+            pending_gpu_results.insert(pending_gpu_results.end(), results.begin(), results.end());
+        }
+    }
+
+    GpuContext* get_or_create_gpu_context(CommandEncoder* encoder)
+    {
+        Device* device = encoder->device();
+        if (!device->has_feature(Feature::timestamp_query) || !device->has_feature(Feature::timestamp_calibration))
+            return nullptr;
+        const CommandQueueType queue = encoder->queue();
+        for (const auto& context : gpu_contexts) {
+            if (device == context->device && context->queue == queue)
+                return context->closed.load(std::memory_order_acquire) ? nullptr : context.get();
+        }
+
+        auto context = std::make_unique<GpuContext>();
+        context->device = ref<Device>(device);
+        context->queue = queue;
+        context->query_pool = device->create_query_pool({QueryType::timestamp, desc.gpu_query_pool_size});
+        context->slots.resize(desc.gpu_query_pool_size / 2);
+        const uint32_t chunk_count = (uint32_t(context->slots.size()) + GPU_ZONES_PER_CHUNK - 1) / GPU_ZONES_PER_CHUNK;
+        context->free_chunks.reserve(chunk_count);
+        for (uint32_t i = chunk_count; i > 0; --i)
+            context->free_chunks.push_back(i - 1);
+        {
+            std::lock_guard lock(thread_mutex);
+            context->timeline_id = uint32_t(timelines.size());
+            timelines.push_back({
+                ProfilerTimelineType::gpu,
+                fmt::format("GPU {} queue {}", uintptr_t(device), uint32_t(queue)),
+                0,
+                uint64_t(uintptr_t(device)),
+                queue,
+            });
+        }
+        GpuContext* result = context.get();
+        context->close_callback = device->register_device_close_callback(
+            [this, result](Device*)
+            {
+                std::lock_guard lock(gpu_mutex);
+                result->closed.store(true, std::memory_order_release);
+                for (auto& [recording_id, recording] : result->recordings) {
+                    SGL_UNUSED(recording_id);
+                    queue_missing_gpu_results(*result, *recording);
+                    pending_gpu_zone_count.fetch_sub(
+                        result->recording_zone_count(*recording),
+                        std::memory_order_relaxed
+                    );
+                    result->recycle_recording(*recording);
+                }
+                result->recordings.clear();
+            }
+        );
+        context->submitted_callback = device->register_command_recording_submitted_callback(
+            [this, result](const CommandRecordingSubmittedEvent& event)
+            {
+                std::lock_guard lock(gpu_mutex);
+                if (auto it = result->recordings.find(event.id); it != result->recordings.end()) {
+                    it->second->submitted = true;
+                    it->second->submit_id = event.submit_id;
+                }
+            }
+        );
+        context->discarded_callback = device->register_command_recording_discarded_callback(
+            [this, result](const CommandRecordingDiscardedEvent& event)
+            {
+                std::lock_guard lock(gpu_mutex);
+                if (auto it = result->recordings.find(event.id); it != result->recordings.end()) {
+                    queue_missing_gpu_results(*result, *it->second);
+                    pending_gpu_zone_count.fetch_sub(
+                        result->recording_zone_count(*it->second),
+                        std::memory_order_relaxed
+                    );
+                    result->recycle_recording(*it->second);
+                    result->recordings.erase(it);
+                }
+            }
+        );
+        gpu_contexts.push_back(std::move(context));
+        return result;
+    }
+
+    GpuSlot* begin_gpu_zone(ProfilerZoneToken& token, CommandEncoder* encoder, uint64_t parent_correlation_id)
+    {
+        ThreadData* thread = static_cast<ThreadData*>(token.thread_data);
+        const uint64_t recording_id = encoder->recording_id();
+        GpuContext* context = static_cast<GpuContext*>(thread->gpu_context);
+        GpuRecording* recording = static_cast<GpuRecording*>(thread->gpu_recording);
+
+        bool needs_chunk = thread->gpu_recording_id != recording_id || !context || !recording
+            || recording->chunk_cursor >= context->chunk_capacity(recording->current_chunk);
+        if (needs_chunk) {
+            std::lock_guard lock(gpu_mutex);
+            context = get_or_create_gpu_context(encoder);
+            if (!context)
+                return nullptr;
+            auto& recording_ptr = context->recordings[recording_id];
+            if (!recording_ptr)
+                recording_ptr = std::make_unique<GpuRecording>();
+            recording = recording_ptr.get();
+            if (recording->chunk_cursor
+                >= (recording->current_chunk == INVALID_INDEX ? 0
+                                                              : context->chunk_capacity(recording->current_chunk))) {
+                if (context->free_chunks.empty()) {
+                    gpu_query_exhaustion_count.fetch_add(1, std::memory_order_relaxed);
+                    return nullptr;
+                }
+                recording->current_chunk = context->free_chunks.back();
+                context->free_chunks.pop_back();
+                recording->chunk_cursor = 0;
+                recording->chunks.push_back(recording->current_chunk);
+                const uint32_t first_query = recording->current_chunk * GPU_ZONES_PER_CHUNK * 2;
+                context->query_pool->reset(first_query, context->chunk_capacity(recording->current_chunk) * 2);
+            }
+            thread->gpu_recording_id = recording_id;
+            thread->gpu_context = context;
+            thread->gpu_recording = recording;
+        }
+
+        const uint32_t index = recording->current_chunk * GPU_ZONES_PER_CHUNK + recording->chunk_cursor++;
+        GpuSlot& slot = context->slots[index];
+        slot.correlation_id = token.correlation_id;
+        slot.parent_correlation_id = parent_correlation_id;
+        slot.site_id = token.site_id;
+        slot.frame_index = token.frame_index;
+        slot.ended = false;
+        encoder->write_timestamp(context->query_pool, index * 2);
+        token.gpu_state = context;
+        token.gpu_begin_query = index;
+        pending_gpu_zone_count.fetch_add(1, std::memory_order_relaxed);
+        return &slot;
+    }
+
+    void end_gpu_zone(const ProfilerZoneToken& token)
+    {
+        if (!token.gpu_state || token.gpu_begin_query == INVALID_INDEX)
+            return;
+        GpuContext* context = static_cast<GpuContext*>(token.gpu_state);
+        if (context->closed.load(std::memory_order_acquire) || token.gpu_begin_query >= context->slots.size())
+            return;
+        GpuSlot& slot = context->slots[token.gpu_begin_query];
+        token.command_encoder->write_timestamp(context->query_pool, token.gpu_begin_query * 2 + 1);
+        std::atomic_ref(slot.ended).store(true, std::memory_order_release);
+    }
+
+    const GpuCalibration& get_gpu_calibration(GpuContext& context)
+    {
+        const uint64_t current_ns = now_ns();
+        const bool expired = !context.calibration.valid || current_ns < context.calibration.refreshed_ns
+            || current_ns - context.calibration.refreshed_ns >= GPU_CALIBRATION_INTERVAL_NS;
+        if (expired) {
+            const uint64_t before_ns = current_ns;
+            context.calibration.value = context.device->get_timestamp_calibration(context.queue);
+            const uint64_t after_ns = now_ns();
+            SGL_CHECK(context.calibration.value.gpu_frequency != 0, "Invalid GPU timestamp calibration frequency");
+            context.calibration.anchor_ns = before_ns / 2 + after_ns / 2 + ((before_ns & 1) + (after_ns & 1)) / 2;
+            context.calibration.refreshed_ns = after_ns;
+            context.calibration.valid = true;
+        }
+        return context.calibration;
+    }
+
+    void tick_gpu()
+    {
+        std::vector<GpuResult> results;
+        std::lock_guard lock(gpu_mutex);
+        for (const auto& context_ptr : gpu_contexts) {
+            GpuContext& context = *context_ptr;
+            if (context.closed.load(std::memory_order_acquire))
+                continue;
+            const GpuCalibration* calibration = nullptr;
+            for (auto it = context.recordings.begin(); it != context.recordings.end();) {
+                GpuRecording& recording = *it->second;
+                if (!recording.submitted || !context.device->is_submit_finished(recording.submit_id)) {
+                    ++it;
+                    continue;
+                }
+
+                bool resolved = true;
+                for (uint32_t chunk : recording.chunks) {
+                    const uint32_t zone_count
+                        = chunk == recording.current_chunk ? recording.chunk_cursor : context.chunk_capacity(chunk);
+                    const uint32_t first_query = chunk * GPU_ZONES_PER_CHUNK * 2;
+                    if (context.query_pool->get_result_state(first_query, zone_count * 2)
+                        != QueryResultState::resolved) {
+                        resolved = false;
+                        break;
+                    }
+                }
+                if (!resolved) {
+                    ++it;
+                    continue;
+                }
+
+                if (!calibration)
+                    calibration = &get_gpu_calibration(context);
+
+                const auto to_ns = [&](uint64_t tick)
+                {
+                    const int64_t delta = tick >= calibration->value.gpu_timestamp
+                        ? int64_t(tick - calibration->value.gpu_timestamp)
+                        : -int64_t(calibration->value.gpu_timestamp - tick);
+                    return uint64_t(
+                        int64_t(calibration->anchor_ns)
+                        + int64_t((static_cast<long double>(delta) * 1.0e9L) / calibration->value.gpu_frequency)
+                    );
+                };
+                const auto duration_ns = [&](uint64_t begin_tick, uint64_t end_tick)
+                {
+                    if (end_tick < begin_tick)
+                        return uint64_t(0);
+                    return uint64_t(
+                        (static_cast<long double>(end_tick - begin_tick) * 1.0e9L) / calibration->value.gpu_frequency
+                    );
+                };
+                for (uint32_t chunk : recording.chunks) {
+                    const uint32_t zone_count
+                        = chunk == recording.current_chunk ? recording.chunk_cursor : context.chunk_capacity(chunk);
+                    const uint32_t first_slot = chunk * GPU_ZONES_PER_CHUNK;
+                    const uint32_t first_query = first_slot * 2;
+                    const std::vector<uint64_t> ticks = context.query_pool->get_results(first_query, zone_count * 2);
+                    for (uint32_t i = 0; i < zone_count; ++i) {
+                        GpuSlot& slot = context.slots[first_slot + i];
+                        if (!std::atomic_ref(slot.ended).load(std::memory_order_acquire))
+                            continue;
+                        StoredZone zone;
+                        zone.start_ns = to_ns(ticks[i * 2]);
+                        zone.duration_ns = duration_ns(ticks[i * 2], ticks[i * 2 + 1]);
+                        zone.correlation_id = slot.correlation_id;
+                        zone.parent_correlation_id = slot.parent_correlation_id;
+                        zone.timeline_id = context.timeline_id;
+                        zone.site_id = slot.site_id;
+                        zone.frame_index = slot.frame_index == INVALID_INDEX ? -1 : int32_t(slot.frame_index);
+                        results.push_back({zone, false});
+                    }
+                }
+                pending_gpu_zone_count.fetch_sub(context.recording_zone_count(recording), std::memory_order_relaxed);
+                context.recycle_recording(recording);
+                it = context.recordings.erase(it);
+            }
+        }
+        if (!results.empty()) {
+            std::lock_guard result_lock(gpu_result_mutex);
+            pending_gpu_results.insert(pending_gpu_results.end(), results.begin(), results.end());
+        }
+    }
+
+    void shutdown_gpu()
+    {
+        std::lock_guard lock(gpu_mutex);
+        for (const auto& context : gpu_contexts) {
+            if (context->closed.load(std::memory_order_acquire))
+                continue;
+            context->device->unregister_command_recording_discarded_callback(context->discarded_callback);
+            context->device->unregister_command_recording_submitted_callback(context->submitted_callback);
+            context->device->unregister_device_close_callback(context->close_callback);
+        }
+        gpu_contexts.clear();
+    }
+
+    template<typename ZoneContainer>
+    ref<ProfilerTrace> make_trace(
+        const ZoneContainer& zones,
+        const std::vector<ProfilerFrame>& frames,
+        uint64_t start,
+        uint64_t stop,
+        ProfilerCaptureStopReason reason,
+        bool truncated,
+        uint64_t memory_bytes
+    ) const
+    {
+        ref<ProfilerTrace> trace(new ProfilerTrace());
+        trace->m_start_ns = start;
+        trace->m_stop_ns = stop;
+        trace->m_stop_reason = reason;
+        trace->m_truncated = truncated;
+        trace->m_memory_bytes = memory_bytes;
+        trace->m_diagnostics = make_diagnostics();
+        trace->m_sites = site_snapshot();
+        {
+            std::lock_guard lock(thread_mutex);
+            trace->m_timelines = timelines;
+        }
+        trace->m_frames = frames;
+        std::unordered_map<uint32_t, std::unordered_map<uint64_t, uint32_t>> indices;
+        for (uint32_t i = 0; i < zones.size(); ++i)
+            indices[zones[i].timeline_id].emplace(zones[i].correlation_id, i);
+
+        ref<ProfilerZoneChunk> chunk;
+        for (uint32_t i = 0; i < zones.size(); ++i) {
+            if (!chunk || chunk->size() == ZONE_CHUNK_SIZE) {
+                chunk = ref<ProfilerZoneChunk>(new ProfilerZoneChunk());
+                const size_t reserve_count = std::min<size_t>(ZONE_CHUNK_SIZE, zones.size() - i);
+                chunk->start_ns.reserve(reserve_count);
+                chunk->duration_ns.reserve(reserve_count);
+                chunk->correlation_id.reserve(reserve_count);
+                chunk->timeline_id.reserve(reserve_count);
+                chunk->site_id.reserve(reserve_count);
+                chunk->parent_index.reserve(reserve_count);
+                chunk->frame_index.reserve(reserve_count);
+                trace->m_zone_chunks.push_back(chunk);
+            }
+            const StoredZone& zone = zones[i];
+            int32_t parent = -1;
+            if (zone.parent_correlation_id != 0) {
+                auto timeline_it = indices.find(zone.timeline_id);
+                if (timeline_it != indices.end()) {
+                    auto it = timeline_it->second.find(zone.parent_correlation_id);
+                    if (it != timeline_it->second.end())
+                        parent = int32_t(it->second);
+                }
+            }
+            chunk->start_ns.push_back(zone.start_ns);
+            chunk->duration_ns.push_back(zone.duration_ns);
+            chunk->correlation_id.push_back(zone.correlation_id);
+            chunk->timeline_id.push_back(zone.timeline_id);
+            chunk->site_id.push_back(zone.site_id);
+            chunk->parent_index.push_back(parent);
+            chunk->frame_index.push_back(zone.frame_index);
+        }
+        return trace;
+    }
+
+    ref<ProfilerFrameStats> make_frame_stats() const
+    {
+        struct AggregatedNode {
+            int32_t parent_index{-1};
+            uint32_t site_id{0};
+            CallAccumulator cpu;
+            CallAccumulator gpu;
+        };
+
+        ref<ProfilerFrameStats> result(new ProfilerFrameStats());
+        const std::vector<ProfilerSite> sites = site_snapshot();
+        result->m_pending_frame_count = frame_stats_pending_frames.size();
+        const size_t frame_count = frame_stats_completed_frames.size();
+        std::vector<uint64_t> frame_durations;
+        frame_durations.reserve(frame_count);
+        result->m_sample_frame_index.reserve(frame_count);
+        result->m_sample_frame_time_ms.reserve(frame_count);
+        for (const FrameRecord& frame : frame_stats_completed_frames) {
+            frame_durations.push_back(frame.frame.duration_ns);
+            result->m_sample_frame_index.push_back(frame.frame.index);
+            result->m_sample_frame_time_ms.push_back(double(frame.frame.duration_ns) * 1e-6);
+        }
+        result->m_frame_time = calculate_statistics(std::move(frame_durations));
+
+        std::vector<AggregatedNode> nodes;
+        std::unordered_map<uint64_t, uint32_t> path_lookup;
+        for (const FrameRecord& frame : frame_stats_completed_frames) {
+            std::vector<uint32_t> local_to_global(frame.nodes.size());
+            for (size_t local_index = 0; local_index < frame.nodes.size(); ++local_index) {
+                const FrameNodeData& node = frame.nodes[local_index];
+                const int32_t parent = node.parent_index < 0 ? -1 : int32_t(local_to_global[size_t(node.parent_index)]);
+                const uint64_t key = (uint64_t(uint32_t(parent + 1)) << 32) | node.site_id;
+                uint32_t global_index;
+                if (auto it = path_lookup.find(key); it != path_lookup.end()) {
+                    global_index = it->second;
+                } else {
+                    global_index = uint32_t(nodes.size());
+                    AggregatedNode aggregated;
+                    aggregated.parent_index = parent;
+                    aggregated.site_id = node.site_id;
+                    nodes.push_back(std::move(aggregated));
+                    path_lookup.emplace(key, global_index);
+                }
+                local_to_global[local_index] = global_index;
+                AggregatedNode& aggregated = nodes[global_index];
+                aggregated.cpu.merge(node.cpu);
+                aggregated.gpu.merge(node.gpu);
+            }
+        }
+
+        std::vector<std::vector<uint32_t>> children(nodes.size());
+        std::vector<uint32_t> roots;
+        for (uint32_t index = 0; index < nodes.size(); ++index) {
+            const int32_t parent = nodes[index].parent_index;
+            if (parent < 0)
+                roots.push_back(index);
+            else
+                children[size_t(parent)].push_back(index);
+        }
+        const auto node_less = [&](uint32_t left, uint32_t right)
+        {
+            const ProfilerSite* left_site = find_site(sites, nodes[left].site_id);
+            const ProfilerSite* right_site = find_site(sites, nodes[right].site_id);
+            const std::string_view left_name = left_site ? left_site->name : std::string_view();
+            const std::string_view right_name = right_site ? right_site->name : std::string_view();
+            if (left_name != right_name)
+                return left_name < right_name;
+            return nodes[left].site_id < nodes[right].site_id;
+        };
+        std::sort(roots.begin(), roots.end(), node_less);
+        for (std::vector<uint32_t>& siblings : children)
+            std::sort(siblings.begin(), siblings.end(), node_less);
+
+        std::vector<uint32_t> canonical_order;
+        canonical_order.reserve(nodes.size());
+        const auto append_preorder = [&](auto&& self, uint32_t index) -> void
+        {
+            canonical_order.push_back(index);
+            for (uint32_t child : children[index])
+                self(self, child);
+        };
+        for (uint32_t root : roots)
+            append_preorder(append_preorder, root);
+
+        std::vector<uint32_t> old_to_canonical(nodes.size());
+        for (uint32_t index = 0; index < canonical_order.size(); ++index)
+            old_to_canonical[canonical_order[index]] = index;
+
+        const size_t entry_count = nodes.size();
+        const size_t matrix_size = frame_count * entry_count;
+        result->m_sample_call_count.resize(matrix_size);
+        result->m_sample_cpu_time_ms.resize(matrix_size);
+        result->m_sample_gpu_time_ms.resize(matrix_size);
+        result->m_sample_gpu_status.resize(matrix_size, ProfilerFrameGpuStatus::absent);
+        for (size_t frame_index = 0; frame_index < frame_count; ++frame_index) {
+            const FrameRecord& source_frame = frame_stats_completed_frames[frame_index];
+            std::vector<uint32_t> local_to_global(source_frame.nodes.size());
+            for (size_t local_index = 0; local_index < source_frame.nodes.size(); ++local_index) {
+                const FrameNodeData& node = source_frame.nodes[local_index];
+                const int32_t parent = node.parent_index < 0 ? -1 : int32_t(local_to_global[size_t(node.parent_index)]);
+                const uint64_t key = (uint64_t(uint32_t(parent + 1)) << 32) | node.site_id;
+                const uint32_t old_index = path_lookup.at(key);
+                local_to_global[local_index] = old_index;
+                const size_t offset = frame_index * entry_count + old_to_canonical[old_index];
+                result->m_sample_call_count[offset] = uint32_t(node.cpu.count);
+                result->m_sample_cpu_time_ms[offset] = double(node.cpu.total_ns) * 1e-6;
+                result->m_sample_gpu_time_ms[offset] = double(node.gpu.total_ns) * 1e-6;
+                if (node.gpu_requested_count == 0) {
+                    result->m_sample_gpu_status[offset] = ProfilerFrameGpuStatus::unavailable;
+                } else if (node.missing_gpu_call_count != 0) {
+                    result->m_sample_gpu_status[offset] = ProfilerFrameGpuStatus::incomplete;
+                } else {
+                    result->m_sample_gpu_status[offset] = ProfilerFrameGpuStatus::complete;
+                }
+            }
+        }
+
+        result->m_entries.reserve(entry_count);
+        std::vector<double> cpu_frames;
+        std::vector<double> valid_gpu_frames;
+        cpu_frames.reserve(frame_count);
+        valid_gpu_frames.reserve(frame_count);
+        for (size_t entry_index = 0; entry_index < canonical_order.size(); ++entry_index) {
+            const uint32_t old_index = canonical_order[entry_index];
+            AggregatedNode& node = nodes[old_index];
+            ProfilerFrameStatsEntry entry;
+            entry.parent_index = node.parent_index < 0 ? -1 : int32_t(old_to_canonical[size_t(node.parent_index)]);
+            entry.site_id = node.site_id;
+            if (const ProfilerSite* site = find_site(sites, node.site_id))
+                entry.name = site->name;
+            bool has_complete_gpu_frame = false;
+            cpu_frames.clear();
+            valid_gpu_frames.clear();
+            for (size_t frame_index = 0; frame_index < frame_count; ++frame_index) {
+                const size_t offset = frame_index * entry_count + entry_index;
+                cpu_frames.push_back(result->m_sample_cpu_time_ms[offset]);
+                switch (result->m_sample_gpu_status[offset]) {
+                case ProfilerFrameGpuStatus::absent:
+                    valid_gpu_frames.push_back(0.0);
+                    break;
+                case ProfilerFrameGpuStatus::unavailable:
+                    break;
+                case ProfilerFrameGpuStatus::complete:
+                    has_complete_gpu_frame = true;
+                    valid_gpu_frames.push_back(result->m_sample_gpu_time_ms[offset]);
+                    break;
+                case ProfilerFrameGpuStatus::incomplete:
+                    break;
+                }
+            }
+            entry.cpu_time_per_frame = calculate_statistics_ms(cpu_frames);
+            if (has_complete_gpu_frame)
+                entry.gpu_time_per_frame = calculate_statistics_ms(valid_gpu_frames);
+            entry.cpu_time_per_call = node.cpu.statistics();
+            entry.gpu_time_per_call = node.gpu.statistics();
+            result->m_entries.push_back(std::move(entry));
+        }
+        result->m_diagnostics = make_diagnostics();
+        return result;
+    }
+
+    void publish(bool publish_live, bool publish_frame_stats)
+    {
+        ref<ProfilerTrace> live;
+        ref<ProfilerFrameStats> frame_stats;
+        if (publish_live) {
+            const uint64_t now = now_ns();
+            live = make_trace(
+                live_zones,
+                live_frames,
+                live_zones.empty() ? now : live_zones.front().start_ns,
+                now,
+                ProfilerCaptureStopReason::user,
+                false,
+                live_zones.size() * sizeof(StoredZone)
+            );
+        }
+        if (publish_frame_stats)
+            frame_stats = make_frame_stats();
+        std::lock_guard lock(snapshot_mutex);
+        if (publish_live) {
+            if (live_published && live_published->self_py())
+                retired_live_snapshots.push_back(std::move(live_published));
+            live_published = std::move(live);
+        }
+        if (publish_frame_stats) {
+            if (frame_stats_published && frame_stats_published->self_py())
+                retired_frame_stats_snapshots.push_back(std::move(frame_stats_published));
+            frame_stats_published = std::move(frame_stats);
+        }
+    }
+
+    bool flush_targets_satisfied() const
+    {
+        if (!flush_pending)
+            return false;
+        std::lock_guard lock(thread_mutex);
+        if (flush_targets.size() > threads.size())
+            return false;
+        for (size_t i = 0; i < flush_targets.size(); ++i) {
+            if (threads[i]->read_index.value.load(std::memory_order_acquire) < flush_targets[i])
+                return false;
+        }
+        return true;
+    }
+
+    void worker_main()
+    {
+        platform::set_current_thread_name("Profiler");
+        auto last_publish = std::chrono::steady_clock::now();
+        bool live_dirty = false;
+        bool frame_stats_dirty = false;
+        for (;;) {
+            {
+                std::unique_lock lock(control_mutex);
+                control_cv.wait_for(
+                    lock,
+                    std::chrono::milliseconds(1),
+                    [&]
+                    {
+                        return stopping || flush_pending || clear_frame_stats_requested != clear_frame_stats_completed
+                            || live_snapshot_refresh_requested.load(std::memory_order_relaxed)
+                            || frame_stats_snapshot_refresh_requested.load(std::memory_order_relaxed);
+                    }
+                );
+            }
+            if (drain()) {
+                live_dirty = true;
+                frame_stats_dirty = true;
+            }
+            const auto now = std::chrono::steady_clock::now();
+            const bool interval_elapsed = now - last_publish >= std::chrono::milliseconds(16);
+            const bool publish_live = live_snapshot_refresh_requested.exchange(false, std::memory_order_relaxed)
+                || (live_dirty && live_snapshot_interest.load(std::memory_order_relaxed) && interval_elapsed);
+            const bool publish_frame_stats
+                = frame_stats_snapshot_refresh_requested.exchange(false, std::memory_order_relaxed)
+                || (frame_stats_dirty && frame_stats_snapshot_interest.load(std::memory_order_relaxed)
+                    && interval_elapsed);
+            if (publish_live || publish_frame_stats) {
+                publish(publish_live, publish_frame_stats);
+                live_dirty &= !publish_live;
+                frame_stats_dirty &= !publish_frame_stats;
+                last_publish = now;
+            }
+            {
+                std::lock_guard lock(control_mutex);
+                if (flush_targets_satisfied()) {
+                    publish(true, true);
+                    live_dirty = false;
+                    frame_stats_dirty = false;
+                    flush_completed = flush_requested;
+                    flush_pending = false;
+                    control_cv.notify_all();
+                }
+                if (clear_frame_stats_requested != clear_frame_stats_completed) {
+                    frame_stats_pending_frames.clear();
+                    frame_stats_completed_frames.clear();
+                    pending_frames.clear();
+                    frame_stats_min_index = next_frame_index.load(std::memory_order_relaxed);
+                    publish(false, true);
+                    frame_stats_dirty = false;
+                    clear_frame_stats_completed = clear_frame_stats_requested;
+                    control_cv.notify_all();
+                }
+                if (stopping) {
+                    const bool final_live = live_dirty && live_snapshot_interest.load(std::memory_order_relaxed);
+                    const bool final_frame_stats
+                        = frame_stats_dirty && frame_stats_snapshot_interest.load(std::memory_order_relaxed);
+                    if (final_live || final_frame_stats)
+                        publish(final_live, final_frame_stats);
+                    return;
+                }
+            }
+        }
+    }
+
+    void flush()
+    {
+        std::unique_lock control_lock(control_mutex);
+        ++flush_requested;
+        const uint64_t request = flush_requested;
+        {
+            std::lock_guard thread_lock(thread_mutex);
+            flush_targets.clear();
+            flush_targets.reserve(threads.size());
+            for (const auto& thread : threads)
+                flush_targets.push_back(thread->write_index.value.load(std::memory_order_acquire));
+        }
+        flush_pending = true;
+        control_cv.notify_all();
+        control_cv.wait(
+            control_lock,
+            [&]
+            {
+                return flush_completed >= request;
+            }
+        );
+    }
+
+    Profiler* owner;
+    ProfilerDesc desc;
+    uint64_t instance_id;
+    std::shared_ptr<void> lifetime{std::make_shared<uint8_t>(uint8_t{0})};
+    mutable std::mutex thread_mutex;
+    std::vector<std::unique_ptr<ThreadData>> threads;
+    std::vector<ProfilerTimeline> timelines;
+    std::vector<CpuEvent> drained_cpu_events;
+
+    std::thread worker;
+    mutable std::mutex control_mutex;
+    std::condition_variable control_cv;
+    bool stopping{false};
+    bool flush_pending{false};
+    uint64_t flush_requested{0};
+    uint64_t flush_completed{0};
+    std::vector<uint64_t> flush_targets;
+    uint64_t clear_frame_stats_requested{0};
+    uint64_t clear_frame_stats_completed{0};
+
+    mutable std::mutex snapshot_mutex;
+    ref<ProfilerTrace> live_published;
+    ref<ProfilerFrameStats> frame_stats_published;
+    // Snapshot objects can transition to Python ownership after publication. The
+    // collector must never increment or decrement such references without the GIL,
+    // so old snapshots are moved here and released with the profiler itself.
+    std::vector<ref<ProfilerTrace>> retired_live_snapshots;
+    std::vector<ref<ProfilerFrameStats>> retired_frame_stats_snapshots;
+    std::atomic<bool> live_snapshot_interest{false};
+    std::atomic<bool> frame_stats_snapshot_interest{false};
+    std::atomic<bool> live_snapshot_refresh_requested{false};
+    std::atomic<bool> frame_stats_snapshot_refresh_requested{false};
+
+    std::deque<StoredZone> live_zones;
+    std::vector<ProfilerFrame> live_frames;
+    std::deque<uint32_t> frame_stats_pending_frames;
+    std::deque<FrameRecord> frame_stats_completed_frames;
+    std::unordered_map<uint32_t, PendingFrameData> pending_frames;
+    uint32_t frame_stats_min_index{0};
+    uint64_t hierarchy_loss_count{0};
+
+    mutable std::mutex capture_mutex;
+    ProfilerCaptureDesc capture_desc;
+    CaptureState capture_state{CaptureState::idle};
+    ProfilerCaptureStopReason capture_reason{ProfilerCaptureStopReason::user};
+    uint64_t capture_start_ns{0};
+    uint64_t capture_stop_ns{0};
+    std::vector<StoredZone> capture_zones;
+    std::vector<ProfilerFrame> capture_frames;
+
+    std::atomic<uint32_t> next_frame_index{0};
+    std::mutex global_frame_mutex;
+    std::atomic<uint64_t> global_frame{0};
+    CpuEvent global_frame_event;
+    std::mutex sealed_frame_mutex;
+    std::vector<CpuEvent> sealed_frame_events;
+    std::atomic<uint64_t> gpu_query_exhaustion_count{0};
+    std::atomic<uint64_t> pending_gpu_zone_count{0};
+    std::mutex gpu_mutex;
+    std::vector<std::unique_ptr<GpuContext>> gpu_contexts;
+    std::mutex gpu_result_mutex;
+    std::vector<GpuResult> pending_gpu_results;
+};
+
+uint32_t Profiler::register_site(std::string_view file, uint32_t line, std::string_view function, std::string_view name)
+{
+    SiteRegistry& registry = site_registry();
+    std::lock_guard lock(registry.mutex);
+    const uint32_t file_id = registry.strings.intern(file);
+    const uint32_t function_signature_id = registry.strings.intern(function);
+    const uint32_t function_id = registry.compact_function_id(function_signature_id);
+    const uint32_t name_id = name.empty() || name == function ? function_id : registry.strings.intern(name);
+    const SiteKey key{file_id, line, function_signature_id, name_id};
+    if (auto it = registry.ids.find(key); it != registry.ids.end())
+        return it->second;
+    const uint32_t id = uint32_t(registry.sites.size() + 1);
+    registry.sites.push_back(
+        {id, registry.strings.get(file_id), line, registry.strings.get(function_id), registry.strings.get(name_id)}
+    );
+    registry.ids.emplace(key, id);
+    return id;
+}
+
+uint64_t ProfilerTrace::zone_count() const
+{
+    uint64_t result = 0;
+    for (const auto& chunk : m_zone_chunks)
+        result += chunk->size();
+    return result;
+}
+
+ProfilerDurationStatistics ProfilerZoneSelection::statistics() const
+{
+    std::vector<uint64_t> durations;
+    durations.reserve(m_indices.size());
+    uint32_t base = 0;
+    size_t selection_index = 0;
+    for (const auto& chunk : m_trace->m_zone_chunks) {
+        const uint32_t end = base + uint32_t(chunk->size());
+        while (selection_index < m_indices.size() && m_indices[selection_index] < end) {
+            durations.push_back(chunk->duration_ns[m_indices[selection_index] - base]);
+            ++selection_index;
+        }
+        base = end;
+    }
+    return calculate_statistics(std::move(durations));
+}
+
+ProfilerFrameStatsSampleView ProfilerFrameStats::sample(size_t index) const
+{
+    const uint32_t frame_index = m_sample_frame_index.at(index);
+    const size_t offset = index * entry_count();
+    return {
+        frame_index,
+        m_sample_frame_time_ms[index],
+        std::span<const uint32_t>(m_sample_call_count).subspan(offset, entry_count()),
+        std::span<const double>(m_sample_cpu_time_ms).subspan(offset, entry_count()),
+        std::span<const double>(m_sample_gpu_time_ms).subspan(offset, entry_count()),
+        std::span<const ProfilerFrameGpuStatus>(m_sample_gpu_status).subspan(offset, entry_count()),
+    };
+}
+
+std::string ProfilerFrameStats::to_string() const
+{
+    std::ostringstream stream;
+    stream << "ProfilerFrameStats(pending_frame_count=" << pending_frame_count() << ", sample_count=" << sample_count()
+           << ", latest=" << latest_frame_ms() << " ms"
+           << ", producer_drop_count=" << m_diagnostics.producer_drop_count
+           << ", thread_event_queue_high_water_mark=" << m_diagnostics.thread_event_queue_high_water_mark
+           << ", hierarchy_loss_count=" << m_diagnostics.hierarchy_loss_count
+           << ", gpu_query_exhaustion_count=" << m_diagnostics.gpu_query_exhaustion_count
+           << ", pending_gpu_zone_count=" << m_diagnostics.pending_gpu_zone_count << ')';
+    for (size_t index = 0; index < entries().size(); ++index) {
+        const ProfilerFrameStatsEntry& entry = entries()[index];
+        size_t depth = 0;
+        int32_t parent = entry.parent_index;
+        while (parent >= 0 && size_t(parent) < index && depth <= entries().size()) {
+            ++depth;
+            parent = entries()[size_t(parent)].parent_index;
+        }
+        uint64_t total_calls = 0;
+        for (size_t sample_index = 0; sample_index < sample_count(); ++sample_index)
+            total_calls += sample(sample_index).call_count[index];
+        const double mean_calls_per_frame = sample_count() == 0 ? 0.0 : double(total_calls) / double(sample_count());
+        stream << '\n'
+               << std::string((depth + 1) * 2, ' ') << entry.name << ": calls/frame mean=" << mean_calls_per_frame
+               << ", cpu/frame=";
+        if (entry.cpu_time_per_frame.count == 0)
+            stream << "n/a";
+        else
+            stream << entry.cpu_time_per_frame.mean_ms << " ms mean, " << entry.cpu_time_per_frame.p95_ms << " ms p95";
+        stream << ", gpu/frame=";
+        if (entry.gpu_time_per_frame.count == 0)
+            stream << "n/a";
+        else
+            stream << entry.gpu_time_per_frame.mean_ms << " ms mean, " << entry.gpu_time_per_frame.p95_ms << " ms p95";
+        stream << ", cpu/call=" << entry.cpu_time_per_call.count << " calls";
+        if (entry.gpu_time_per_call.count != 0)
+            stream << ", gpu/call=" << entry.gpu_time_per_call.count << " calls";
+    }
+    return stream.str();
+}
+
+ref<ProfilerZoneSelection> ProfilerTrace::query_zones(
+    std::optional<std::string> name,
+    std::optional<ProfilerTimelineType> timeline_type,
+    std::optional<uint32_t> frame_begin,
+    std::optional<uint32_t> frame_end,
+    std::optional<uint64_t> range_start_ns,
+    std::optional<uint64_t> range_end_ns
+) const
+{
+    SGL_CHECK(!frame_begin || !frame_end || *frame_begin <= *frame_end, "frame_begin must not exceed frame_end");
+    SGL_CHECK(!range_start_ns || !range_end_ns || *range_start_ns <= *range_end_ns, "start_ns must not exceed end_ns");
+    ref<ProfilerZoneSelection> result(new ProfilerZoneSelection());
+    result->m_trace = ref<ProfilerTrace>(const_cast<ProfilerTrace*>(this));
+    uint32_t global_index = 0;
+    for (const auto& chunk : m_zone_chunks) {
+        for (size_t i = 0; i < chunk->size(); ++i, ++global_index) {
+            const ProfilerSite* site = find_site(m_sites, chunk->site_id[i]);
+            if (name && (!site || site->name != *name))
+                continue;
+            if (timeline_type) {
+                const uint32_t id = chunk->timeline_id[i];
+                if (id >= m_timelines.size() || m_timelines[id].type != *timeline_type)
+                    continue;
+            }
+            const int32_t frame = chunk->frame_index[i];
+            if ((frame_begin || frame_end) && frame < 0)
+                continue;
+            if (frame_begin && uint32_t(frame) < *frame_begin)
+                continue;
+            if (frame_end && uint32_t(frame) >= *frame_end)
+                continue;
+            const uint64_t zone_start = chunk->start_ns[i];
+            const uint64_t zone_end = zone_start + chunk->duration_ns[i];
+            if (range_start_ns && zone_end <= *range_start_ns)
+                continue;
+            if (range_end_ns && zone_start >= *range_end_ns)
+                continue;
+            result->m_indices.push_back(global_index);
+        }
+    }
+    return result;
+}
+
+void ProfilerTrace::write_to_json(const std::filesystem::path& path) const
+{
+    std::ofstream stream(path, std::ios::binary);
+    SGL_CHECK(stream, "Failed to open profiler trace file '{}'", path);
+    stream << "{\"traceEvents\":[";
+    bool first = true;
+    auto separator = [&]
+    {
+        if (!first)
+            stream << ',';
+        first = false;
+    };
+    for (size_t timeline_id = 0; timeline_id < m_timelines.size(); ++timeline_id) {
+        const ProfilerTimeline& timeline = m_timelines[timeline_id];
+        separator();
+        stream << "{\"ph\":\"M\",\"name\":\"thread_name\",\"pid\":1,\"tid\":" << timeline_id << ",\"args\":{\"name\":";
+        write_json_string(stream, timeline.name);
+        stream << "}}";
+    }
+    for (const auto& chunk : m_zone_chunks) {
+        for (size_t i = 0; i < chunk->size(); ++i) {
+            separator();
+            const ProfilerSite* site = find_site(m_sites, chunk->site_id[i]);
+            stream << "{\"ph\":\"X\",\"name\":";
+            write_json_string(stream, site ? site->name : "unknown");
+            stream << ",\"pid\":1,\"tid\":" << chunk->timeline_id[i] << ",\"ts\":" << std::fixed << std::setprecision(3)
+                   << double(chunk->start_ns[i]) / 1000.0 << ",\"dur\":" << double(chunk->duration_ns[i]) / 1000.0
+                   << ",\"args\":{\"correlation_id\":" << chunk->correlation_id[i] << "}}";
+        }
+    }
+    struct FlowStart {
+        uint64_t timestamp_ns;
+        uint32_t timeline_id;
+    };
+    std::unordered_map<uint64_t, FlowStart> cpu_flow_starts;
+    for (const auto& chunk : m_zone_chunks) {
+        for (size_t i = 0; i < chunk->size(); ++i) {
+            const uint32_t timeline_id = chunk->timeline_id[i];
+            if (timeline_id < m_timelines.size() && m_timelines[timeline_id].type == ProfilerTimelineType::cpu)
+                cpu_flow_starts.emplace(chunk->correlation_id[i], FlowStart{chunk->start_ns[i], timeline_id});
+        }
+    }
+    for (const auto& chunk : m_zone_chunks) {
+        for (size_t i = 0; i < chunk->size(); ++i) {
+            const uint32_t timeline_id = chunk->timeline_id[i];
+            if (timeline_id >= m_timelines.size() || m_timelines[timeline_id].type != ProfilerTimelineType::gpu)
+                continue;
+            auto cpu = cpu_flow_starts.find(chunk->correlation_id[i]);
+            if (cpu == cpu_flow_starts.end())
+                continue;
+            separator();
+            stream << "{\"ph\":\"s\",\"cat\":\"cpu_gpu\",\"name\":\"CPU to GPU\",\"id\":" << chunk->correlation_id[i]
+                   << ",\"pid\":1,\"tid\":" << cpu->second.timeline_id
+                   << ",\"ts\":" << double(cpu->second.timestamp_ns) / 1000.0 << '}';
+            separator();
+            stream << "{\"ph\":\"f\",\"bp\":\"e\",\"cat\":\"cpu_gpu\",\"name\":\"CPU to GPU\",\"id\":"
+                   << chunk->correlation_id[i] << ",\"pid\":1,\"tid\":" << timeline_id
+                   << ",\"ts\":" << double(chunk->start_ns[i]) / 1000.0 << '}';
+        }
+    }
+    for (const ProfilerFrame& frame : m_frames) {
+        separator();
+        const ProfilerSite* site = find_site(m_sites, frame.site_id);
+        stream << "{\"ph\":\"X\",\"cat\":\"frame\",\"name\":";
+        write_json_string(stream, site ? site->name : "frame");
+        stream << ",\"pid\":1,\"tid\":" << frame.timeline_id << ",\"ts\":" << double(frame.start_ns) / 1000.0
+               << ",\"dur\":" << double(frame.duration_ns) / 1000.0 << '}';
+    }
+    stream << "],\"displayTimeUnit\":\"ns\"}";
+    SGL_CHECK(stream, "Failed while writing profiler trace file '{}'", path);
+}
+
+Profiler::Profiler(ProfilerDesc desc)
+    : m_desc(desc)
+    , m_enable_auto_zones(desc.enable_auto_zones)
+    , m_enable_debug_groups(desc.enable_debug_groups)
+{
+    SGL_CHECK(
+        desc.thread_event_capacity > 0 && (desc.thread_event_capacity & (desc.thread_event_capacity - 1)) == 0,
+        "thread_event_capacity must be a positive power of two"
+    );
+    SGL_CHECK(desc.live_frame_count > 0, "live_frame_count must be positive");
+    SGL_CHECK(desc.live_event_capacity > 0, "live_event_capacity must be positive");
+    SGL_CHECK(desc.frame_stats_window_size > 0, "frame_stats_window_size must be positive");
+    SGL_CHECK(
+        desc.gpu_query_pool_size > 0 && (desc.gpu_query_pool_size & 1) == 0,
+        "gpu_query_pool_size must be positive and even"
+    );
+    m_impl = std::make_unique<ProfilerImpl>(this, desc);
+    if (tls_profiler_stack.empty())
+        tls_profiler_stack.push_back(this);
+}
+
+Profiler::~Profiler()
+{
+    if (tls_profiler_stack.size() == 1 && tls_profiler_stack.back() == this)
+        tls_profiler_stack.clear();
+    std::erase_if(
+        tls_thread_cache,
+        [&](const TlsCacheEntry& entry)
+        {
+            return entry.profiler == this && entry.instance_id == m_impl->instance_id;
+        }
+    );
+    m_impl.reset();
+}
+
+bool Profiler::capture_active() const
+{
+    std::lock_guard lock(m_impl->capture_mutex);
+    return m_impl->capture_state == ProfilerImpl::CaptureState::recording;
+}
+
+void Profiler::start_capture(ProfilerCaptureDesc desc)
+{
+    SGL_CHECK(desc.max_memory_bytes > 0, "max_memory_bytes must be positive");
+    flush();
+    std::lock_guard lock(m_impl->capture_mutex);
+    SGL_CHECK(
+        m_impl->capture_state == ProfilerImpl::CaptureState::idle,
+        "A capture is already active or awaiting retrieval"
+    );
+    m_impl->capture_desc = desc;
+    m_impl->clear_capture_storage();
+    m_impl->capture_reason = ProfilerCaptureStopReason::user;
+    m_impl->capture_start_ns = now_ns();
+    m_impl->capture_stop_ns = 0;
+    m_impl->capture_state = ProfilerImpl::CaptureState::recording;
+}
+
+ref<ProfilerTrace> Profiler::stop_capture()
+{
+    tick();
+    flush();
+    std::lock_guard lock(m_impl->capture_mutex);
+    SGL_CHECK(m_impl->capture_state != ProfilerImpl::CaptureState::idle, "No active or completed capture");
+    if (m_impl->capture_state == ProfilerImpl::CaptureState::recording) {
+        m_impl->capture_state = ProfilerImpl::CaptureState::ready;
+        m_impl->capture_stop_ns = now_ns();
+        m_impl->capture_reason = ProfilerCaptureStopReason::user;
+    }
+    ref<ProfilerTrace> result = m_impl->make_trace(
+        m_impl->capture_zones,
+        m_impl->capture_frames,
+        m_impl->capture_start_ns,
+        m_impl->capture_stop_ns,
+        m_impl->capture_reason,
+        m_impl->capture_reason == ProfilerCaptureStopReason::memory_limit,
+        m_impl->capture_storage_bytes()
+    );
+    m_impl->capture_state = ProfilerImpl::CaptureState::idle;
+    m_impl->clear_capture_storage();
+    return result;
+}
+
+void Profiler::discard_capture()
+{
+    std::lock_guard lock(m_impl->capture_mutex);
+    SGL_CHECK(m_impl->capture_state != ProfilerImpl::CaptureState::idle, "No active or completed capture");
+    m_impl->capture_state = ProfilerImpl::CaptureState::idle;
+    m_impl->clear_capture_storage();
+}
+
+ref<ProfilerTrace> Profiler::live_snapshot() const
+{
+    if (!m_impl->live_snapshot_interest.exchange(true, std::memory_order_relaxed)) {
+        m_impl->live_snapshot_refresh_requested.store(true, std::memory_order_relaxed);
+        m_impl->control_cv.notify_all();
+    }
+    std::lock_guard lock(m_impl->snapshot_mutex);
+    return m_impl->live_published;
+}
+
+ref<ProfilerFrameStats> Profiler::frame_stats_snapshot() const
+{
+    if (!m_impl->frame_stats_snapshot_interest.exchange(true, std::memory_order_relaxed)) {
+        m_impl->frame_stats_snapshot_refresh_requested.store(true, std::memory_order_relaxed);
+        m_impl->control_cv.notify_all();
+    }
+    std::lock_guard lock(m_impl->snapshot_mutex);
+    return m_impl->frame_stats_published;
+}
+
+void Profiler::release_retired_snapshots()
+{
+    std::lock_guard lock(m_impl->snapshot_mutex);
+    m_impl->retired_live_snapshots.clear();
+    m_impl->retired_frame_stats_snapshots.clear();
+}
+
+void Profiler::clear_frame_stats()
+{
+    flush();
+    std::unique_lock lock(m_impl->control_mutex);
+    const uint64_t request = ++m_impl->clear_frame_stats_requested;
+    m_impl->control_cv.notify_all();
+    m_impl->control_cv.wait(
+        lock,
+        [&]
+        {
+            return m_impl->clear_frame_stats_completed >= request;
+        }
+    );
+}
+
+void Profiler::tick()
+{
+    m_impl->tick_gpu();
+}
+
+void Profiler::flush()
+{
+    m_impl->flush();
+}
+
+ProfilerZoneToken Profiler::begin_zone(uint32_t site_id, CommandEncoder* command_encoder) noexcept
+{
+    ProfilerZoneToken token;
+    if (!enabled())
+        return token;
+    ThreadData* data = m_impl->thread_data();
+    if (data->zone_depth == MAX_ZONE_DEPTH) {
+        data->stack_overflow_count.fetch_add(1, std::memory_order_relaxed);
+        return token;
+    }
+    const uint32_t sequence = ++data->local_sequence;
+    const uint64_t correlation = (uint64_t(data->timeline_id + 1) << 32) | sequence;
+    token.profiler = this;
+    token.thread_data = data;
+    token.command_encoder = command_encoder;
+    token.start_ns = now_ns();
+    token.correlation_id = correlation;
+    token.parent_correlation_id = data->zone_depth ? data->zone_stack[data->zone_depth - 1] : 0;
+    uint64_t gpu_parent_correlation_id = 0;
+    if (command_encoder) {
+        const uint64_t recording_id = command_encoder->recording_id();
+        for (uint32_t i = data->zone_depth; i > 0; --i) {
+            if (data->zone_gpu_recording_stack[i - 1] == recording_id) {
+                gpu_parent_correlation_id = data->zone_stack[i - 1];
+                break;
+            }
+        }
+    }
+    token.site_id = site_id;
+    m_impl->attach_zone_to_global_frame(token);
+    token.stack_index = data->zone_depth;
+    data->zone_stack[data->zone_depth] = correlation;
+    data->zone_gpu_recording_stack[data->zone_depth] = command_encoder ? command_encoder->recording_id() : 0;
+    ++data->zone_depth;
+    if (command_encoder && enable_debug_groups()) {
+        const std::string_view name = site_name(site_id);
+        if (!name.empty()) {
+            command_encoder->push_debug_group(name.data(), {});
+            token.debug_group_active = true;
+        }
+    }
+    if (command_encoder)
+        m_impl->begin_gpu_zone(token, command_encoder, gpu_parent_correlation_id);
+    return token;
+}
+
+void Profiler::end_zone(const ProfilerZoneToken& token) noexcept
+{
+    if (token.profiler != this || !token.thread_data)
+        return;
+    ThreadData* data = static_cast<ThreadData*>(token.thread_data);
+    const uint64_t end_ns = now_ns();
+    if (token.gpu_state)
+        m_impl->end_gpu_zone(token);
+    if (token.debug_group_active && token.command_encoder)
+        token.command_encoder->pop_debug_group();
+    if (data->zone_depth == 0 || token.stack_index + 1 != data->zone_depth
+        || data->zone_stack[token.stack_index] != token.correlation_id) {
+        data->stack_overflow_count.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    --data->zone_depth;
+    CpuEvent event;
+    event.type = CpuEvent::Type::zone;
+    event.start_ns = token.start_ns;
+    event.duration_ns = end_ns - token.start_ns;
+    event.correlation_id = token.correlation_id;
+    event.parent_correlation_id = token.parent_correlation_id;
+    event.timeline_id = data->timeline_id;
+    event.site_id = token.site_id;
+    event.frame_index = token.frame_index;
+    if (!token.command_encoder)
+        event.gpu_timing_status = GpuTimingStatus::unavailable;
+    else if (token.gpu_state)
+        event.gpu_timing_status = GpuTimingStatus::pending;
+    else
+        event.gpu_timing_status = GpuTimingStatus::missing;
+    data->push(event);
+    if (token.frame_index != INVALID_INDEX)
+        m_impl->release_zone_from_global_frame(token.frame_index);
+}
+
+ProfilerFrameToken Profiler::begin_frame(uint32_t site_id) noexcept
+{
+    ProfilerFrameToken token;
+    if (!enabled())
+        return token;
+    ThreadData* data = m_impl->thread_data();
+    m_impl->begin_global_frame(token, data, site_id, now_ns());
+    return token;
+}
+
+void Profiler::end_frame(const ProfilerFrameToken& token) noexcept
+{
+    if (token.profiler != this)
+        return;
+    m_impl->end_global_frame(token, now_ns());
+}
+
+std::string Profiler::to_string() const
+{
+    return fmt::format("Profiler(enabled={}, capture_active={})", enabled(), capture_active());
+}
+
+Profiler* current_profiler()
+{
+    SGL_CHECK(!tls_profiler_stack.empty(), "No current profiler on this thread");
+    return tls_profiler_stack.back();
+}
+
+Profiler* current_profiler_or_null() noexcept
+{
+    return tls_profiler_stack.empty() ? nullptr : tls_profiler_stack.back();
+}
+
+void push_current_profiler(Profiler* profiler)
+{
+    SGL_CHECK_NOT_NULL(profiler);
+    tls_profiler_stack.push_back(profiler);
+}
+
+Profiler* pop_current_profiler()
+{
+    SGL_CHECK(!tls_profiler_stack.empty(), "No current profiler on this thread");
+    Profiler* result = tls_profiler_stack.back();
+    tls_profiler_stack.pop_back();
+    return result;
+}
+
+ProfilerScope::ProfilerScope(Profiler* profiler)
+    : m_profiler(profiler)
+{
+    push_current_profiler(profiler);
+}
+
+ProfilerScope::~ProfilerScope()
+{
+    SGL_ASSERT(current_profiler_or_null() == m_profiler);
+    pop_current_profiler();
+}
+
+detail::ProfilerZoneGuard::ProfilerZoneGuard(uint32_t site_id, CommandEncoder* command_encoder) noexcept
+{
+    if (Profiler* profiler = current_profiler_or_null())
+        m_token = profiler->begin_zone(site_id, command_encoder);
+}
+
+detail::ProfilerZoneGuard::~ProfilerZoneGuard() noexcept
+{
+    if (m_token.profiler)
+        m_token.profiler->end_zone(m_token);
+}
+
+detail::ProfilerFrameGuard::ProfilerFrameGuard(uint32_t site_id) noexcept
+{
+    if (Profiler* profiler = current_profiler_or_null())
+        m_token = profiler->begin_frame(site_id);
+}
+
+detail::ProfilerFrameGuard::~ProfilerFrameGuard() noexcept
+{
+    if (m_token.profiler)
+        m_token.profiler->end_frame(m_token);
+}
+
+} // namespace sgl

--- a/src/sgl/utils/profiler.cpp
+++ b/src/sgl/utils/profiler.cpp
@@ -116,7 +116,13 @@ namespace {
             }
             --start;
         }
-        return std::string(prefix.substr(start));
+        std::string result(prefix.substr(start));
+        constexpr std::string_view anonymous_namespace = "(anonymous namespace)::";
+        for (size_t pos = result.find(anonymous_namespace); pos != std::string::npos;
+             pos = result.find(anonymous_namespace)) {
+            result.erase(pos, anonymous_namespace.size());
+        }
+        return result;
     }
 
     struct StringInterner {

--- a/src/sgl/utils/profiler.cpp
+++ b/src/sgl/utils/profiler.cpp
@@ -605,13 +605,19 @@ struct ProfilerImpl {
         finalizing = 3,
     };
 
-    static constexpr uint64_t GLOBAL_FRAME_STATUS_MASK = 3;
-    static constexpr uint64_t GLOBAL_FRAME_ZONE_COUNT_INCREMENT = 1ull << 2;
-    static constexpr uint64_t GLOBAL_FRAME_ZONE_COUNT_MASK = 0x3fffffffull << 2;
+    static constexpr uint32_t GLOBAL_FRAME_STATUS_BITS = 2;
+    static constexpr uint32_t GLOBAL_FRAME_ZONE_COUNT_BITS = 30;
+    static constexpr uint32_t GLOBAL_FRAME_INDEX_SHIFT = GLOBAL_FRAME_STATUS_BITS + GLOBAL_FRAME_ZONE_COUNT_BITS;
+    static constexpr uint32_t GLOBAL_FRAME_MAX_ZONE_COUNT = (1u << GLOBAL_FRAME_ZONE_COUNT_BITS) - 1;
+    static constexpr uint64_t GLOBAL_FRAME_STATUS_MASK = (1ull << GLOBAL_FRAME_STATUS_BITS) - 1;
+    static constexpr uint64_t GLOBAL_FRAME_ZONE_COUNT_INCREMENT = 1ull << GLOBAL_FRAME_STATUS_BITS;
+    static constexpr uint64_t GLOBAL_FRAME_ZONE_COUNT_MASK = uint64_t(GLOBAL_FRAME_MAX_ZONE_COUNT)
+        << GLOBAL_FRAME_STATUS_BITS;
 
     static uint64_t global_frame_state(uint32_t frame_index, GlobalFrameStatus status, uint32_t zone_count = 0)
     {
-        return uint64_t(frame_index) << 32 | uint64_t(zone_count) << 2 | uint64_t(status);
+        return uint64_t(frame_index) << GLOBAL_FRAME_INDEX_SHIFT | uint64_t(zone_count) << GLOBAL_FRAME_STATUS_BITS
+            | uint64_t(status);
     }
 
     static GlobalFrameStatus global_frame_status(uint64_t state)
@@ -619,11 +625,11 @@ struct ProfilerImpl {
         return GlobalFrameStatus(state & GLOBAL_FRAME_STATUS_MASK);
     }
 
-    static uint32_t global_frame_index(uint64_t state) { return uint32_t(state >> 32); }
+    static uint32_t global_frame_index(uint64_t state) { return uint32_t(state >> GLOBAL_FRAME_INDEX_SHIFT); }
 
     static uint32_t global_frame_zone_count(uint64_t state)
     {
-        return uint32_t((state & GLOBAL_FRAME_ZONE_COUNT_MASK) >> 2);
+        return uint32_t((state & GLOBAL_FRAME_ZONE_COUNT_MASK) >> GLOBAL_FRAME_STATUS_BITS);
     }
 
     std::optional<uint32_t> allocate_frame_index()
@@ -662,7 +668,7 @@ struct ProfilerImpl {
     {
         uint64_t state = global_frame.load(std::memory_order_acquire);
         while (global_frame_status(state) == GlobalFrameStatus::open) {
-            if (global_frame_zone_count(state) == 0x3fffffffu)
+            if (global_frame_zone_count(state) == GLOBAL_FRAME_MAX_ZONE_COUNT)
                 return;
             if (global_frame.compare_exchange_weak(
                     state,
@@ -1351,6 +1357,61 @@ struct ProfilerImpl {
         return trace;
     }
 
+    bool capture_active() const
+    {
+        std::lock_guard lock(capture_mutex);
+        return capture_state == CaptureState::recording;
+    }
+
+    void start_capture(ProfilerCaptureDesc capture_desc_)
+    {
+        SGL_CHECK(capture_desc_.max_memory_bytes > 0, "max_memory_bytes must be positive");
+        flush();
+
+        std::lock_guard lock(capture_mutex);
+        SGL_CHECK(capture_state == CaptureState::idle, "A capture is already active or awaiting retrieval");
+        capture_desc = capture_desc_;
+        clear_capture_storage();
+        capture_reason = ProfilerCaptureStopReason::user;
+        capture_start_ns = now_ns();
+        capture_stop_ns = 0;
+        capture_state = CaptureState::recording;
+    }
+
+    ref<ProfilerTrace> stop_capture()
+    {
+        tick_gpu();
+        flush();
+
+        std::lock_guard lock(capture_mutex);
+        SGL_CHECK(capture_state != CaptureState::idle, "No active or completed capture");
+        if (capture_state == CaptureState::recording) {
+            capture_state = CaptureState::ready;
+            capture_stop_ns = now_ns();
+            capture_reason = ProfilerCaptureStopReason::user;
+        }
+        ref<ProfilerTrace> result = make_trace(
+            capture_zones,
+            capture_frames,
+            capture_start_ns,
+            capture_stop_ns,
+            capture_reason,
+            capture_reason == ProfilerCaptureStopReason::memory_limit,
+            capture_storage_bytes()
+        );
+        capture_state = CaptureState::idle;
+        clear_capture_storage();
+        return result;
+    }
+
+    void discard_capture()
+    {
+        std::lock_guard lock(capture_mutex);
+        SGL_CHECK(capture_state != CaptureState::idle, "No active or completed capture");
+        capture_state = CaptureState::idle;
+        clear_capture_storage();
+    }
+
     ref<ProfilerFrameStats> make_frame_stats() const
     {
         struct AggregatedNode {
@@ -1966,58 +2027,22 @@ Profiler::~Profiler()
 
 bool Profiler::capture_active() const
 {
-    std::lock_guard lock(m_impl->capture_mutex);
-    return m_impl->capture_state == ProfilerImpl::CaptureState::recording;
+    return m_impl->capture_active();
 }
 
 void Profiler::start_capture(ProfilerCaptureDesc desc)
 {
-    SGL_CHECK(desc.max_memory_bytes > 0, "max_memory_bytes must be positive");
-    flush();
-    std::lock_guard lock(m_impl->capture_mutex);
-    SGL_CHECK(
-        m_impl->capture_state == ProfilerImpl::CaptureState::idle,
-        "A capture is already active or awaiting retrieval"
-    );
-    m_impl->capture_desc = desc;
-    m_impl->clear_capture_storage();
-    m_impl->capture_reason = ProfilerCaptureStopReason::user;
-    m_impl->capture_start_ns = now_ns();
-    m_impl->capture_stop_ns = 0;
-    m_impl->capture_state = ProfilerImpl::CaptureState::recording;
+    m_impl->start_capture(desc);
 }
 
 ref<ProfilerTrace> Profiler::stop_capture()
 {
-    tick();
-    flush();
-    std::lock_guard lock(m_impl->capture_mutex);
-    SGL_CHECK(m_impl->capture_state != ProfilerImpl::CaptureState::idle, "No active or completed capture");
-    if (m_impl->capture_state == ProfilerImpl::CaptureState::recording) {
-        m_impl->capture_state = ProfilerImpl::CaptureState::ready;
-        m_impl->capture_stop_ns = now_ns();
-        m_impl->capture_reason = ProfilerCaptureStopReason::user;
-    }
-    ref<ProfilerTrace> result = m_impl->make_trace(
-        m_impl->capture_zones,
-        m_impl->capture_frames,
-        m_impl->capture_start_ns,
-        m_impl->capture_stop_ns,
-        m_impl->capture_reason,
-        m_impl->capture_reason == ProfilerCaptureStopReason::memory_limit,
-        m_impl->capture_storage_bytes()
-    );
-    m_impl->capture_state = ProfilerImpl::CaptureState::idle;
-    m_impl->clear_capture_storage();
-    return result;
+    return m_impl->stop_capture();
 }
 
 void Profiler::discard_capture()
 {
-    std::lock_guard lock(m_impl->capture_mutex);
-    SGL_CHECK(m_impl->capture_state != ProfilerImpl::CaptureState::idle, "No active or completed capture");
-    m_impl->capture_state = ProfilerImpl::CaptureState::idle;
-    m_impl->clear_capture_storage();
+    m_impl->discard_capture();
 }
 
 ref<ProfilerTrace> Profiler::live_snapshot() const

--- a/src/sgl/utils/profiler.cpp
+++ b/src/sgl/utils/profiler.cpp
@@ -666,7 +666,7 @@ struct ProfilerImpl {
                 if (global_frame_status(state) != GlobalFrameStatus::open
                     || global_frame_index(state) != token.frame_index)
                     return;
-                const uint64_t closed_state = state & ~GLOBAL_FRAME_STATUS_MASK | uint64_t(GlobalFrameStatus::closed);
+                const uint64_t closed_state = (state & ~GLOBAL_FRAME_STATUS_MASK) | uint64_t(GlobalFrameStatus::closed);
                 if (global_frame.compare_exchange_weak(
                         state,
                         closed_state,
@@ -1020,7 +1020,7 @@ struct ProfilerImpl {
             return nullptr;
         const CommandQueueType queue = encoder->queue();
         for (const auto& context : gpu_contexts) {
-            if (device == context->device && context->queue == queue)
+            if (device == context->device.get() && context->queue == queue)
                 return context->closed.load(std::memory_order_acquire) ? nullptr : context.get();
         }
 

--- a/src/sgl/utils/profiler.cpp
+++ b/src/sgl/utils/profiler.cpp
@@ -301,7 +301,7 @@ namespace {
         uint64_t parent_correlation_id{0};
         uint32_t timeline_id{0};
         uint32_t site_id{0};
-        int32_t frame_index{-1};
+        uint32_t frame_index{INVALID_INDEX};
     };
 
 #if SGL_MSVC
@@ -626,22 +626,35 @@ struct ProfilerImpl {
         return uint32_t((state & GLOBAL_FRAME_ZONE_COUNT_MASK) >> 2);
     }
 
+    std::optional<uint32_t> allocate_frame_index()
+    {
+        uint32_t index = next_frame_index.load(std::memory_order_relaxed);
+        while (index != INVALID_INDEX) {
+            if (next_frame_index
+                    .compare_exchange_weak(index, index + 1, std::memory_order_relaxed, std::memory_order_relaxed))
+                return index;
+        }
+        return {};
+    }
+
     bool begin_global_frame(ProfilerFrameToken& token, ThreadData* data, uint32_t site_id, uint64_t start_ns)
     {
         std::lock_guard lock(global_frame_mutex);
         if (global_frame.load(std::memory_order_acquire) != uint64_t(GlobalFrameStatus::inactive))
             return false;
-        const uint32_t frame_index = next_frame_index.fetch_add(1, std::memory_order_relaxed);
+        const std::optional<uint32_t> frame_index = allocate_frame_index();
+        if (!frame_index)
+            return false;
         global_frame_event = {};
         global_frame_event.type = CpuEvent::Type::frame;
         global_frame_event.start_ns = start_ns;
         global_frame_event.timeline_id = data->timeline_id;
         global_frame_event.site_id = site_id;
-        global_frame_event.frame_index = frame_index;
-        global_frame.store(global_frame_state(frame_index, GlobalFrameStatus::open), std::memory_order_release);
+        global_frame_event.frame_index = *frame_index;
+        global_frame.store(global_frame_state(*frame_index, GlobalFrameStatus::open), std::memory_order_release);
         token.profiler = owner;
         token.start_ns = start_ns;
-        token.frame_index = frame_index;
+        token.frame_index = *frame_index;
         return true;
     }
 
@@ -898,7 +911,7 @@ struct ProfilerImpl {
         zone.parent_correlation_id = event.parent_correlation_id;
         zone.timeline_id = event.timeline_id;
         zone.site_id = event.site_id;
-        zone.frame_index = event.frame_index == INVALID_INDEX ? -1 : int32_t(event.frame_index);
+        zone.frame_index = event.frame_index;
         retain_zone(zone);
 
         if (event.frame_index != INVALID_INDEX && event.frame_index >= frame_stats_min_index) {
@@ -920,9 +933,9 @@ struct ProfilerImpl {
         const StoredZone& zone = result.zone;
         if (!result.missing)
             retain_zone(zone);
-        if (zone.frame_index < 0 || uint32_t(zone.frame_index) < frame_stats_min_index)
+        if (zone.frame_index == INVALID_INDEX || zone.frame_index < frame_stats_min_index)
             return;
-        auto pending_it = pending_frames.find(uint32_t(zone.frame_index));
+        auto pending_it = pending_frames.find(zone.frame_index);
         if (pending_it == pending_frames.end())
             return;
         auto zone_it = pending_it->second.zones.find(zone.correlation_id);
@@ -1009,7 +1022,7 @@ struct ProfilerImpl {
                 zone.parent_correlation_id = slot.parent_correlation_id;
                 zone.timeline_id = context.timeline_id;
                 zone.site_id = slot.site_id;
-                zone.frame_index = slot.frame_index == INVALID_INDEX ? -1 : int32_t(slot.frame_index);
+                zone.frame_index = slot.frame_index;
                 results.push_back({zone, true});
             }
         }
@@ -1247,7 +1260,7 @@ struct ProfilerImpl {
                         zone.parent_correlation_id = slot.parent_correlation_id;
                         zone.timeline_id = context.timeline_id;
                         zone.site_id = slot.site_id;
-                        zone.frame_index = slot.frame_index == INVALID_INDEX ? -1 : int32_t(slot.frame_index);
+                        zone.frame_index = slot.frame_index;
                         results.push_back({zone, false});
                     }
                 }
@@ -1308,13 +1321,13 @@ struct ProfilerImpl {
             if (!chunk || chunk->size() == ZONE_CHUNK_SIZE) {
                 chunk = ref<ProfilerZoneChunk>(new ProfilerZoneChunk());
                 const size_t reserve_count = std::min<size_t>(ZONE_CHUNK_SIZE, zones.size() - i);
-                chunk->start_ns.reserve(reserve_count);
-                chunk->duration_ns.reserve(reserve_count);
-                chunk->correlation_id.reserve(reserve_count);
-                chunk->timeline_id.reserve(reserve_count);
-                chunk->site_id.reserve(reserve_count);
-                chunk->parent_index.reserve(reserve_count);
-                chunk->frame_index.reserve(reserve_count);
+                chunk->m_start_ns.reserve(reserve_count);
+                chunk->m_duration_ns.reserve(reserve_count);
+                chunk->m_correlation_id.reserve(reserve_count);
+                chunk->m_timeline_id.reserve(reserve_count);
+                chunk->m_site_id.reserve(reserve_count);
+                chunk->m_parent_index.reserve(reserve_count);
+                chunk->m_frame_index.reserve(reserve_count);
                 trace->m_zone_chunks.push_back(chunk);
             }
             const StoredZone& zone = zones[i];
@@ -1327,13 +1340,13 @@ struct ProfilerImpl {
                         parent = int32_t(it->second);
                 }
             }
-            chunk->start_ns.push_back(zone.start_ns);
-            chunk->duration_ns.push_back(zone.duration_ns);
-            chunk->correlation_id.push_back(zone.correlation_id);
-            chunk->timeline_id.push_back(zone.timeline_id);
-            chunk->site_id.push_back(zone.site_id);
-            chunk->parent_index.push_back(parent);
-            chunk->frame_index.push_back(zone.frame_index);
+            chunk->m_start_ns.push_back(zone.start_ns);
+            chunk->m_duration_ns.push_back(zone.duration_ns);
+            chunk->m_correlation_id.push_back(zone.correlation_id);
+            chunk->m_timeline_id.push_back(zone.timeline_id);
+            chunk->m_site_id.push_back(zone.site_id);
+            chunk->m_parent_index.push_back(parent);
+            chunk->m_frame_index.push_back(zone.frame_index);
         }
         return trace;
     }
@@ -1737,7 +1750,7 @@ ProfilerDurationStatistics ProfilerZoneSelection::statistics() const
     for (const auto& chunk : m_trace->m_zone_chunks) {
         const uint32_t end = base + uint32_t(chunk->size());
         while (selection_index < m_indices.size() && m_indices[selection_index] < end) {
-            durations.push_back(chunk->duration_ns[m_indices[selection_index] - base]);
+            durations.push_back(chunk->duration_ns()[m_indices[selection_index] - base]);
             ++selection_index;
         }
         base = end;
@@ -1816,23 +1829,23 @@ ref<ProfilerZoneSelection> ProfilerTrace::query_zones(
     uint32_t global_index = 0;
     for (const auto& chunk : m_zone_chunks) {
         for (size_t i = 0; i < chunk->size(); ++i, ++global_index) {
-            const ProfilerSite* site = find_site(m_sites, chunk->site_id[i]);
+            const ProfilerSite* site = find_site(m_sites, chunk->site_id()[i]);
             if (name && (!site || site->name != *name))
                 continue;
             if (timeline_type) {
-                const uint32_t id = chunk->timeline_id[i];
+                const uint32_t id = chunk->timeline_id()[i];
                 if (id >= m_timelines.size() || m_timelines[id].type != *timeline_type)
                     continue;
             }
-            const int32_t frame = chunk->frame_index[i];
-            if ((frame_begin || frame_end) && frame < 0)
+            const uint32_t frame = chunk->frame_index()[i];
+            if ((frame_begin || frame_end) && frame == INVALID_INDEX)
                 continue;
-            if (frame_begin && uint32_t(frame) < *frame_begin)
+            if (frame_begin && frame < *frame_begin)
                 continue;
-            if (frame_end && uint32_t(frame) >= *frame_end)
+            if (frame_end && frame >= *frame_end)
                 continue;
-            const uint64_t zone_start = chunk->start_ns[i];
-            const uint64_t zone_end = zone_start + chunk->duration_ns[i];
+            const uint64_t zone_start = chunk->start_ns()[i];
+            const uint64_t zone_end = zone_start + chunk->duration_ns()[i];
             if (range_start_ns && zone_end <= *range_start_ns)
                 continue;
             if (range_end_ns && zone_start >= *range_end_ns)
@@ -1865,12 +1878,13 @@ void ProfilerTrace::write_to_json(const std::filesystem::path& path) const
     for (const auto& chunk : m_zone_chunks) {
         for (size_t i = 0; i < chunk->size(); ++i) {
             separator();
-            const ProfilerSite* site = find_site(m_sites, chunk->site_id[i]);
+            const ProfilerSite* site = find_site(m_sites, chunk->site_id()[i]);
             stream << "{\"ph\":\"X\",\"name\":";
             write_json_string(stream, site ? site->name : "unknown");
-            stream << ",\"pid\":1,\"tid\":" << chunk->timeline_id[i] << ",\"ts\":" << std::fixed << std::setprecision(3)
-                   << double(chunk->start_ns[i]) / 1000.0 << ",\"dur\":" << double(chunk->duration_ns[i]) / 1000.0
-                   << ",\"args\":{\"correlation_id\":" << chunk->correlation_id[i] << "}}";
+            stream << ",\"pid\":1,\"tid\":" << chunk->timeline_id()[i] << ",\"ts\":" << std::fixed
+                   << std::setprecision(3) << double(chunk->start_ns()[i]) / 1000.0
+                   << ",\"dur\":" << double(chunk->duration_ns()[i]) / 1000.0
+                   << ",\"args\":{\"correlation_id\":" << chunk->correlation_id()[i] << "}}";
         }
     }
     struct FlowStart {
@@ -1880,27 +1894,27 @@ void ProfilerTrace::write_to_json(const std::filesystem::path& path) const
     std::unordered_map<uint64_t, FlowStart> cpu_flow_starts;
     for (const auto& chunk : m_zone_chunks) {
         for (size_t i = 0; i < chunk->size(); ++i) {
-            const uint32_t timeline_id = chunk->timeline_id[i];
+            const uint32_t timeline_id = chunk->timeline_id()[i];
             if (timeline_id < m_timelines.size() && m_timelines[timeline_id].type == ProfilerTimelineType::cpu)
-                cpu_flow_starts.emplace(chunk->correlation_id[i], FlowStart{chunk->start_ns[i], timeline_id});
+                cpu_flow_starts.emplace(chunk->correlation_id()[i], FlowStart{chunk->start_ns()[i], timeline_id});
         }
     }
     for (const auto& chunk : m_zone_chunks) {
         for (size_t i = 0; i < chunk->size(); ++i) {
-            const uint32_t timeline_id = chunk->timeline_id[i];
+            const uint32_t timeline_id = chunk->timeline_id()[i];
             if (timeline_id >= m_timelines.size() || m_timelines[timeline_id].type != ProfilerTimelineType::gpu)
                 continue;
-            auto cpu = cpu_flow_starts.find(chunk->correlation_id[i]);
+            auto cpu = cpu_flow_starts.find(chunk->correlation_id()[i]);
             if (cpu == cpu_flow_starts.end())
                 continue;
             separator();
-            stream << "{\"ph\":\"s\",\"cat\":\"cpu_gpu\",\"name\":\"CPU to GPU\",\"id\":" << chunk->correlation_id[i]
+            stream << "{\"ph\":\"s\",\"cat\":\"cpu_gpu\",\"name\":\"CPU to GPU\",\"id\":" << chunk->correlation_id()[i]
                    << ",\"pid\":1,\"tid\":" << cpu->second.timeline_id
                    << ",\"ts\":" << double(cpu->second.timestamp_ns) / 1000.0 << '}';
             separator();
             stream << "{\"ph\":\"f\",\"bp\":\"e\",\"cat\":\"cpu_gpu\",\"name\":\"CPU to GPU\",\"id\":"
-                   << chunk->correlation_id[i] << ",\"pid\":1,\"tid\":" << timeline_id
-                   << ",\"ts\":" << double(chunk->start_ns[i]) / 1000.0 << '}';
+                   << chunk->correlation_id()[i] << ",\"pid\":1,\"tid\":" << timeline_id
+                   << ",\"ts\":" << double(chunk->start_ns()[i]) / 1000.0 << '}';
         }
     }
     for (const ProfilerFrame& frame : m_frames) {

--- a/src/sgl/utils/profiler.h
+++ b/src/sgl/utils/profiler.h
@@ -486,14 +486,6 @@ private:
     friend struct ProfilerImpl;
 };
 
-inline const char* profiler_frame_name()
-{
-    return "frame";
-}
-inline const char* profiler_frame_name(const char* name)
-{
-    return name;
-}
 /// Return the current thread's profiler or throw if none is active.
 SGL_API Profiler* current_profiler();
 /// Return the current thread's profiler, or nullptr if none is active.
@@ -513,6 +505,15 @@ private:
 };
 
 namespace detail {
+    inline CommandEncoder* profiler_command_encoder() noexcept
+    {
+        return nullptr;
+    }
+    inline CommandEncoder* profiler_command_encoder(CommandEncoder* command_encoder) noexcept
+    {
+        return command_encoder;
+    }
+
     class SGL_API ProfilerZoneGuard {
     public:
         ProfilerZoneGuard(uint32_t site_id, CommandEncoder* command_encoder = nullptr) noexcept;
@@ -522,6 +523,15 @@ namespace detail {
         ProfilerZoneToken m_token;
         SGL_NON_COPYABLE_AND_MOVABLE(ProfilerZoneGuard);
     };
+
+    inline const char* profiler_frame_name()
+    {
+        return "frame";
+    }
+    inline const char* profiler_frame_name(const char* name)
+    {
+        return name;
+    }
 
     class SGL_API ProfilerFrameGuard {
     public:
@@ -551,7 +561,7 @@ namespace detail {
         = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, SGL_PROFILER_FUNCTION_NAME);  \
     ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
         SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter),                                                              \
-        ##__VA_ARGS__                                                                                                  \
+        ::sgl::detail::profiler_command_encoder(__VA_ARGS__)                                                           \
     )
 
 #define SGL_PROFILE_ZONE(name, ...) SGL_PROFILE_ZONE_I(__COUNTER__, name, __VA_ARGS__)
@@ -561,7 +571,7 @@ namespace detail {
         = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, name);                        \
     ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
         SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter),                                                              \
-        ##__VA_ARGS__                                                                                                  \
+        ::sgl::detail::profiler_command_encoder(__VA_ARGS__)                                                           \
     )
 
 #define SGL_PROFILE_FRAME(...) SGL_PROFILE_FRAME_I(__COUNTER__, __VA_ARGS__)
@@ -571,7 +581,7 @@ namespace detail {
         __FILE__,                                                                                                      \
         __LINE__,                                                                                                      \
         SGL_PROFILER_FUNCTION_NAME,                                                                                    \
-        ::sgl::profiler_frame_name(__VA_ARGS__)                                                                        \
+        ::sgl::detail::profiler_frame_name(__VA_ARGS__)                                                                \
     );                                                                                                                 \
     ::sgl::detail::ProfilerFrameGuard SGL_CONCAT_STRINGS(_sgl_profiler_frame_, counter)(                               \
         SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                                               \

--- a/src/sgl/utils/profiler.h
+++ b/src/sgl/utils/profiler.h
@@ -1,0 +1,578 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "sgl/core/enum.h"
+#include "sgl/core/macros.h"
+#include "sgl/core/object.h"
+#include "sgl/device/fwd.h"
+#include "sgl/device/types.h"
+
+#include <atomic>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sgl {
+
+/// Type of execution timeline stored in a profiler trace.
+enum class ProfilerTimelineType : uint32_t {
+    cpu, ///< CPU thread timeline.
+    gpu, ///< GPU device queue timeline.
+};
+SGL_ENUM_INFO(
+    ProfilerTimelineType,
+    {
+        {ProfilerTimelineType::cpu, "cpu"},
+        {ProfilerTimelineType::gpu, "gpu"},
+    }
+);
+SGL_ENUM_REGISTER(ProfilerTimelineType);
+
+/// Reason why a bounded profiler capture stopped recording.
+enum class ProfilerCaptureStopReason : uint32_t {
+    user,        ///< The capture was stopped explicitly by the user.
+    memory_limit ///< The capture reached ProfilerCaptureDesc::max_memory_bytes.
+};
+SGL_ENUM_INFO(
+    ProfilerCaptureStopReason,
+    {
+        {ProfilerCaptureStopReason::user, "user"},
+        {ProfilerCaptureStopReason::memory_limit, "memory_limit"},
+    }
+);
+SGL_ENUM_REGISTER(ProfilerCaptureStopReason);
+
+/// Configuration used to construct a Profiler.
+struct ProfilerDesc {
+    /// Maximum number of unread CPU events in each producer thread's queue. Must be a positive power of two.
+    uint32_t thread_event_capacity{8192};
+    /// Maximum number of completed frames retained in live trace snapshots.
+    uint32_t live_frame_count{120};
+    /// Maximum number of CPU and GPU zones retained in live trace snapshots.
+    uint32_t live_event_capacity{100000};
+    /// Maximum completed and ended GPU-pending frames retained in the global frame stream.
+    uint32_t frame_stats_window_size{120};
+    /// Number of timestamp queries shared by GPU zones. Each GPU zone uses two queries; the count must be positive and
+    /// even.
+    uint32_t gpu_query_pool_size{16384};
+    /// Enable automatic zones around SlangPy functional dispatch recording.
+    bool enable_auto_zones{true};
+    /// Mirror command-encoder profiling zones into backend debug groups.
+    bool enable_debug_groups{false};
+};
+
+/// Configuration for a bounded profiler capture.
+struct ProfilerCaptureDesc {
+    /// Maximum capture-owned zone and frame storage in bytes.
+    uint64_t max_memory_bytes{256ull * 1024ull * 1024ull};
+};
+
+/// Profiling-site metadata backed by process-lifetime interned strings.
+/// String views remain valid for the lifetime of the process.
+struct ProfilerSite {
+    /// One-based site identifier referenced by zones and frames.
+    uint32_t id{0};
+    /// Source filename supplied when the site was registered.
+    std::string_view file;
+    /// One-based source line number, or zero when unavailable.
+    uint32_t line{0};
+    /// Compact qualified function name.
+    std::string_view function;
+    /// User-facing zone or frame name.
+    std::string_view name;
+};
+
+/// Metadata for one CPU thread or GPU queue timeline.
+struct ProfilerTimeline {
+    /// Execution domain represented by the timeline.
+    ProfilerTimelineType type{ProfilerTimelineType::cpu};
+    /// Human-readable timeline name.
+    std::string name;
+    /// Platform thread identifier for CPU timelines, otherwise zero.
+    uint64_t thread_id{0};
+    /// Device identity for GPU timelines, otherwise zero.
+    uint64_t device_id{0};
+    /// Command queue type for GPU timelines.
+    CommandQueueType queue{CommandQueueType::graphics};
+};
+
+/// Completed frame boundary stored in a profiler trace.
+struct ProfilerFrame {
+    /// Monotonically increasing profiler-wide frame index.
+    uint32_t index{0};
+    /// Profiling site that names this frame.
+    uint32_t site_id{0};
+    /// CPU timeline on which the frame was recorded.
+    uint32_t timeline_id{0};
+    /// Frame start time in profiler-clock nanoseconds.
+    uint64_t start_ns{0};
+    /// Frame duration in nanoseconds.
+    uint64_t duration_ns{0};
+};
+
+/// Distribution of duration samples in milliseconds.
+struct ProfilerDurationStatistics {
+    /// Number of samples.
+    uint64_t count{0};
+    /// Sum of sample durations in milliseconds.
+    double total_ms{0.0};
+    /// Minimum sample duration in milliseconds.
+    double minimum_ms{0.0};
+    /// Maximum sample duration in milliseconds.
+    double maximum_ms{0.0};
+    /// Arithmetic mean duration in milliseconds.
+    double mean_ms{0.0};
+    /// Population standard deviation in milliseconds.
+    double standard_deviation_ms{0.0};
+    /// Linearly interpolated 50th percentile in milliseconds.
+    double p50_ms{0.0};
+    /// Linearly interpolated 90th percentile in milliseconds.
+    double p90_ms{0.0};
+    /// Linearly interpolated 95th percentile in milliseconds.
+    double p95_ms{0.0};
+    /// Linearly interpolated 99th percentile in milliseconds.
+    double p99_ms{0.0};
+};
+
+/// Mergeable duration summary that does not retain individual call samples.
+struct ProfilerCallStatistics {
+    /// Number of calls.
+    uint64_t count{0};
+    /// Sum of call durations in milliseconds.
+    double total_ms{0.0};
+    /// Minimum call duration in milliseconds.
+    double minimum_ms{0.0};
+    /// Maximum call duration in milliseconds.
+    double maximum_ms{0.0};
+    /// Arithmetic mean call duration in milliseconds.
+    double mean_ms{0.0};
+    /// Population standard deviation in milliseconds.
+    double standard_deviation_ms{0.0};
+};
+
+/// Diagnostic counters shared by immutable profiler snapshots.
+struct ProfilerDiagnostics {
+    /// Number of producer events dropped because a per-thread event queue or zone stack was full.
+    uint64_t producer_drop_count{0};
+    /// Maximum number of unread events observed in any per-thread producer queue.
+    uint64_t thread_event_queue_high_water_mark{0};
+    /// Number of statistics nodes promoted to roots because their parent event was unavailable.
+    uint64_t hierarchy_loss_count{0};
+    /// Number of GPU zones recorded without GPU timing because no timestamp-query pair was available.
+    uint64_t gpu_query_exhaustion_count{0};
+    /// Number of allocated GPU zones still awaiting submission or timestamp resolution.
+    uint64_t pending_gpu_zone_count{0};
+};
+
+/// Availability of one entry's GPU duration in one retained frame.
+enum class ProfilerFrameGpuStatus : uint8_t {
+    absent,      ///< The entry had no occurrences; its zero duration is valid.
+    unavailable, ///< The entry occurred but did not request GPU timing.
+    complete,    ///< All requested GPU timings resolved successfully.
+    incomplete,  ///< At least one requested GPU timing could not be resolved.
+};
+SGL_ENUM_INFO(
+    ProfilerFrameGpuStatus,
+    {
+        {ProfilerFrameGpuStatus::absent, "absent"},
+        {ProfilerFrameGpuStatus::unavailable, "unavailable"},
+        {ProfilerFrameGpuStatus::complete, "complete"},
+        {ProfilerFrameGpuStatus::incomplete, "incomplete"},
+    }
+);
+SGL_ENUM_REGISTER(ProfilerFrameGpuStatus);
+
+/// Frame-aligned statistics for one hierarchical CPU zone path.
+///
+/// CPU time per frame is the sum of inclusive occurrences at this path. Parent and child entries are therefore not
+/// additive. GPU time is the sum of directly measured occurrences and can exceed elapsed frame time when work
+/// overlaps.
+struct ProfilerFrameStatsEntry {
+    /// Index of the parent entry in the same frame statistics list, or -1 for a root.
+    int32_t parent_index{-1};
+    /// Profiling site represented by this hierarchical path.
+    uint32_t site_id{0};
+    /// User-facing profiling-site name.
+    std::string name;
+    /// Distribution of summed CPU duration per retained frame.
+    ProfilerDurationStatistics cpu_time_per_frame;
+    /// Distribution of summed GPU duration for frames with complete GPU measurements.
+    ProfilerDurationStatistics gpu_time_per_frame;
+    /// Mergeable statistics over individual CPU occurrences.
+    ProfilerCallStatistics cpu_time_per_call;
+    /// Mergeable statistics over individual resolved GPU occurrences.
+    ProfilerCallStatistics gpu_time_per_call;
+};
+
+/// Non-owning view of one retained completed frame.
+struct ProfilerFrameStatsSampleView {
+    /// Monotonically increasing profiler-wide frame index.
+    uint32_t frame_index{0};
+    /// Completed frame duration in milliseconds.
+    double frame_time_ms{0.0};
+    /// Number of occurrences for each entry.
+    std::span<const uint32_t> call_count;
+    /// Summed inclusive CPU duration in milliseconds for each entry.
+    std::span<const double> cpu_time_ms;
+    /// Summed directly measured GPU duration in milliseconds for each entry.
+    std::span<const double> gpu_time_ms;
+    /// GPU timing availability for each entry.
+    std::span<const ProfilerFrameGpuStatus> gpu_status;
+};
+
+/// Immutable structure-of-arrays storage for at most 4096 zones.
+///
+/// Bounded chunks let trace queries and exports process large captures without flattening all zones into one
+/// allocation. The Python bindings expose each column as a zero-copy, read-only NumPy array whose lifetime is tied to
+/// the chunk.
+class SGL_API ProfilerZoneChunk : public Object {
+    SGL_OBJECT(ProfilerZoneChunk)
+public:
+    /// Number of zones in this chunk.
+    size_t size() const { return start_ns.size(); }
+
+    /// Zone start times in profiler-clock nanoseconds.
+    std::vector<uint64_t> start_ns;
+    /// Zone durations in nanoseconds.
+    std::vector<uint64_t> duration_ns;
+    /// CPU/GPU correlation identifiers.
+    std::vector<uint64_t> correlation_id;
+    /// Indices into ProfilerTrace::timelines().
+    std::vector<uint32_t> timeline_id;
+    /// One-based identifiers into ProfilerTrace::sites().
+    std::vector<uint32_t> site_id;
+    /// Global zone indices of parents on the same timeline, or -1 for roots.
+    std::vector<int32_t> parent_index;
+    /// Profiler-wide frame indices, or -1 for zones outside a frame.
+    std::vector<int32_t> frame_index;
+};
+
+class ProfilerTrace;
+
+/// Immutable set of global zone indices selected from one ProfilerTrace.
+class SGL_API ProfilerZoneSelection : public Object {
+    SGL_OBJECT(ProfilerZoneSelection)
+public:
+    /// Number of selected zones.
+    uint64_t count() const { return m_indices.size(); }
+    /// Sorted global zone indices into the source trace.
+    const std::vector<uint32_t>& indices() const { return m_indices; }
+    /// Calculate duration statistics for the selected zones.
+    ProfilerDurationStatistics statistics() const;
+
+private:
+    ref<ProfilerTrace> m_trace;
+    std::vector<uint32_t> m_indices;
+    friend class ProfilerTrace;
+};
+
+/// Immutable profiler trace containing metadata, frame boundaries, and chunked CPU/GPU zones.
+class SGL_API ProfilerTrace : public Object {
+    SGL_OBJECT(ProfilerTrace)
+public:
+    /// Capture or live-history start time in profiler-clock nanoseconds.
+    uint64_t start_ns() const { return m_start_ns; }
+    /// Capture or live-history stop time in profiler-clock nanoseconds.
+    uint64_t stop_ns() const { return m_stop_ns; }
+    /// Reason why capture recording stopped.
+    ProfilerCaptureStopReason stop_reason() const { return m_stop_reason; }
+    /// Whether a bounded capture stopped at its memory limit.
+    bool truncated() const { return m_truncated; }
+    /// Capture-owned zone and frame storage in bytes.
+    uint64_t memory_bytes() const { return m_memory_bytes; }
+    /// Diagnostic counters captured with this snapshot.
+    const ProfilerDiagnostics& diagnostics() const { return m_diagnostics; }
+
+    /// Process-global profiling sites visible when the snapshot was built.
+    const std::vector<ProfilerSite>& sites() const { return m_sites; }
+    /// CPU and GPU timelines referenced by this trace.
+    const std::vector<ProfilerTimeline>& timelines() const { return m_timelines; }
+    /// Completed frame boundaries retained by this trace.
+    const std::vector<ProfilerFrame>& frames() const { return m_frames; }
+    /// Immutable structure-of-arrays zone chunks.
+    const std::vector<ref<ProfilerZoneChunk>>& zone_chunks() const { return m_zone_chunks; }
+    /// Total number of zones across all chunks.
+    uint64_t zone_count() const;
+
+    /// Select zones using exact-name, timeline, frame, and timestamp filters.
+    /// Frame and timestamp ranges are half-open. Zones overlap the requested timestamp range rather than requiring
+    /// their complete duration to be contained in it. Zones outside frames are excluded whenever a frame bound is set.
+    ref<ProfilerZoneSelection> query_zones(
+        std::optional<std::string> name = {},
+        std::optional<ProfilerTimelineType> timeline_type = {},
+        std::optional<uint32_t> frame_begin = {},
+        std::optional<uint32_t> frame_end = {},
+        std::optional<uint64_t> start_ns = {},
+        std::optional<uint64_t> end_ns = {}
+    ) const;
+    /// Stream this trace as Chrome trace-event JSON suitable for Perfetto.
+    void write_to_json(const std::filesystem::path& path) const;
+
+private:
+    uint64_t m_start_ns{0};
+    uint64_t m_stop_ns{0};
+    ProfilerCaptureStopReason m_stop_reason{ProfilerCaptureStopReason::user};
+    bool m_truncated{false};
+    uint64_t m_memory_bytes{0};
+    ProfilerDiagnostics m_diagnostics;
+    std::vector<ProfilerSite> m_sites;
+    std::vector<ProfilerTimeline> m_timelines;
+    std::vector<ProfilerFrame> m_frames;
+    std::vector<ref<ProfilerZoneChunk>> m_zone_chunks;
+    friend class Profiler;
+    friend class ProfilerZoneSelection;
+    friend struct ProfilerImpl;
+};
+
+/// Immutable snapshot of rolling statistics for the profiler's global frame stream.
+///
+/// Sample matrices are row-major with shape (sample_count(), entry_count()). All columns are ordered oldest to newest.
+class SGL_API ProfilerFrameStats : public Object {
+    SGL_OBJECT(ProfilerFrameStats)
+public:
+    /// Number of retained completed frames.
+    size_t sample_count() const { return m_sample_frame_index.size(); }
+    /// Number of hierarchical entries.
+    size_t entry_count() const { return m_entries.size(); }
+    /// Total ended frames still waiting for GPU measurements.
+    uint64_t pending_frame_count() const { return m_pending_frame_count; }
+    /// Duration of the most recently completed frame in milliseconds.
+    double latest_frame_ms() const { return m_sample_frame_time_ms.empty() ? 0.0 : m_sample_frame_time_ms.back(); }
+    /// Distribution of completed frame durations.
+    const ProfilerDurationStatistics& frame_time() const { return m_frame_time; }
+    /// Hierarchical CPU-zone paths in deterministic parent-before-child preorder.
+    const std::vector<ProfilerFrameStatsEntry>& entries() const { return m_entries; }
+    /// Profiler-wide frame index for each retained sample.
+    const std::vector<uint32_t>& sample_frame_index() const { return m_sample_frame_index; }
+    /// Completed frame duration in milliseconds for each retained sample.
+    const std::vector<double>& sample_frame_time_ms() const { return m_sample_frame_time_ms; }
+    /// Row-major occurrence-count matrix with shape (sample_count(), entry_count()).
+    const std::vector<uint32_t>& sample_call_count() const { return m_sample_call_count; }
+    /// Row-major CPU-duration matrix with shape (sample_count(), entry_count()).
+    const std::vector<double>& sample_cpu_time_ms() const { return m_sample_cpu_time_ms; }
+    /// Row-major GPU-duration matrix with shape (sample_count(), entry_count()).
+    const std::vector<double>& sample_gpu_time_ms() const { return m_sample_gpu_time_ms; }
+    /// Row-major GPU-status matrix with shape (sample_count(), entry_count()).
+    const std::vector<ProfilerFrameGpuStatus>& sample_gpu_status() const { return m_sample_gpu_status; }
+    /// Return a non-owning entry-aligned view of one retained sample.
+    ProfilerFrameStatsSampleView sample(size_t index) const;
+    /// Diagnostic counters captured with this snapshot.
+    const ProfilerDiagnostics& diagnostics() const { return m_diagnostics; }
+
+    /// Return a terminal-oriented representation of the hierarchy, timings, and diagnostic counters.
+    std::string to_string() const override;
+
+private:
+    uint64_t m_pending_frame_count{0};
+    ProfilerDurationStatistics m_frame_time;
+    std::vector<ProfilerFrameStatsEntry> m_entries;
+    std::vector<uint32_t> m_sample_frame_index;
+    std::vector<double> m_sample_frame_time_ms;
+    std::vector<uint32_t> m_sample_call_count;
+    std::vector<double> m_sample_cpu_time_ms;
+    std::vector<double> m_sample_gpu_time_ms;
+    std::vector<ProfilerFrameGpuStatus> m_sample_gpu_status;
+    ProfilerDiagnostics m_diagnostics;
+    friend struct ProfilerImpl;
+};
+
+struct ProfilerImpl;
+class Profiler;
+
+struct ProfilerZoneToken {
+    Profiler* profiler{nullptr};
+    void* thread_data{nullptr};
+    void* gpu_state{nullptr};
+    CommandEncoder* command_encoder{nullptr};
+    uint64_t start_ns{0};
+    uint64_t correlation_id{0};
+    uint64_t parent_correlation_id{0};
+    uint32_t site_id{0};
+    uint32_t frame_index{~0u};
+    uint32_t stack_index{0};
+    uint32_t gpu_begin_query{~0u};
+    bool debug_group_active{false};
+};
+
+struct ProfilerFrameToken {
+    Profiler* profiler{nullptr};
+    uint64_t start_ns{0};
+    uint32_t frame_index{~0u};
+};
+
+/// Bounded CPU/GPU instrumentation profiler with immutable trace and frame-statistics snapshots.
+class SGL_API Profiler : public Object {
+    SGL_OBJECT(Profiler)
+public:
+    /// Create a profiler. If the current thread has no current profiler, this profiler becomes its default.
+    /// The destructor removes that default entry when it remains the stack's sole entry. A default profiler must be
+    /// destroyed on its constructing thread after temporary profiler scopes on that thread have ended. Destruction
+    /// must not race device submission, command-buffer discard, or device close operations associated with GPU zones.
+    explicit Profiler(ProfilerDesc desc = {});
+    ~Profiler();
+
+    /// Register a profiling site in the process-global site registry.
+    /// Metadata is interned and remains valid for the lifetime of the process.
+    static uint32_t
+    register_site(std::string_view file, uint32_t line, std::string_view function, std::string_view name);
+
+    /// Whether manual and automatic profiling zones are recorded.
+    bool enabled() const { return m_enabled.load(std::memory_order_relaxed); }
+    /// Enable or disable all zone and frame recording.
+    void set_enabled(bool value) { m_enabled.store(value, std::memory_order_relaxed); }
+    /// Whether SlangPy functional dispatches create automatic zones.
+    bool enable_auto_zones() const { return m_enable_auto_zones.load(std::memory_order_relaxed); }
+    /// Enable or disable automatic SlangPy functional dispatch zones.
+    void set_enable_auto_zones(bool value) { m_enable_auto_zones.store(value, std::memory_order_relaxed); }
+    /// Whether command-encoder profiling zones also emit backend debug groups.
+    bool enable_debug_groups() const { return m_enable_debug_groups.load(std::memory_order_relaxed); }
+    /// Enable or disable backend debug groups for command-encoder zones.
+    void set_enable_debug_groups(bool value) { m_enable_debug_groups.store(value, std::memory_order_relaxed); }
+    /// Whether a bounded capture is currently recording. A capture stopped by its memory limit is ready but inactive.
+    bool capture_active() const;
+    /// Constructor configuration. Python exposes this as a copy because changing it does not reconfigure the profiler.
+    const ProfilerDesc& desc() const { return m_desc; }
+
+    /// Start a bounded capture after flushing events completed before this call.
+    void start_capture(ProfilerCaptureDesc desc = {});
+    /// Stop and return the current or memory-limited capture.
+    ///
+    /// This performs one tick and flushes completed CPU producer events. It does not deliberately wait for submitted
+    /// GPU work or unresolved timestamp queries, but a backend timestamp-calibration refresh performed by tick() may
+    /// synchronize queued GPU work. Call Device::wait(), then tick(), before stopping when complete GPU data is
+    /// required.
+    ref<ProfilerTrace> stop_capture();
+    /// Discard the active or completed capture without producing a trace.
+    void discard_capture();
+    /// Return the most recently published immutable live trace and request periodic live-trace publication.
+    ref<ProfilerTrace> live_snapshot() const;
+    /// Return the most recently published immutable frame statistics and request periodic statistics publication.
+    ref<ProfilerFrameStats> frame_stats_snapshot() const;
+    /// Release profiler-owned references to snapshots previously handed to Python.
+    /// Python bindings call this while holding the GIL before acquiring a new snapshot.
+    void release_retired_snapshots();
+    /// Clear completed and pending frame statistics after flushing current producer events.
+    void clear_frame_stats();
+    /// Poll submitted GPU timestamp queries and queue resolved measurements for the collector.
+    ///
+    /// The poll does not deliberately wait for profiled submissions or unresolved queries. Refreshing timestamp
+    /// calibration can nevertheless synchronize queued GPU work on some backends, notably CUDA.
+    void tick();
+    /// Block until the collector consumes events published before this call and publishes both snapshot products.
+    void flush();
+
+    /// Begin a CPU zone and optionally reserve GPU timestamp queries on a command encoder.
+    ProfilerZoneToken begin_zone(uint32_t site_id, CommandEncoder* command_encoder = nullptr) noexcept;
+    /// End a zone previously returned by begin_zone().
+    void end_zone(const ProfilerZoneToken& token) noexcept;
+    /// Begin the profiler's global frame, or return an invalid token if a frame is already open or closing.
+    ProfilerFrameToken begin_frame(uint32_t site_id) noexcept;
+    /// Close a frame previously returned by begin_frame(). The collector seals it after all attached zones publish.
+    void end_frame(const ProfilerFrameToken& token) noexcept;
+
+    std::string to_string() const override;
+
+private:
+    ProfilerDesc m_desc;
+    std::atomic<bool> m_enabled{true};
+    std::atomic<bool> m_enable_auto_zones{true};
+    std::atomic<bool> m_enable_debug_groups{false};
+    std::unique_ptr<ProfilerImpl> m_impl;
+    friend struct ProfilerImpl;
+};
+
+inline const char* profiler_frame_name()
+{
+    return "frame";
+}
+inline const char* profiler_frame_name(const char* name)
+{
+    return name;
+}
+/// Return the current thread's profiler or throw if none is active.
+SGL_API Profiler* current_profiler();
+/// Return the current thread's profiler, or nullptr if none is active.
+SGL_API Profiler* current_profiler_or_null() noexcept;
+SGL_API void push_current_profiler(Profiler* profiler);
+SGL_API Profiler* pop_current_profiler();
+
+class SGL_API ProfilerScope {
+public:
+    explicit ProfilerScope(Profiler* profiler);
+    ~ProfilerScope();
+    ProfilerScope(const ProfilerScope&) = delete;
+    ProfilerScope& operator=(const ProfilerScope&) = delete;
+
+private:
+    Profiler* m_profiler;
+};
+
+namespace detail {
+    class SGL_API ProfilerZoneGuard {
+    public:
+        ProfilerZoneGuard(uint32_t site_id, CommandEncoder* command_encoder = nullptr) noexcept;
+        ~ProfilerZoneGuard() noexcept;
+
+    private:
+        ProfilerZoneToken m_token;
+        SGL_NON_COPYABLE_AND_MOVABLE(ProfilerZoneGuard);
+    };
+
+    class SGL_API ProfilerFrameGuard {
+    public:
+        explicit ProfilerFrameGuard(uint32_t site_id) noexcept;
+        ~ProfilerFrameGuard() noexcept;
+
+    private:
+        ProfilerFrameToken m_token;
+        SGL_NON_COPYABLE_AND_MOVABLE(ProfilerFrameGuard);
+    };
+} // namespace detail
+
+} // namespace sgl
+
+#if SGL_MSVC
+#define SGL_PROFILER_FUNCTION_NAME __FUNCSIG__
+#elif SGL_GCC || SGL_CLANG
+#define SGL_PROFILER_FUNCTION_NAME __PRETTY_FUNCTION__
+#else
+#define SGL_PROFILER_FUNCTION_NAME __func__
+#endif
+
+#define SGL_PROFILE_FUNCTION(...) SGL_PROFILE_FUNCTION_I(__COUNTER__, __VA_ARGS__)
+#define SGL_PROFILE_FUNCTION_I(counter, ...) SGL_PROFILE_FUNCTION_II(counter, __VA_ARGS__)
+#define SGL_PROFILE_FUNCTION_II(counter, ...)                                                                          \
+    static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                             \
+        = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, SGL_PROFILER_FUNCTION_NAME);  \
+    ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
+        SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter),                                                              \
+        ##__VA_ARGS__                                                                                                  \
+    )
+
+#define SGL_PROFILE_ZONE(name, ...) SGL_PROFILE_ZONE_I(__COUNTER__, name, __VA_ARGS__)
+#define SGL_PROFILE_ZONE_I(counter, name, ...) SGL_PROFILE_ZONE_II(counter, name, __VA_ARGS__)
+#define SGL_PROFILE_ZONE_II(counter, name, ...)                                                                        \
+    static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                             \
+        = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, name);                        \
+    ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
+        SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter),                                                              \
+        ##__VA_ARGS__                                                                                                  \
+    )
+
+#define SGL_PROFILE_FRAME(...) SGL_PROFILE_FRAME_I(__COUNTER__, __VA_ARGS__)
+#define SGL_PROFILE_FRAME_I(counter, ...) SGL_PROFILE_FRAME_II(counter, __VA_ARGS__)
+#define SGL_PROFILE_FRAME_II(counter, ...)                                                                             \
+    static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter) = ::sgl::Profiler::register_site(           \
+        __FILE__,                                                                                                      \
+        __LINE__,                                                                                                      \
+        SGL_PROFILER_FUNCTION_NAME,                                                                                    \
+        ::sgl::profiler_frame_name(__VA_ARGS__)                                                                        \
+    );                                                                                                                 \
+    ::sgl::detail::ProfilerFrameGuard SGL_CONCAT_STRINGS(_sgl_profiler_frame_, counter)(                               \
+        SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                                               \
+    )

--- a/src/sgl/utils/profiler.h
+++ b/src/sgl/utils/profiler.h
@@ -508,15 +508,6 @@ private:
 };
 
 namespace detail {
-    inline CommandEncoder* profiler_command_encoder() noexcept
-    {
-        return nullptr;
-    }
-    inline CommandEncoder* profiler_command_encoder(CommandEncoder* command_encoder) noexcept
-    {
-        return command_encoder;
-    }
-
     class SGL_API ProfilerZoneGuard {
     public:
         ProfilerZoneGuard(uint32_t site_id, CommandEncoder* command_encoder = nullptr) noexcept;
@@ -563,8 +554,7 @@ namespace detail {
     static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                             \
         = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, SGL_PROFILER_FUNCTION_NAME);  \
     ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
-        SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter),                                                              \
-        ::sgl::detail::profiler_command_encoder(__VA_ARGS__)                                                           \
+        SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter) __VA_OPT__(, ) __VA_ARGS__                                    \
     )
 
 #define SGL_PROFILE_ZONE(name, ...) SGL_PROFILE_ZONE_IMPL(__COUNTER__, name, __VA_ARGS__)
@@ -573,8 +563,7 @@ namespace detail {
     static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                             \
         = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, name);                        \
     ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
-        SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter),                                                              \
-        ::sgl::detail::profiler_command_encoder(__VA_ARGS__)                                                           \
+        SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter) __VA_OPT__(, ) __VA_ARGS__                                    \
     )
 
 #define SGL_PROFILE_FRAME(...) SGL_PROFILE_FRAME_IMPL(__COUNTER__, __VA_ARGS__)

--- a/src/sgl/utils/profiler.h
+++ b/src/sgl/utils/profiler.h
@@ -234,22 +234,32 @@ class SGL_API ProfilerZoneChunk : public Object {
     SGL_OBJECT(ProfilerZoneChunk)
 public:
     /// Number of zones in this chunk.
-    size_t size() const { return start_ns.size(); }
+    size_t size() const { return m_start_ns.size(); }
 
     /// Zone start times in profiler-clock nanoseconds.
-    std::vector<uint64_t> start_ns;
+    const std::vector<uint64_t>& start_ns() const { return m_start_ns; }
     /// Zone durations in nanoseconds.
-    std::vector<uint64_t> duration_ns;
+    const std::vector<uint64_t>& duration_ns() const { return m_duration_ns; }
     /// CPU/GPU correlation identifiers.
-    std::vector<uint64_t> correlation_id;
+    const std::vector<uint64_t>& correlation_id() const { return m_correlation_id; }
     /// Indices into ProfilerTrace::timelines().
-    std::vector<uint32_t> timeline_id;
+    const std::vector<uint32_t>& timeline_id() const { return m_timeline_id; }
     /// One-based identifiers into ProfilerTrace::sites().
-    std::vector<uint32_t> site_id;
+    const std::vector<uint32_t>& site_id() const { return m_site_id; }
     /// Global zone indices of parents on the same timeline, or -1 for roots.
-    std::vector<int32_t> parent_index;
-    /// Profiler-wide frame indices, or -1 for zones outside a frame.
-    std::vector<int32_t> frame_index;
+    const std::vector<int32_t>& parent_index() const { return m_parent_index; }
+    /// Profiler-wide frame indices, or UINT32_MAX for zones outside a frame.
+    const std::vector<uint32_t>& frame_index() const { return m_frame_index; }
+
+private:
+    std::vector<uint64_t> m_start_ns;
+    std::vector<uint64_t> m_duration_ns;
+    std::vector<uint64_t> m_correlation_id;
+    std::vector<uint32_t> m_timeline_id;
+    std::vector<uint32_t> m_site_id;
+    std::vector<int32_t> m_parent_index;
+    std::vector<uint32_t> m_frame_index;
+    friend struct ProfilerImpl;
 };
 
 class ProfilerTrace;

--- a/src/sgl/utils/profiler.h
+++ b/src/sgl/utils/profiler.h
@@ -470,8 +470,8 @@ public:
     void clear_frame_stats();
     /// Poll submitted GPU timestamp queries and queue resolved measurements for the collector.
     ///
-    /// The poll does not deliberately wait for profiled submissions or unresolved queries. Refreshing timestamp
-    /// calibration can nevertheless synchronize queued GPU work on some backends, notably CUDA.
+    /// The poll does not deliberately wait for profiled submissions or unresolved queries. On CUDA, refreshing
+    /// timestamp calibration synchronizes queued GPU work.
     void tick();
     /// Block until the collector consumes events published before this call and publishes both snapshot products.
     void flush();

--- a/src/sgl/utils/profiler.h
+++ b/src/sgl/utils/profiler.h
@@ -557,9 +557,9 @@ namespace detail {
 #define SGL_PROFILER_FUNCTION_NAME __func__
 #endif
 
-#define SGL_PROFILE_FUNCTION(...) SGL_PROFILE_FUNCTION_I(__COUNTER__, __VA_ARGS__)
-#define SGL_PROFILE_FUNCTION_I(counter, ...) SGL_PROFILE_FUNCTION_II(counter, __VA_ARGS__)
-#define SGL_PROFILE_FUNCTION_II(counter, ...)                                                                          \
+#define SGL_PROFILE_FUNCTION(...) SGL_PROFILE_FUNCTION_IMPL(__COUNTER__, __VA_ARGS__)
+#define SGL_PROFILE_FUNCTION_IMPL(counter, ...) SGL_PROFILE_FUNCTION_IMPL2(counter, __VA_ARGS__)
+#define SGL_PROFILE_FUNCTION_IMPL2(counter, ...)                                                                       \
     static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                             \
         = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, SGL_PROFILER_FUNCTION_NAME);  \
     ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
@@ -567,9 +567,9 @@ namespace detail {
         ::sgl::detail::profiler_command_encoder(__VA_ARGS__)                                                           \
     )
 
-#define SGL_PROFILE_ZONE(name, ...) SGL_PROFILE_ZONE_I(__COUNTER__, name, __VA_ARGS__)
-#define SGL_PROFILE_ZONE_I(counter, name, ...) SGL_PROFILE_ZONE_II(counter, name, __VA_ARGS__)
-#define SGL_PROFILE_ZONE_II(counter, name, ...)                                                                        \
+#define SGL_PROFILE_ZONE(name, ...) SGL_PROFILE_ZONE_IMPL(__COUNTER__, name, __VA_ARGS__)
+#define SGL_PROFILE_ZONE_IMPL(counter, name, ...) SGL_PROFILE_ZONE_IMPL2(counter, name, __VA_ARGS__)
+#define SGL_PROFILE_ZONE_IMPL2(counter, name, ...)                                                                     \
     static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter)                                             \
         = ::sgl::Profiler::register_site(__FILE__, __LINE__, SGL_PROFILER_FUNCTION_NAME, name);                        \
     ::sgl::detail::ProfilerZoneGuard SGL_CONCAT_STRINGS(_sgl_profiler_zone_, counter)(                                 \
@@ -577,9 +577,9 @@ namespace detail {
         ::sgl::detail::profiler_command_encoder(__VA_ARGS__)                                                           \
     )
 
-#define SGL_PROFILE_FRAME(...) SGL_PROFILE_FRAME_I(__COUNTER__, __VA_ARGS__)
-#define SGL_PROFILE_FRAME_I(counter, ...) SGL_PROFILE_FRAME_II(counter, __VA_ARGS__)
-#define SGL_PROFILE_FRAME_II(counter, ...)                                                                             \
+#define SGL_PROFILE_FRAME(...) SGL_PROFILE_FRAME_IMPL(__COUNTER__, __VA_ARGS__)
+#define SGL_PROFILE_FRAME_IMPL(counter, ...) SGL_PROFILE_FRAME_IMPL2(counter, __VA_ARGS__)
+#define SGL_PROFILE_FRAME_IMPL2(counter, ...)                                                                          \
     static const uint32_t SGL_CONCAT_STRINGS(_sgl_profiler_site_, counter) = ::sgl::Profiler::register_site(           \
         __FILE__,                                                                                                      \
         __LINE__,                                                                                                      \

--- a/src/sgl/utils/profiler.h
+++ b/src/sgl/utils/profiler.h
@@ -466,6 +466,9 @@ public:
     /// Block until the collector consumes events published before this call and publishes both snapshot products.
     void flush();
 
+    /// The noexcept instrumentation entry points below intentionally call std::terminate if an internal allocation or
+    /// backend operation throws. Such failures indicate violated profiler or backend invariants.
+
     /// Begin a CPU zone and optionally reserve GPU timestamp queries on a command encoder.
     ProfilerZoneToken begin_zone(uint32_t site_id, CommandEncoder* command_encoder = nullptr) noexcept;
     /// End a zone previously returned by begin_zone().

--- a/src/sgl/utils/profiler_ui.cpp
+++ b/src/sgl/utils/profiler_ui.cpp
@@ -33,6 +33,7 @@ namespace {
         Profiler* profiler{nullptr};
         bool paused{false};
         ref<ProfilerFrameStats> stats;
+        std::vector<ImU32> entry_colors;
         ValueMode value_mode{ValueMode::mean};
         GraphMode graph_mode{GraphMode::gpu};
         bool graph_open{true};
@@ -174,20 +175,19 @@ namespace {
         return {mode == ValueMode::mean ? statistics.mean_ms : statistics.p95_ms, true};
     }
 
-    ImU32 entry_color(const ProfilerFrameStats& stats, size_t entry_index)
+    std::vector<ImU32> make_entry_colors(const ProfilerFrameStats& stats)
     {
-        std::vector<uint32_t> path;
-        int32_t index = int32_t(entry_index);
-        while (index >= 0 && size_t(index) < stats.entries().size() && path.size() <= stats.entries().size()) {
-            path.push_back(stats.entries()[size_t(index)].site_id);
-            index = stats.entries()[size_t(index)].parent_index;
-        }
-        uint64_t hash = 1469598103934665603ull;
-        for (auto it = path.rbegin(); it != path.rend(); ++it) {
-            hash ^= *it;
+        std::vector<uint64_t> hashes(stats.entries().size());
+        std::vector<ImU32> colors(stats.entries().size());
+        for (size_t index = 0; index < stats.entries().size(); ++index) {
+            const ProfilerFrameStatsEntry& entry = stats.entries()[index];
+            uint64_t hash = entry.parent_index < 0 ? 1469598103934665603ull : hashes[size_t(entry.parent_index)];
+            hash ^= entry.site_id;
             hash *= 1099511628211ull;
+            hashes[index] = hash;
+            colors[index] = PALETTE[size_t(hash % PALETTE.size())];
         }
-        return PALETTE[size_t(hash % PALETTE.size())];
+        return colors;
     }
 
     ImU32 muted_color(ImU32 color)
@@ -296,8 +296,10 @@ namespace {
         return false;
     }
 
-    void draw_table(UIState& state, const ProfilerFrameStats& stats, float height, int32_t highlighted_entry)
+    void draw_table(UIState& state, float height, int32_t highlighted_entry)
     {
+        const ProfilerFrameStats& stats = *state.stats;
+        const std::vector<ImU32>& entry_colors = state.entry_colors;
         double cpu_root_total = 0.0;
         double gpu_root_total = 0.0;
         for (size_t index = 0; index < stats.entries().size(); ++index) {
@@ -328,7 +330,7 @@ namespace {
 
         for (size_t index = 0; index < stats.entries().size(); ++index) {
             const ProfilerFrameStatsEntry& entry = stats.entries()[index];
-            const ImU32 color = entry_color(stats, index);
+            const ImU32 color = entry_colors[index];
             ImGui::PushID(int(index));
             ImGui::TableNextRow();
             if (highlighted_entry == int32_t(index))
@@ -389,8 +391,10 @@ namespace {
         ImGui::EndTable();
     }
 
-    void draw_graph(UIState& state, const ProfilerFrameStats& stats, float height, int32_t highlighted_entry)
+    void draw_graph(UIState& state, float height, int32_t highlighted_entry)
     {
+        const ProfilerFrameStats& stats = *state.stats;
+        const std::vector<ImU32>& entry_colors = state.entry_colors;
         const bool gpu = state.graph_mode == GraphMode::gpu;
         if (stats.sample_count() == 0) {
             ImGui::TextUnformatted("No completed frame history");
@@ -486,7 +490,7 @@ namespace {
                     continue;
                 const float y0 = plot_bottom - float((band_bottom[index] + band_height[index]) / maximum) * plot_height;
                 const float y1 = plot_bottom - float(band_bottom[index] / maximum) * plot_height;
-                ImU32 color = entry_color(stats, index);
+                ImU32 color = entry_colors[index];
                 if (gpu && !valid_gpu_status(sample.gpu_status[index]))
                     color = muted_color(color);
                 draw->AddRectFilled(ImVec2(x0, y0), ImVec2(std::max(x0 + 1.f, x1), y1), color);
@@ -624,8 +628,10 @@ void render_profiler_window(Profiler* profiler)
     ImGui::SameLine();
     ImGui::Checkbox("Pause display", &state.paused);
 
-    if (!state.paused || !state.stats)
+    if (!state.paused || !state.stats) {
         state.stats = profiler->frame_stats_snapshot();
+        state.entry_colors = state.stats ? make_entry_colors(*state.stats) : std::vector<ImU32>();
+    }
     if (!state.stats) {
         ImGui::TextUnformatted("No frame statistics available");
         ImGui::End();
@@ -669,18 +675,13 @@ void render_profiler_window(Profiler* profiler)
     const int32_t previous_hovered = state.hovered_entry;
     state.hovered_entry = -1;
     const float table_height = std::max(1.f, ImGui::GetContentRegionAvail().y - bottom_height);
-    draw_table(state, *state.stats, table_height, previous_hovered);
+    draw_table(state, table_height, previous_hovered);
 
     ImGui::SetNextItemOpen(state.graph_open, ImGuiCond_Always);
     state.graph_open = ImGui::CollapsingHeader("Graph");
     if (state.graph_open) {
         draw_graph_selector(state);
-        draw_graph(
-            state,
-            *state.stats,
-            GRAPH_HEIGHT,
-            state.hovered_entry >= 0 ? state.hovered_entry : previous_hovered
-        );
+        draw_graph(state, GRAPH_HEIGHT, state.hovered_entry >= 0 ? state.hovered_entry : previous_hovered);
     }
 
     ImGui::SetNextItemOpen(state.diagnostics_open, ImGuiCond_Always);

--- a/src/sgl/utils/profiler_ui.cpp
+++ b/src/sgl/utils/profiler_ui.cpp
@@ -1,0 +1,709 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "profiler_ui.h"
+
+#include "sgl/ui/ui.h"
+#include "sgl/utils/profiler.h"
+
+#include <imgui.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+namespace sgl::ui {
+namespace {
+
+    enum class ValueMode : uint32_t {
+        mean,
+        latest,
+        p95,
+    };
+    constexpr std::array<const char*, 3> VALUE_MODE_LABELS{"Mean", "Latest", "P95"};
+
+    enum class GraphMode : uint32_t {
+        cpu,
+        gpu,
+    };
+    constexpr std::array<const char*, 2> GRAPH_MODE_LABELS{"CPU", "GPU"};
+
+    struct UIState {
+        Profiler* profiler{nullptr};
+        bool paused{false};
+        ref<ProfilerFrameStats> stats;
+        ValueMode value_mode{ValueMode::mean};
+        GraphMode graph_mode{GraphMode::gpu};
+        bool graph_open{true};
+        bool diagnostics_open{false};
+        int32_t hovered_entry{-1};
+    };
+
+    struct SelectedValue {
+        double value{0.0};
+        bool valid{false};
+    };
+
+    struct CallSummary {
+        uint32_t minimum{0};
+        uint32_t maximum{0};
+        double mean{0.0};
+    };
+
+    struct GpuCoverage {
+        uint64_t absent{0};
+        uint64_t unavailable{0};
+        uint64_t complete{0};
+        uint64_t incomplete{0};
+    };
+
+    constexpr std::array PALETTE{
+        IM_COL32(0, 114, 178, 255),
+        IM_COL32(230, 159, 0, 255),
+        IM_COL32(0, 158, 115, 255),
+        IM_COL32(204, 121, 167, 255),
+        IM_COL32(86, 180, 233, 255),
+        IM_COL32(213, 94, 0, 255),
+        IM_COL32(148, 103, 189, 255),
+        IM_COL32(27, 158, 119, 255),
+        IM_COL32(217, 95, 14, 255),
+        IM_COL32(117, 112, 179, 255),
+        IM_COL32(231, 138, 195, 255),
+        IM_COL32(102, 166, 30, 255),
+    };
+
+    constexpr ImVec2 INITIAL_WINDOW_SIZE = ImVec2(800.f, 700.f);
+
+    constexpr float TABLE_HIERARCHY_INDENT = 12.f;
+    constexpr float TABLE_COLOR_SWATCH_SIZE = 12.f;
+    constexpr uint32_t TABLE_MAX_HIERARCHY_DEPTH = 64;
+
+    constexpr ImU32 SHARE_BAR_BACKGROUND_COLOR = IM_COL32(70, 74, 82, 100);
+    constexpr float SHARE_BAR_ROUNDING = 2.f;
+
+    constexpr float GRAPH_HEIGHT = 260.f;
+    constexpr float GRAPH_LABEL_WIDTH = 80.f;
+    constexpr float GRAPH_TOP_PADDING = 8.f;
+    constexpr float GRAPH_RIGHT_PADDING = 4.f;
+    constexpr float GRAPH_BOTTOM_PADDING = 8.f;
+    constexpr float GRAPH_AXIS_LABEL_OFFSET = 2.f;
+    constexpr float GRAPH_AXIS_LABEL_CENTER = 0.5f;
+    constexpr float GRAPH_COLUMN_INSET = 0.5f;
+    constexpr float GRAPH_OVERFLOW_MARKER_SIZE = 5.f;
+    constexpr float GRAPH_INCOMPLETE_MARKER_OFFSET = 3.f;
+    constexpr float GRAPH_LINE_THICKNESS = 2.f;
+    constexpr uint32_t GRAPH_GRID_COUNT = 4;
+    constexpr ImU32 GRAPH_BACKGROUND_COLOR = IM_COL32(22, 24, 29, 255);
+    constexpr ImU32 GRAPH_GRID_COLOR = IM_COL32(120, 125, 135, 70);
+    constexpr ImU32 GRAPH_LABEL_COLOR = IM_COL32(185, 188, 195, 255);
+    constexpr ImU32 GRAPH_HIGHLIGHT_COLOR = IM_COL32(255, 255, 255, 230);
+    constexpr ImU32 GRAPH_OVERFLOW_COLOR = IM_COL32(255, 90, 70, 255);
+    constexpr ImU32 GRAPH_INCOMPLETE_COLOR = IM_COL32(190, 190, 195, 180);
+
+    const ImVec4 DATA_LOSS_WARNING_COLOR(1.f, 0.48f, 0.35f, 1.f);
+
+    constexpr uint32_t DIAGNOSTICS_LINE_COUNT = 3;
+
+    UIState ui_state;
+
+    bool valid_gpu_status(ProfilerFrameGpuStatus status)
+    {
+        return status == ProfilerFrameGpuStatus::absent || status == ProfilerFrameGpuStatus::complete;
+    }
+
+    CallSummary call_summary(const ProfilerFrameStats& stats, size_t entry_index)
+    {
+        CallSummary result;
+        uint64_t total = 0;
+        for (size_t sample_index = 0; sample_index < stats.sample_count(); ++sample_index) {
+            const uint32_t calls = stats.sample(sample_index).call_count[entry_index];
+            if (sample_index == 0)
+                result.minimum = calls;
+            else
+                result.minimum = std::min(result.minimum, calls);
+            result.maximum = std::max(result.maximum, calls);
+            total += calls;
+        }
+        if (stats.sample_count() != 0)
+            result.mean = double(total) / double(stats.sample_count());
+        return result;
+    }
+
+    GpuCoverage gpu_coverage(const ProfilerFrameStats& stats, size_t entry_index)
+    {
+        GpuCoverage result;
+        for (size_t sample_index = 0; sample_index < stats.sample_count(); ++sample_index) {
+            switch (stats.sample(sample_index).gpu_status[entry_index]) {
+            case ProfilerFrameGpuStatus::absent:
+                ++result.absent;
+                break;
+            case ProfilerFrameGpuStatus::unavailable:
+                ++result.unavailable;
+                break;
+            case ProfilerFrameGpuStatus::complete:
+                ++result.complete;
+                break;
+            case ProfilerFrameGpuStatus::incomplete:
+                ++result.incomplete;
+                break;
+            }
+        }
+        return result;
+    }
+
+    uint32_t latest_calls(const ProfilerFrameStats& stats, size_t entry_index)
+    {
+        return stats.sample_count() == 0 ? 0 : stats.sample(stats.sample_count() - 1).call_count[entry_index];
+    }
+
+    SelectedValue selected_time(const ProfilerFrameStats& stats, size_t entry_index, ValueMode mode, bool gpu)
+    {
+        const ProfilerFrameStatsEntry& entry = stats.entries()[entry_index];
+        if (mode == ValueMode::latest) {
+            if (stats.sample_count() == 0)
+                return {};
+            const ProfilerFrameStatsSampleView sample = stats.sample(stats.sample_count() - 1);
+            if (gpu)
+                return {sample.gpu_time_ms[entry_index], valid_gpu_status(sample.gpu_status[entry_index])};
+            return {sample.cpu_time_ms[entry_index], true};
+        }
+        const ProfilerDurationStatistics& statistics = gpu ? entry.gpu_time_per_frame : entry.cpu_time_per_frame;
+        if (statistics.count == 0)
+            return {};
+        return {mode == ValueMode::mean ? statistics.mean_ms : statistics.p95_ms, true};
+    }
+
+    ImU32 entry_color(const ProfilerFrameStats& stats, size_t entry_index)
+    {
+        std::vector<uint32_t> path;
+        int32_t index = int32_t(entry_index);
+        while (index >= 0 && size_t(index) < stats.entries().size() && path.size() <= stats.entries().size()) {
+            path.push_back(stats.entries()[size_t(index)].site_id);
+            index = stats.entries()[size_t(index)].parent_index;
+        }
+        uint64_t hash = 1469598103934665603ull;
+        for (auto it = path.rbegin(); it != path.rend(); ++it) {
+            hash ^= *it;
+            hash *= 1099511628211ull;
+        }
+        return PALETTE[size_t(hash % PALETTE.size())];
+    }
+
+    ImU32 muted_color(ImU32 color)
+    {
+        ImVec4 value = ImGui::ColorConvertU32ToFloat4(color);
+        value.x = value.x * 0.35f + 0.35f;
+        value.y = value.y * 0.35f + 0.35f;
+        value.z = value.z * 0.35f + 0.35f;
+        value.w = 0.55f;
+        return ImGui::ColorConvertFloat4ToU32(value);
+    }
+
+    void show_duration_statistics(const char* label, const ProfilerDurationStatistics& statistics)
+    {
+        if (statistics.count == 0) {
+            ImGui::Text("%s: n/a", label);
+            return;
+        }
+        ImGui::Text(
+            "%s/frame (%llu samples): min %.3f, max %.3f, mean %.3f, stddev %.3f ms",
+            label,
+            static_cast<unsigned long long>(statistics.count),
+            statistics.minimum_ms,
+            statistics.maximum_ms,
+            statistics.mean_ms,
+            statistics.standard_deviation_ms
+        );
+        ImGui::Text(
+            "  P50 %.3f, P90 %.3f, P95 %.3f, P99 %.3f ms",
+            statistics.p50_ms,
+            statistics.p90_ms,
+            statistics.p95_ms,
+            statistics.p99_ms
+        );
+    }
+
+    void show_call_statistics(const char* label, const ProfilerCallStatistics& statistics)
+    {
+        if (statistics.count == 0) {
+            ImGui::Text("%s/call: n/a", label);
+            return;
+        }
+        ImGui::Text(
+            "%s/call (%llu calls): min %.3f, max %.3f, mean %.3f, stddev %.3f ms",
+            label,
+            static_cast<unsigned long long>(statistics.count),
+            statistics.minimum_ms,
+            statistics.maximum_ms,
+            statistics.mean_ms,
+            statistics.standard_deviation_ms
+        );
+    }
+
+    void show_entry_tooltip(const ProfilerFrameStats& stats, size_t entry_index)
+    {
+        const ProfilerFrameStatsEntry& entry = stats.entries()[entry_index];
+        const CallSummary calls = call_summary(stats, entry_index);
+        const GpuCoverage coverage = gpu_coverage(stats, entry_index);
+        ImGui::BeginTooltip();
+        ImGui::TextUnformatted(entry.name.c_str());
+        ImGui::Separator();
+        ImGui::Text("Calls/frame: min %u, max %u, mean %.2f", calls.minimum, calls.maximum, calls.mean);
+        show_duration_statistics("CPU", entry.cpu_time_per_frame);
+        show_call_statistics("CPU", entry.cpu_time_per_call);
+        show_duration_statistics("GPU", entry.gpu_time_per_frame);
+        show_call_statistics("GPU", entry.gpu_time_per_call);
+        ImGui::Text(
+            "GPU frames: %llu complete, %llu unavailable, %llu incomplete, %llu absent",
+            static_cast<unsigned long long>(coverage.complete),
+            static_cast<unsigned long long>(coverage.unavailable),
+            static_cast<unsigned long long>(coverage.incomplete),
+            static_cast<unsigned long long>(coverage.absent)
+        );
+        ImGui::EndTooltip();
+    }
+
+    bool item_hovered_with_tooltip(const ProfilerFrameStats& stats, size_t entry_index)
+    {
+        if (!ImGui::IsItemHovered())
+            return false;
+        show_entry_tooltip(stats, entry_index);
+        return true;
+    }
+
+    bool draw_share_bar(const char* id, double fraction, ImU32 color)
+    {
+        const ImVec2 origin = ImGui::GetCursorScreenPos();
+        const ImVec2 size(std::max(1.f, ImGui::GetContentRegionAvail().x), ImGui::GetTextLineHeight());
+        ImGui::InvisibleButton(id, size);
+        ImDrawList* draw = ImGui::GetWindowDrawList();
+        draw->AddRectFilled(
+            origin,
+            ImVec2(origin.x + size.x, origin.y + size.y),
+            SHARE_BAR_BACKGROUND_COLOR,
+            SHARE_BAR_ROUNDING
+        );
+        const float fill = float(std::clamp(fraction, 0.0, 1.0));
+        if (fill > 0.f)
+            draw->AddRectFilled(origin, ImVec2(origin.x + size.x * fill, origin.y + size.y), color, SHARE_BAR_ROUNDING);
+        if (ImGui::IsItemHovered()) {
+            ImGui::BeginTooltip();
+            ImGui::Text("%.2f%% of summed root-zone time", fraction * 100.0);
+            ImGui::EndTooltip();
+            return true;
+        }
+        return false;
+    }
+
+    void draw_table(UIState& state, const ProfilerFrameStats& stats, float height, int32_t highlighted_entry)
+    {
+        double cpu_root_total = 0.0;
+        double gpu_root_total = 0.0;
+        for (size_t index = 0; index < stats.entries().size(); ++index) {
+            if (stats.entries()[index].parent_index >= 0)
+                continue;
+            cpu_root_total += selected_time(stats, index, state.value_mode, false).value;
+            const SelectedValue gpu = selected_time(stats, index, state.value_mode, true);
+            if (gpu.valid)
+                gpu_root_total += gpu.value;
+        }
+
+        if (!ImGui::BeginTable(
+                "profiler_frame_stats",
+                6,
+                ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_ScrollY
+                    | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp,
+                ImVec2(0.f, height)
+            ))
+            return;
+        ImGui::TableSetupScrollFreeze(0, 1);
+        ImGui::TableSetupColumn("Zone", ImGuiTableColumnFlags_WidthStretch, 2.2f);
+        ImGui::TableSetupColumn("Calls/frame", ImGuiTableColumnFlags_WidthStretch, 0.85f);
+        ImGui::TableSetupColumn("CPU time", ImGuiTableColumnFlags_WidthStretch, 0.8f);
+        ImGui::TableSetupColumn("CPU share", ImGuiTableColumnFlags_WidthStretch, 0.9f);
+        ImGui::TableSetupColumn("GPU time", ImGuiTableColumnFlags_WidthStretch, 0.8f);
+        ImGui::TableSetupColumn("GPU share", ImGuiTableColumnFlags_WidthStretch, 0.9f);
+        ImGui::TableHeadersRow();
+
+        for (size_t index = 0; index < stats.entries().size(); ++index) {
+            const ProfilerFrameStatsEntry& entry = stats.entries()[index];
+            const ImU32 color = entry_color(stats, index);
+            ImGui::PushID(int(index));
+            ImGui::TableNextRow();
+            if (highlighted_entry == int32_t(index))
+                ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, muted_color(color));
+
+            bool row_hovered = false;
+            ImGui::TableNextColumn();
+            uint32_t depth = 0;
+            int32_t parent = entry.parent_index;
+            while (parent >= 0 && size_t(parent) < index && depth < TABLE_MAX_HIERARCHY_DEPTH) {
+                ++depth;
+                parent = stats.entries()[size_t(parent)].parent_index;
+            }
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + float(depth) * TABLE_HIERARCHY_INDENT);
+            ImGui::ColorButton(
+                "##color",
+                ImGui::ColorConvertU32ToFloat4(color),
+                ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoBorder,
+                ImVec2(TABLE_COLOR_SWATCH_SIZE, TABLE_COLOR_SWATCH_SIZE)
+            );
+            row_hovered |= item_hovered_with_tooltip(stats, index);
+            ImGui::SameLine();
+            ImGui::TextUnformatted(entry.name.c_str());
+            row_hovered |= item_hovered_with_tooltip(stats, index);
+
+            ImGui::TableNextColumn();
+            ImGui::Text("%u", latest_calls(stats, index));
+            row_hovered |= item_hovered_with_tooltip(stats, index);
+
+            const SelectedValue cpu = selected_time(stats, index, state.value_mode, false);
+            ImGui::TableNextColumn();
+            ImGui::Text("%.3f ms", cpu.value);
+            row_hovered |= item_hovered_with_tooltip(stats, index);
+            ImGui::TableNextColumn();
+            row_hovered
+                |= draw_share_bar("##cpu_share", cpu_root_total > 0.0 ? cpu.value / cpu_root_total : 0.0, color);
+
+            const SelectedValue gpu = selected_time(stats, index, state.value_mode, true);
+            ImGui::TableNextColumn();
+            if (gpu.valid)
+                ImGui::Text("%.3f ms", gpu.value);
+            else
+                ImGui::TextUnformatted("n/a");
+            row_hovered |= item_hovered_with_tooltip(stats, index);
+            ImGui::TableNextColumn();
+            if (gpu.valid) {
+                row_hovered
+                    |= draw_share_bar("##gpu_share", gpu_root_total > 0.0 ? gpu.value / gpu_root_total : 0.0, color);
+            } else {
+                ImGui::TextDisabled("n/a");
+                row_hovered |= item_hovered_with_tooltip(stats, index);
+            }
+
+            if (row_hovered)
+                state.hovered_entry = int32_t(index);
+            ImGui::PopID();
+        }
+        ImGui::EndTable();
+    }
+
+    void draw_graph(UIState& state, const ProfilerFrameStats& stats, float height, int32_t highlighted_entry)
+    {
+        const bool gpu = state.graph_mode == GraphMode::gpu;
+        if (stats.sample_count() == 0) {
+            ImGui::TextUnformatted("No completed frame history");
+            return;
+        }
+        if (stats.entries().empty()) {
+            ImGui::TextUnformatted("No profiled zones in completed frame history");
+            return;
+        }
+
+        const ImVec2 origin = ImGui::GetCursorScreenPos();
+        const ImVec2 size(std::max(1.f, ImGui::GetContentRegionAvail().x), height);
+        ImGui::InvisibleButton("profiler_history", size);
+        const bool graph_hovered = ImGui::IsItemHovered();
+        ImDrawList* draw = ImGui::GetWindowDrawList();
+        draw->AddRectFilled(origin, ImVec2(origin.x + size.x, origin.y + size.y), GRAPH_BACKGROUND_COLOR);
+
+        const float plot_left = origin.x + GRAPH_LABEL_WIDTH;
+        const float plot_right = origin.x + size.x - GRAPH_RIGHT_PADDING;
+        const float plot_top = origin.y + GRAPH_TOP_PADDING;
+        const float plot_bottom = origin.y + size.y - GRAPH_BOTTOM_PADDING;
+        const float plot_width = std::max(1.f, plot_right - plot_left);
+        const float plot_height = std::max(1.f, plot_bottom - plot_top);
+
+        double maximum = 0.0;
+        for (size_t sample_index = 0; sample_index < stats.sample_count(); ++sample_index) {
+            const ProfilerFrameStatsSampleView sample = stats.sample(sample_index);
+            double total = 0.0;
+            for (size_t index = 0; index < stats.entries().size(); ++index) {
+                if (stats.entries()[index].parent_index < 0)
+                    total += gpu ? sample.gpu_time_ms[index] : sample.cpu_time_ms[index];
+            }
+            maximum = std::max(maximum, total);
+        }
+        if (maximum <= 0.0)
+            maximum = 1.0;
+
+        for (uint32_t grid = 0; grid <= GRAPH_GRID_COUNT; ++grid) {
+            const float y = plot_bottom - plot_height * float(grid) / float(GRAPH_GRID_COUNT);
+            draw->AddLine(ImVec2(plot_left, y), ImVec2(plot_right, y), GRAPH_GRID_COLOR);
+            char label[32];
+            snprintf(label, sizeof(label), "%.1f ms", maximum * double(grid) / double(GRAPH_GRID_COUNT));
+            draw->AddText(
+                ImVec2(origin.x + GRAPH_AXIS_LABEL_OFFSET, y - ImGui::GetTextLineHeight() * GRAPH_AXIS_LABEL_CENTER),
+                GRAPH_LABEL_COLOR,
+                label
+            );
+        }
+
+        const float column_width = plot_width / float(stats.sample_count());
+        int32_t hovered_entry = -1;
+        size_t hovered_sample = 0;
+        bool hovered_overflow = false;
+        bool hovered_sample_incomplete = false;
+        std::vector<bool> sample_incomplete_flags(gpu ? stats.sample_count() : 0);
+        std::vector<double> band_bottom(stats.entries().size());
+        std::vector<double> band_height(stats.entries().size());
+        std::vector<double> child_used(stats.entries().size());
+        std::vector<bool> overflow(stats.entries().size());
+        const ImVec2 mouse = ImGui::GetIO().MousePos;
+
+        for (size_t sample_index = 0; sample_index < stats.sample_count(); ++sample_index) {
+            const ProfilerFrameStatsSampleView sample = stats.sample(sample_index);
+            const float x0 = plot_left + column_width * float(sample_index) + GRAPH_COLUMN_INSET;
+            const float x1 = plot_left + column_width * float(sample_index + 1) - GRAPH_COLUMN_INSET;
+            std::fill(band_bottom.begin(), band_bottom.end(), 0.0);
+            std::fill(band_height.begin(), band_height.end(), 0.0);
+            std::fill(child_used.begin(), child_used.end(), 0.0);
+            std::fill(overflow.begin(), overflow.end(), false);
+
+            double root_bottom = 0.0;
+            bool sample_incomplete = false;
+            for (size_t index = 0; index < stats.entries().size(); ++index) {
+                const ProfilerFrameStatsEntry& entry = stats.entries()[index];
+                const double value = gpu ? sample.gpu_time_ms[index] : sample.cpu_time_ms[index];
+                if (gpu && !valid_gpu_status(sample.gpu_status[index]))
+                    sample_incomplete = true;
+                if (entry.parent_index < 0) {
+                    band_bottom[index] = root_bottom;
+                    band_height[index] = value;
+                    root_bottom += value;
+                } else {
+                    const size_t parent = size_t(entry.parent_index);
+                    const double available = std::max(0.0, band_height[parent] - child_used[parent]);
+                    band_bottom[index] = band_bottom[parent] + child_used[parent];
+                    band_height[index] = std::min(value, available);
+                    if (value > available + 1e-9)
+                        overflow[parent] = true;
+                    child_used[parent] += value;
+                }
+
+                if (band_height[index] <= 0.0)
+                    continue;
+                const float y0 = plot_bottom - float((band_bottom[index] + band_height[index]) / maximum) * plot_height;
+                const float y1 = plot_bottom - float(band_bottom[index] / maximum) * plot_height;
+                ImU32 color = entry_color(stats, index);
+                if (gpu && !valid_gpu_status(sample.gpu_status[index]))
+                    color = muted_color(color);
+                draw->AddRectFilled(ImVec2(x0, y0), ImVec2(std::max(x0 + 1.f, x1), y1), color);
+                if (highlighted_entry == int32_t(index))
+                    draw->AddRect(
+                        ImVec2(x0, y0),
+                        ImVec2(std::max(x0 + 1.f, x1), y1),
+                        GRAPH_HIGHLIGHT_COLOR,
+                        0.f,
+                        0,
+                        GRAPH_LINE_THICKNESS
+                    );
+                if (graph_hovered && mouse.x >= x0 && mouse.x <= x1 && mouse.y >= y0 && mouse.y <= y1) {
+                    hovered_entry = int32_t(index);
+                    hovered_sample = sample_index;
+                }
+            }
+
+            for (size_t index = 0; index < overflow.size(); ++index) {
+                if (!overflow[index])
+                    continue;
+                const float y = plot_bottom - float((band_bottom[index] + band_height[index]) / maximum) * plot_height;
+                draw->AddTriangleFilled(
+                    ImVec2(x1 - GRAPH_OVERFLOW_MARKER_SIZE, y),
+                    ImVec2(x1, y),
+                    ImVec2(x1, y + GRAPH_OVERFLOW_MARKER_SIZE),
+                    GRAPH_OVERFLOW_COLOR
+                );
+            }
+            if (hovered_entry >= 0 && hovered_sample == sample_index)
+                hovered_overflow = overflow[size_t(hovered_entry)];
+
+            if (gpu)
+                sample_incomplete_flags[sample_index] = sample_incomplete;
+            if (hovered_entry >= 0 && hovered_sample == sample_index)
+                hovered_sample_incomplete = sample_incomplete;
+            if (gpu && sample_incomplete)
+                draw->AddLine(
+                    ImVec2(x0, plot_bottom + GRAPH_INCOMPLETE_MARKER_OFFSET),
+                    ImVec2(x1, plot_bottom + GRAPH_INCOMPLETE_MARKER_OFFSET),
+                    GRAPH_INCOMPLETE_COLOR,
+                    GRAPH_LINE_THICKNESS
+                );
+        }
+
+        if (hovered_entry >= 0) {
+            state.hovered_entry = hovered_entry;
+            const ProfilerFrameStatsSampleView sample = stats.sample(hovered_sample);
+            const size_t index = size_t(hovered_entry);
+            ImGui::BeginTooltip();
+            ImGui::TextUnformatted(stats.entries()[index].name.c_str());
+            ImGui::Text(
+                "Frame %u: %.3f ms (%u calls)",
+                sample.frame_index,
+                gpu ? sample.gpu_time_ms[index] : sample.cpu_time_ms[index],
+                sample.call_count[index]
+            );
+            ImGui::Text("Frame time: %.3f ms", sample.frame_time_ms);
+            if (gpu && sample.gpu_status[index] == ProfilerFrameGpuStatus::unavailable)
+                ImGui::TextUnformatted("GPU timing was not requested; value is muted.");
+            if (gpu && sample.gpu_status[index] == ProfilerFrameGpuStatus::incomplete)
+                ImGui::TextUnformatted("GPU timing is incomplete; value is muted.");
+            if (hovered_overflow)
+                ImGui::TextUnformatted("Child totals overflow this parent and are clipped.");
+            if (gpu && hovered_sample_incomplete)
+                ImGui::TextUnformatted("This frame contains incomplete GPU samples.");
+            ImGui::EndTooltip();
+        } else if (gpu && graph_hovered && mouse.x >= plot_left && mouse.x <= plot_right) {
+            const size_t sample_index
+                = std::min(stats.sample_count() - 1, size_t(std::max(0.f, mouse.x - plot_left) / column_width));
+            if (sample_incomplete_flags[sample_index]) {
+                const ProfilerFrameStatsSampleView sample = stats.sample(sample_index);
+                ImGui::BeginTooltip();
+                ImGui::Text("Frame %u: incomplete GPU timing", sample.frame_index);
+                ImGui::Text("Frame time: %.3f ms", sample.frame_time_ms);
+                ImGui::TextUnformatted("Muted entries are unavailable or partial measurements.");
+                ImGui::EndTooltip();
+            }
+        }
+    }
+
+    template<typename T, size_t N>
+    void draw_selector(const char* label, T& value, const std::array<const char*, N>& labels, float width)
+    {
+        ImGui::SetNextItemWidth(width);
+        if (ImGui::BeginCombo(label, labels[static_cast<size_t>(value)])) {
+            for (size_t index = 0; index < labels.size(); ++index) {
+                const bool selected = index == static_cast<size_t>(value);
+                if (ImGui::Selectable(labels[index], selected))
+                    value = static_cast<T>(index);
+                if (selected)
+                    ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+        }
+    }
+
+    void draw_value_selector(UIState& state)
+    {
+        draw_selector("Value", state.value_mode, VALUE_MODE_LABELS, 120.f);
+    }
+
+    void draw_graph_selector(UIState& state)
+    {
+        draw_selector("Mode", state.graph_mode, GRAPH_MODE_LABELS, 100.f);
+    }
+
+} // namespace
+
+void render_profiler_window(Profiler* profiler)
+{
+    if (!profiler)
+        profiler = current_profiler_or_null();
+    if (ui_state.profiler != profiler)
+        ui_state = UIState{.profiler = profiler};
+    ImGui::SetNextWindowSize(INITIAL_WINDOW_SIZE, ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Profiler", nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
+        ImGui::End();
+        return;
+    }
+    if (!profiler) {
+        ImGui::TextUnformatted("No active profiler");
+        ImGui::End();
+        return;
+    }
+
+    UIState& state = ui_state;
+    bool enabled = profiler->enabled();
+    if (ImGui::Checkbox("Enabled", &enabled))
+        profiler->set_enabled(enabled);
+    ImGui::SameLine();
+    bool automatic = profiler->enable_auto_zones();
+    if (ImGui::Checkbox("Automatic zones", &automatic))
+        profiler->set_enable_auto_zones(automatic);
+    ImGui::SameLine();
+    ImGui::Checkbox("Pause display", &state.paused);
+
+    if (!state.paused || !state.stats)
+        state.stats = profiler->frame_stats_snapshot();
+    if (!state.stats) {
+        ImGui::TextUnformatted("No frame statistics available");
+        ImGui::End();
+        return;
+    }
+
+    const ProfilerDiagnostics& diagnostics = state.stats->diagnostics();
+    const bool data_loss = diagnostics.producer_drop_count != 0 || diagnostics.hierarchy_loss_count != 0
+        || diagnostics.gpu_query_exhaustion_count != 0;
+    if (data_loss) {
+        ImGui::TextColored(
+            DATA_LOSS_WARNING_COLOR,
+            "Warning: profiler data loss detected; expand Diagnostics for details."
+        );
+    }
+
+    ImGui::PushFont("monospace");
+    const double latest_frame_ms = state.stats->latest_frame_ms();
+    if (latest_frame_ms > 0.0) {
+        ImGui::Text(
+            "FPS: %.1f  Frame time: %.3f ms latest  %.3f ms mean  %.3f ms P95",
+            1000.0 / latest_frame_ms,
+            latest_frame_ms,
+            state.stats->frame_time().mean_ms,
+            state.stats->frame_time().p95_ms
+        );
+    } else {
+        ImGui::TextUnformatted("FPS: n/a  Frame time: n/a");
+    }
+    draw_value_selector(state);
+
+    const bool graph_has_data = state.stats->sample_count() != 0 && !state.stats->entries().empty();
+    const float graph_content_height = graph_has_data ? GRAPH_HEIGHT : ImGui::GetTextLineHeight();
+    float bottom_height = ImGui::GetFrameHeightWithSpacing();
+    if (state.graph_open)
+        bottom_height += ImGui::GetFrameHeightWithSpacing() + graph_content_height + ImGui::GetStyle().ItemSpacing.y;
+    bottom_height += ImGui::GetFrameHeight();
+    if (state.diagnostics_open)
+        bottom_height += DIAGNOSTICS_LINE_COUNT * ImGui::GetTextLineHeightWithSpacing();
+
+    const int32_t previous_hovered = state.hovered_entry;
+    state.hovered_entry = -1;
+    const float table_height = std::max(1.f, ImGui::GetContentRegionAvail().y - bottom_height);
+    draw_table(state, *state.stats, table_height, previous_hovered);
+
+    ImGui::SetNextItemOpen(state.graph_open, ImGuiCond_Always);
+    state.graph_open = ImGui::CollapsingHeader("Graph");
+    if (state.graph_open) {
+        draw_graph_selector(state);
+        draw_graph(
+            state,
+            *state.stats,
+            GRAPH_HEIGHT,
+            state.hovered_entry >= 0 ? state.hovered_entry : previous_hovered
+        );
+    }
+
+    ImGui::SetNextItemOpen(state.diagnostics_open, ImGuiCond_Always);
+    state.diagnostics_open = ImGui::CollapsingHeader("Diagnostics");
+    if (state.diagnostics_open) {
+        ImGui::Text(
+            "Pending frames: %llu  pending GPU zones: %llu",
+            static_cast<unsigned long long>(state.stats->pending_frame_count()),
+            static_cast<unsigned long long>(diagnostics.pending_gpu_zone_count)
+        );
+        ImGui::Text(
+            "Dropped producer events: %llu  hierarchy losses: %llu  GPU query exhaustion: %llu",
+            static_cast<unsigned long long>(diagnostics.producer_drop_count),
+            static_cast<unsigned long long>(diagnostics.hierarchy_loss_count),
+            static_cast<unsigned long long>(diagnostics.gpu_query_exhaustion_count)
+        );
+        ImGui::Text(
+            "Thread event queue high-water mark: %llu",
+            static_cast<unsigned long long>(diagnostics.thread_event_queue_high_water_mark)
+        );
+    }
+    ImGui::PopFont();
+    ImGui::End();
+}
+
+} // namespace sgl::ui

--- a/src/sgl/utils/profiler_ui.h
+++ b/src/sgl/utils/profiler_ui.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "sgl/core/macros.h"
+
+namespace sgl {
+class Profiler;
+}
+
+namespace sgl::ui {
+
+/// Render real-time frame-aligned profiler statistics from cached snapshots.
+/// @param profiler Profiler to display, or nullptr to use the current profiler.
+SGL_API void render_profiler_window(Profiler* profiler = nullptr);
+
+} // namespace sgl::ui

--- a/src/slangpy_ext/CMakeLists.txt
+++ b/src/slangpy_ext/CMakeLists.txt
@@ -51,6 +51,7 @@ nanobind_add_module(slangpy_ext NB_STATIC LTO
     refl/layout.cpp
     utils/crashpad.cpp
     utils/renderdoc.cpp
+    utils/profiler.cpp
     utils/slangpy.h
     utils/slangpy.cpp
     utils/slangpyvalue.h

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -6873,7 +6873,21 @@ static const char *__doc_sgl_ProfilerZoneChunk_correlation_id = R"doc(CPU/GPU co
 
 static const char *__doc_sgl_ProfilerZoneChunk_duration_ns = R"doc(Zone durations in nanoseconds.)doc";
 
-static const char *__doc_sgl_ProfilerZoneChunk_frame_index = R"doc(Profiler-wide frame indices, or -1 for zones outside a frame.)doc";
+static const char *__doc_sgl_ProfilerZoneChunk_frame_index = R"doc(Profiler-wide frame indices, or UINT32_MAX for zones outside a frame.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_m_correlation_id = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_m_duration_ns = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_m_frame_index = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_m_parent_index = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_m_site_id = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_m_start_ns = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_m_timeline_id = R"doc()doc";
 
 static const char *__doc_sgl_ProfilerZoneChunk_parent_index = R"doc(Global zone indices of parents on the same timeline, or -1 for roots.)doc";
 
@@ -10560,6 +10574,10 @@ owned by that device is invalidated.)doc";
 
 static const char *__doc_sgl_detail_on_slang_wrapper_destroyed = R"doc()doc";
 
+static const char *__doc_sgl_detail_profiler_frame_name = R"doc()doc";
+
+static const char *__doc_sgl_detail_profiler_frame_name_2 = R"doc()doc";
+
 static const char *__doc_sgl_detail_strip_class_key = R"doc(Remove MSVC's "class " / "struct " prefix from a type name fragment.)doc";
 
 static const char *__doc_sgl_detail_throw_exception = R"doc()doc";
@@ -12312,6 +12330,8 @@ static const char *__doc_sgl_platform_create_junction = R"doc(Create a junction 
 
 static const char *__doc_sgl_platform_current_process_id = R"doc(Get the process ID of the current process.)doc";
 
+static const char *__doc_sgl_platform_current_thread_id = R"doc(Get the native platform identifier of the current thread.)doc";
+
 static const char *__doc_sgl_platform_debug_break = R"doc(Breaks in debugger (int 3 functionality).)doc";
 
 static const char *__doc_sgl_platform_delete_junction = R"doc(Delete a junction (sof link).)doc";
@@ -12418,10 +12438,6 @@ Returns:
     The popped device.)doc";
 
 static const char *__doc_sgl_pop_current_profiler = R"doc()doc";
-
-static const char *__doc_sgl_profiler_frame_name = R"doc()doc";
-
-static const char *__doc_sgl_profiler_frame_name_2 = R"doc()doc";
 
 static const char *__doc_sgl_push_current_device =
 R"doc(Push a device onto the thread-local current device stack.

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -7043,8 +7043,8 @@ R"doc(Poll submitted GPU timestamp queries and queue resolved measurements
 for the collector.
 
 The poll does not deliberately wait for profiled submissions or
-unresolved queries. Refreshing timestamp calibration can nevertheless
-synchronize queued GPU work on some backends, notably CUDA.)doc";
+unresolved queries. On CUDA, refreshing timestamp calibration synchronizes
+queued GPU work.)doc";
 
 static const char *__doc_sgl_Profiler_to_string = R"doc()doc";
 

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -1451,6 +1451,50 @@ static const char *__doc_sgl_Buffer_write_slangpy_signature = R"doc(Write the Sl
 
 static const char *__doc_sgl_Buffer_write_to_cursor = R"doc(Bind a nullable buffer value to a shader cursor.)doc";
 
+static const char *__doc_sgl_CacheWriter = R"doc(Background worker for best-effort cache write jobs.)doc";
+
+static const char *__doc_sgl_CacheWriter_2 = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_CacheWriter = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_Job = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_Job_byte_size = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_Job_func = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_class_name = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_enqueue = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_enqueue_2 = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_flush = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_cv = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_jobs = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_max_pending_bytes = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_mutex = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_pending_bytes = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_pending_jobs = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_space_cv = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_stop = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_m_thread = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_release = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_reserve = R"doc()doc";
+
+static const char *__doc_sgl_CacheWriter_run = R"doc()doc";
+
 static const char *__doc_sgl_CallbackList = R"doc()doc";
 
 static const char *__doc_sgl_CallbackList_CallbackList = R"doc()doc";
@@ -2977,6 +3021,8 @@ static const char *__doc_sgl_Device_blitter = R"doc()doc";
 
 static const char *__doc_sgl_Device_builtin_layout = R"doc(Return the cached reflection layout for the built-in support module.)doc";
 
+static const char *__doc_sgl_Device_cache_writer = R"doc()doc";
+
 static const char *__doc_sgl_Device_capabilities = R"doc(List of slang capabilities supported by the device.)doc";
 
 static const char *__doc_sgl_Device_class_name = R"doc()doc";
@@ -3329,6 +3375,8 @@ static const char *__doc_sgl_Device_load_program = R"doc(Load a module and link 
 static const char *__doc_sgl_Device_m_blitter = R"doc()doc";
 
 static const char *__doc_sgl_Device_m_builtin_layout = R"doc()doc";
+
+static const char *__doc_sgl_Device_m_cache_writer = R"doc()doc";
 
 static const char *__doc_sgl_Device_m_capabilities = R"doc()doc";
 
@@ -3811,6 +3859,8 @@ static const char *__doc_sgl_Feature_residency_set = R"doc()doc";
 
 static const char *__doc_sgl_Feature_sampler_feedback = R"doc()doc";
 
+static const char *__doc_sgl_Feature_shader_abort = R"doc()doc";
+
 static const char *__doc_sgl_Feature_shader_execution_reordering = R"doc()doc";
 
 static const char *__doc_sgl_Feature_shader_resource_min_lod = R"doc()doc";
@@ -3820,6 +3870,8 @@ static const char *__doc_sgl_Feature_sm_5_1 = R"doc()doc";
 static const char *__doc_sgl_Feature_sm_6_0 = R"doc()doc";
 
 static const char *__doc_sgl_Feature_sm_6_1 = R"doc()doc";
+
+static const char *__doc_sgl_Feature_sm_6_10 = R"doc()doc";
 
 static const char *__doc_sgl_Feature_sm_6_2 = R"doc()doc";
 
@@ -5168,6 +5220,40 @@ Parameter ``value``:
 Returns:
     True if the key was found, false otherwise.)doc";
 
+static const char *__doc_sgl_LMDBCache_get_impl = R"doc()doc";
+
+static const char *__doc_sgl_LMDBCache_get_readonly =
+R"doc(Get a value from the cache without updating its last-access metadata.
+Throws on error.
+
+Parameter ``key_data``:
+    Pointer to the key data.
+
+Parameter ``key_size``:
+    Size of the key data.
+
+Parameter ``write_value_func``:
+    Function to write the value data.
+
+Parameter ``user_data``:
+    User data passed to the write_value_func.
+
+Returns:
+    True if the key was found, false otherwise.)doc";
+
+static const char *__doc_sgl_LMDBCache_get_readonly_2 =
+R"doc(Get a value from the cache without updating its last-access metadata.
+Throws on error.
+
+Parameter ``key``:
+    Key.
+
+Parameter ``value``:
+    Vector to store the value.
+
+Returns:
+    True if the key was found, false otherwise.)doc";
+
 static const char *__doc_sgl_LMDBCache_m_db = R"doc()doc";
 
 static const char *__doc_sgl_LMDBCache_m_evict_mutex = R"doc()doc";
@@ -5179,6 +5265,8 @@ static const char *__doc_sgl_LMDBCache_m_eviction_threshold_size = R"doc()doc";
 static const char *__doc_sgl_LMDBCache_m_evictions = R"doc()doc";
 
 static const char *__doc_sgl_LMDBCache_m_max_key_size = R"doc()doc";
+
+static const char *__doc_sgl_LMDBCache_max_key_size = R"doc(Maximum key size supported by the database.)doc";
 
 static const char *__doc_sgl_LMDBCache_open_db = R"doc()doc";
 
@@ -5211,6 +5299,28 @@ Parameter ``value``:
     Value.)doc";
 
 static const char *__doc_sgl_LMDBCache_stats = R"doc()doc";
+
+static const char *__doc_sgl_LMDBCache_touch =
+R"doc(Update an entry's last-access metadata without reading its value.
+Throws on error.
+
+Parameter ``key_data``:
+    Pointer to the key data.
+
+Parameter ``key_size``:
+    Size of the key data.
+
+Returns:
+    True if the key was found and touched, false otherwise.)doc";
+
+static const char *__doc_sgl_LMDBCache_touch_2 =
+R"doc(Update an entry's last-access metadata. Throws on error.
+
+Parameter ``key``:
+    Key.
+
+Returns:
+    True if the key was found and touched, false otherwise.)doc";
 
 static const char *__doc_sgl_LMDBCache_usage = R"doc()doc";
 
@@ -6119,7 +6229,11 @@ static const char *__doc_sgl_PersistentCache_addRef = R"doc()doc";
 
 static const char *__doc_sgl_PersistentCache_class_name = R"doc()doc";
 
+static const char *__doc_sgl_PersistentCache_flush = R"doc()doc";
+
 static const char *__doc_sgl_PersistentCache_m_cache = R"doc()doc";
+
+static const char *__doc_sgl_PersistentCache_m_cache_writer = R"doc()doc";
 
 static const char *__doc_sgl_PersistentCache_m_hit_count = R"doc()doc";
 
@@ -6390,6 +6504,535 @@ static const char *__doc_sgl_PrimitiveTopology_point_list = R"doc()doc";
 static const char *__doc_sgl_PrimitiveTopology_triangle_list = R"doc()doc";
 
 static const char *__doc_sgl_PrimitiveTopology_triangle_strip = R"doc()doc";
+
+static const char *__doc_sgl_Profiler =
+R"doc(Bounded CPU/GPU instrumentation profiler with immutable trace and
+frame-statistics snapshots.)doc";
+
+static const char *__doc_sgl_Profiler_2 =
+R"doc(Bounded CPU/GPU instrumentation profiler with immutable trace and
+frame-statistics snapshots.)doc";
+
+static const char *__doc_sgl_Profiler_3 = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerCallStatistics =
+R"doc(Mergeable duration summary that does not retain individual call
+samples.)doc";
+
+static const char *__doc_sgl_ProfilerCallStatistics_count = R"doc(Number of calls.)doc";
+
+static const char *__doc_sgl_ProfilerCallStatistics_maximum_ms = R"doc(Maximum call duration in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerCallStatistics_mean_ms = R"doc(Arithmetic mean call duration in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerCallStatistics_minimum_ms = R"doc(Minimum call duration in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerCallStatistics_standard_deviation_ms = R"doc(Population standard deviation in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerCallStatistics_total_ms = R"doc(Sum of call durations in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerCaptureDesc = R"doc(Configuration for a bounded profiler capture.)doc";
+
+static const char *__doc_sgl_ProfilerCaptureDesc_max_memory_bytes = R"doc(Maximum capture-owned zone and frame storage in bytes.)doc";
+
+static const char *__doc_sgl_ProfilerCaptureStopReason = R"doc(Reason why a bounded profiler capture stopped recording.)doc";
+
+static const char *__doc_sgl_ProfilerCaptureStopReason_info = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerCaptureStopReason_memory_limit = R"doc(< The capture reached ProfilerCaptureDesc::max_memory_bytes.)doc";
+
+static const char *__doc_sgl_ProfilerCaptureStopReason_user = R"doc(< The capture was stopped explicitly by the user.)doc";
+
+static const char *__doc_sgl_ProfilerDesc = R"doc(Configuration used to construct a Profiler.)doc";
+
+static const char *__doc_sgl_ProfilerDesc_enable_auto_zones = R"doc(Enable automatic zones around SlangPy functional dispatch recording.)doc";
+
+static const char *__doc_sgl_ProfilerDesc_enable_debug_groups = R"doc(Mirror command-encoder profiling zones into backend debug groups.)doc";
+
+static const char *__doc_sgl_ProfilerDesc_frame_stats_window_size =
+R"doc(Maximum completed and ended GPU-pending frames retained in the global
+frame stream.)doc";
+
+static const char *__doc_sgl_ProfilerDesc_gpu_query_pool_size =
+R"doc(Number of timestamp queries shared by GPU zones. Each GPU zone uses
+two queries; the count must be positive and even.)doc";
+
+static const char *__doc_sgl_ProfilerDesc_live_event_capacity = R"doc(Maximum number of CPU and GPU zones retained in live trace snapshots.)doc";
+
+static const char *__doc_sgl_ProfilerDesc_live_frame_count = R"doc(Maximum number of completed frames retained in live trace snapshots.)doc";
+
+static const char *__doc_sgl_ProfilerDesc_thread_event_capacity =
+R"doc(Maximum number of unread CPU events in each producer thread's queue.
+Must be a positive power of two.)doc";
+
+static const char *__doc_sgl_ProfilerDiagnostics = R"doc(Diagnostic counters shared by immutable profiler snapshots.)doc";
+
+static const char *__doc_sgl_ProfilerDiagnostics_gpu_query_exhaustion_count =
+R"doc(Number of GPU zones recorded without GPU timing because no timestamp-
+query pair was available.)doc";
+
+static const char *__doc_sgl_ProfilerDiagnostics_hierarchy_loss_count =
+R"doc(Number of statistics nodes promoted to roots because their parent
+event was unavailable.)doc";
+
+static const char *__doc_sgl_ProfilerDiagnostics_pending_gpu_zone_count =
+R"doc(Number of allocated GPU zones still awaiting submission or timestamp
+resolution.)doc";
+
+static const char *__doc_sgl_ProfilerDiagnostics_producer_drop_count =
+R"doc(Number of producer events dropped because a per-thread event queue or
+zone stack was full.)doc";
+
+static const char *__doc_sgl_ProfilerDiagnostics_thread_event_queue_high_water_mark =
+R"doc(Maximum number of unread events observed in any per-thread producer
+queue.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics = R"doc(Distribution of duration samples in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_count = R"doc(Number of samples.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_maximum_ms = R"doc(Maximum sample duration in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_mean_ms = R"doc(Arithmetic mean duration in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_minimum_ms = R"doc(Minimum sample duration in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_p50_ms = R"doc(Linearly interpolated 50th percentile in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_p90_ms = R"doc(Linearly interpolated 90th percentile in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_p95_ms = R"doc(Linearly interpolated 95th percentile in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_p99_ms = R"doc(Linearly interpolated 99th percentile in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_standard_deviation_ms = R"doc(Population standard deviation in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerDurationStatistics_total_ms = R"doc(Sum of sample durations in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerFrame = R"doc(Completed frame boundary stored in a profiler trace.)doc";
+
+static const char *__doc_sgl_ProfilerFrameGpuStatus = R"doc(Availability of one entry's GPU duration in one retained frame.)doc";
+
+static const char *__doc_sgl_ProfilerFrameGpuStatus_absent = R"doc(< The entry had no occurrences; its zero duration is valid.)doc";
+
+static const char *__doc_sgl_ProfilerFrameGpuStatus_complete = R"doc(< All requested GPU timings resolved successfully.)doc";
+
+static const char *__doc_sgl_ProfilerFrameGpuStatus_incomplete = R"doc(< At least one requested GPU timing could not be resolved.)doc";
+
+static const char *__doc_sgl_ProfilerFrameGpuStatus_info = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameGpuStatus_unavailable = R"doc(< The entry occurred but did not request GPU timing.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats =
+R"doc(Immutable snapshot of rolling statistics for the profiler's global
+frame stream.
+
+Sample matrices are row-major with shape (sample_count(),
+entry_count()). All columns are ordered oldest to newest.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry =
+R"doc(Frame-aligned statistics for one hierarchical CPU zone path.
+
+CPU time per frame is the sum of inclusive occurrences at this path.
+Parent and child entries are therefore not additive. GPU time is the
+sum of directly measured occurrences and can exceed elapsed frame time
+when work overlaps.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry_cpu_time_per_call = R"doc(Mergeable statistics over individual CPU occurrences.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry_cpu_time_per_frame = R"doc(Distribution of summed CPU duration per retained frame.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry_gpu_time_per_call = R"doc(Mergeable statistics over individual resolved GPU occurrences.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry_gpu_time_per_frame =
+R"doc(Distribution of summed GPU duration for frames with complete GPU
+measurements.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry_name = R"doc(User-facing profiling-site name.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry_parent_index =
+R"doc(Index of the parent entry in the same frame statistics list, or -1 for
+a root.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsEntry_site_id = R"doc(Profiling site represented by this hierarchical path.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsSampleView = R"doc(Non-owning view of one retained completed frame.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsSampleView_call_count = R"doc(Number of occurrences for each entry.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsSampleView_cpu_time_ms = R"doc(Summed inclusive CPU duration in milliseconds for each entry.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsSampleView_frame_index = R"doc(Monotonically increasing profiler-wide frame index.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsSampleView_frame_time_ms = R"doc(Completed frame duration in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsSampleView_gpu_status = R"doc(GPU timing availability for each entry.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStatsSampleView_gpu_time_ms = R"doc(Summed directly measured GPU duration in milliseconds for each entry.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_class_name = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_diagnostics = R"doc(Diagnostic counters captured with this snapshot.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_entries =
+R"doc(Hierarchical CPU-zone paths in deterministic parent-before-child
+preorder.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_entry_count = R"doc(Number of hierarchical entries.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_frame_time = R"doc(Distribution of completed frame durations.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_latest_frame_ms = R"doc(Duration of the most recently completed frame in milliseconds.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_diagnostics = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_entries = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_frame_time = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_pending_frame_count = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_sample_call_count = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_sample_cpu_time_ms = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_sample_frame_index = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_sample_frame_time_ms = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_sample_gpu_status = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_m_sample_gpu_time_ms = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_pending_frame_count = R"doc(Total ended frames still waiting for GPU measurements.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample = R"doc(Return a non-owning entry-aligned view of one retained sample.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample_call_count =
+R"doc(Row-major occurrence-count matrix with shape (sample_count(),
+entry_count()).)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample_count = R"doc(Number of retained completed frames.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample_cpu_time_ms =
+R"doc(Row-major CPU-duration matrix with shape (sample_count(),
+entry_count()).)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample_frame_index = R"doc(Profiler-wide frame index for each retained sample.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample_frame_time_ms = R"doc(Completed frame duration in milliseconds for each retained sample.)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample_gpu_status =
+R"doc(Row-major GPU-status matrix with shape (sample_count(),
+entry_count()).)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_sample_gpu_time_ms =
+R"doc(Row-major GPU-duration matrix with shape (sample_count(),
+entry_count()).)doc";
+
+static const char *__doc_sgl_ProfilerFrameStats_to_string =
+R"doc(Return a terminal-oriented representation of the hierarchy, timings,
+and diagnostic counters.)doc";
+
+static const char *__doc_sgl_ProfilerFrameToken = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameToken_frame_index = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameToken_profiler = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrameToken_start_ns = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerFrame_duration_ns = R"doc(Frame duration in nanoseconds.)doc";
+
+static const char *__doc_sgl_ProfilerFrame_index = R"doc(Monotonically increasing profiler-wide frame index.)doc";
+
+static const char *__doc_sgl_ProfilerFrame_site_id = R"doc(Profiling site that names this frame.)doc";
+
+static const char *__doc_sgl_ProfilerFrame_start_ns = R"doc(Frame start time in profiler-clock nanoseconds.)doc";
+
+static const char *__doc_sgl_ProfilerFrame_timeline_id = R"doc(CPU timeline on which the frame was recorded.)doc";
+
+static const char *__doc_sgl_ProfilerImpl = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerScope = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerScope_ProfilerScope = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerScope_ProfilerScope_2 = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerScope_m_profiler = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerScope_operator_assign = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerSite =
+R"doc(Profiling-site metadata backed by process-lifetime interned strings.
+String views remain valid for the lifetime of the process.)doc";
+
+static const char *__doc_sgl_ProfilerSite_file = R"doc(Source filename supplied when the site was registered.)doc";
+
+static const char *__doc_sgl_ProfilerSite_function = R"doc(Compact qualified function name.)doc";
+
+static const char *__doc_sgl_ProfilerSite_id = R"doc(One-based site identifier referenced by zones and frames.)doc";
+
+static const char *__doc_sgl_ProfilerSite_line = R"doc(One-based source line number, or zero when unavailable.)doc";
+
+static const char *__doc_sgl_ProfilerSite_name = R"doc(User-facing zone or frame name.)doc";
+
+static const char *__doc_sgl_ProfilerTimeline = R"doc(Metadata for one CPU thread or GPU queue timeline.)doc";
+
+static const char *__doc_sgl_ProfilerTimelineType = R"doc(Type of execution timeline stored in a profiler trace.)doc";
+
+static const char *__doc_sgl_ProfilerTimelineType_cpu = R"doc(< CPU thread timeline.)doc";
+
+static const char *__doc_sgl_ProfilerTimelineType_gpu = R"doc(< GPU device queue timeline.)doc";
+
+static const char *__doc_sgl_ProfilerTimelineType_info = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTimeline_device_id = R"doc(Device identity for GPU timelines, otherwise zero.)doc";
+
+static const char *__doc_sgl_ProfilerTimeline_name = R"doc(Human-readable timeline name.)doc";
+
+static const char *__doc_sgl_ProfilerTimeline_queue = R"doc(Command queue type for GPU timelines.)doc";
+
+static const char *__doc_sgl_ProfilerTimeline_thread_id = R"doc(Platform thread identifier for CPU timelines, otherwise zero.)doc";
+
+static const char *__doc_sgl_ProfilerTimeline_type = R"doc(Execution domain represented by the timeline.)doc";
+
+static const char *__doc_sgl_ProfilerTrace =
+R"doc(Immutable profiler trace containing metadata, frame boundaries, and
+chunked CPU/GPU zones.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_2 =
+R"doc(Immutable profiler trace containing metadata, frame boundaries, and
+chunked CPU/GPU zones.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_class_name = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_diagnostics = R"doc(Diagnostic counters captured with this snapshot.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_frames = R"doc(Completed frame boundaries retained by this trace.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_diagnostics = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_frames = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_memory_bytes = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_sites = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_start_ns = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_stop_ns = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_stop_reason = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_timelines = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_truncated = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_m_zone_chunks = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerTrace_memory_bytes = R"doc(Capture-owned zone and frame storage in bytes.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_query_zones =
+R"doc(Select zones using exact-name, timeline, frame, and timestamp filters.
+Frame and timestamp ranges are half-open. Zones overlap the requested
+timestamp range rather than requiring their complete duration to be
+contained in it. Zones outside frames are excluded whenever a frame
+bound is set.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_sites = R"doc(Process-global profiling sites visible when the snapshot was built.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_start_ns = R"doc(Capture or live-history start time in profiler-clock nanoseconds.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_stop_ns = R"doc(Capture or live-history stop time in profiler-clock nanoseconds.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_stop_reason = R"doc(Reason why capture recording stopped.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_timelines = R"doc(CPU and GPU timelines referenced by this trace.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_truncated = R"doc(Whether a bounded capture stopped at its memory limit.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_write_to_json = R"doc(Stream this trace as Chrome trace-event JSON suitable for Perfetto.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_zone_chunks = R"doc(Immutable structure-of-arrays zone chunks.)doc";
+
+static const char *__doc_sgl_ProfilerTrace_zone_count = R"doc(Total number of zones across all chunks.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk =
+R"doc(Immutable structure-of-arrays storage for at most 4096 zones.
+
+Bounded chunks let trace queries and exports process large captures
+without flattening all zones into one allocation. The Python bindings
+expose each column as a zero-copy, read-only NumPy array whose
+lifetime is tied to the chunk.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_class_name = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_correlation_id = R"doc(CPU/GPU correlation identifiers.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_duration_ns = R"doc(Zone durations in nanoseconds.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_frame_index = R"doc(Profiler-wide frame indices, or -1 for zones outside a frame.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_parent_index = R"doc(Global zone indices of parents on the same timeline, or -1 for roots.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_site_id = R"doc(One-based identifiers into ProfilerTrace::sites().)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_size = R"doc(Number of zones in this chunk.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_start_ns = R"doc(Zone start times in profiler-clock nanoseconds.)doc";
+
+static const char *__doc_sgl_ProfilerZoneChunk_timeline_id = R"doc(Indices into ProfilerTrace::timelines().)doc";
+
+static const char *__doc_sgl_ProfilerZoneSelection = R"doc(Immutable set of global zone indices selected from one ProfilerTrace.)doc";
+
+static const char *__doc_sgl_ProfilerZoneSelection_class_name = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneSelection_count = R"doc(Number of selected zones.)doc";
+
+static const char *__doc_sgl_ProfilerZoneSelection_indices = R"doc(Sorted global zone indices into the source trace.)doc";
+
+static const char *__doc_sgl_ProfilerZoneSelection_m_indices = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneSelection_m_trace = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneSelection_statistics = R"doc(Calculate duration statistics for the selected zones.)doc";
+
+static const char *__doc_sgl_ProfilerZoneToken = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_command_encoder = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_correlation_id = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_debug_group_active = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_frame_index = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_gpu_begin_query = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_gpu_state = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_parent_correlation_id = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_profiler = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_site_id = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_stack_index = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_start_ns = R"doc()doc";
+
+static const char *__doc_sgl_ProfilerZoneToken_thread_data = R"doc()doc";
+
+static const char *__doc_sgl_Profiler_Profiler =
+R"doc(Create a profiler. If the current thread has no current profiler, this
+profiler becomes its default. The destructor removes that default
+entry when it remains the stack's sole entry. A default profiler must
+be destroyed on its constructing thread after temporary profiler
+scopes on that thread have ended. Destruction must not race device
+submission, command-buffer discard, or device close operations
+associated with GPU zones.)doc";
+
+static const char *__doc_sgl_Profiler_begin_frame =
+R"doc(Begin the profiler's global frame, or return an invalid token if a
+frame is already open or closing.)doc";
+
+static const char *__doc_sgl_Profiler_begin_zone =
+R"doc(Begin a CPU zone and optionally reserve GPU timestamp queries on a
+command encoder.)doc";
+
+static const char *__doc_sgl_Profiler_capture_active =
+R"doc(Whether a bounded capture is currently recording. A capture stopped by
+its memory limit is ready but inactive.)doc";
+
+static const char *__doc_sgl_Profiler_class_name = R"doc()doc";
+
+static const char *__doc_sgl_Profiler_clear_frame_stats =
+R"doc(Clear completed and pending frame statistics after flushing current
+producer events.)doc";
+
+static const char *__doc_sgl_Profiler_desc =
+R"doc(Constructor configuration. Python exposes this as a copy because
+changing it does not reconfigure the profiler.)doc";
+
+static const char *__doc_sgl_Profiler_discard_capture = R"doc(Discard the active or completed capture without producing a trace.)doc";
+
+static const char *__doc_sgl_Profiler_enable_auto_zones = R"doc(Whether SlangPy functional dispatches create automatic zones.)doc";
+
+static const char *__doc_sgl_Profiler_enable_debug_groups =
+R"doc(Whether command-encoder profiling zones also emit backend debug
+groups.)doc";
+
+static const char *__doc_sgl_Profiler_enabled = R"doc(Whether manual and automatic profiling zones are recorded.)doc";
+
+static const char *__doc_sgl_Profiler_end_frame =
+R"doc(Close a frame previously returned by begin_frame(). The collector
+seals it after all attached zones publish.)doc";
+
+static const char *__doc_sgl_Profiler_end_zone = R"doc(End a zone previously returned by begin_zone().)doc";
+
+static const char *__doc_sgl_Profiler_flush =
+R"doc(Block until the collector consumes events published before this call
+and publishes both snapshot products.)doc";
+
+static const char *__doc_sgl_Profiler_frame_stats_snapshot =
+R"doc(Return the most recently published immutable frame statistics and
+request periodic statistics publication.)doc";
+
+static const char *__doc_sgl_Profiler_live_snapshot =
+R"doc(Return the most recently published immutable live trace and request
+periodic live-trace publication.)doc";
+
+static const char *__doc_sgl_Profiler_m_desc = R"doc()doc";
+
+static const char *__doc_sgl_Profiler_m_enable_auto_zones = R"doc()doc";
+
+static const char *__doc_sgl_Profiler_m_enable_debug_groups = R"doc()doc";
+
+static const char *__doc_sgl_Profiler_m_enabled = R"doc()doc";
+
+static const char *__doc_sgl_Profiler_m_impl = R"doc()doc";
+
+static const char *__doc_sgl_Profiler_register_site =
+R"doc(Register a profiling site in the process-global site registry.
+Metadata is interned and remains valid for the lifetime of the
+process.)doc";
+
+static const char *__doc_sgl_Profiler_release_retired_snapshots =
+R"doc(Release profiler-owned references to snapshots previously handed to
+Python. Python bindings call this while holding the GIL before
+acquiring a new snapshot.)doc";
+
+static const char *__doc_sgl_Profiler_set_enable_auto_zones = R"doc(Enable or disable automatic SlangPy functional dispatch zones.)doc";
+
+static const char *__doc_sgl_Profiler_set_enable_debug_groups = R"doc(Enable or disable backend debug groups for command-encoder zones.)doc";
+
+static const char *__doc_sgl_Profiler_set_enabled = R"doc(Enable or disable all zone and frame recording.)doc";
+
+static const char *__doc_sgl_Profiler_start_capture =
+R"doc(Start a bounded capture after flushing events completed before this
+call.)doc";
+
+static const char *__doc_sgl_Profiler_stop_capture =
+R"doc(Stop and return the current or memory-limited capture.
+
+This performs one tick and flushes completed CPU producer events. It
+does not deliberately wait for submitted GPU work or unresolved
+timestamp queries, but a backend timestamp-calibration refresh
+performed by tick() may synchronize queued GPU work. Call
+Device::wait(), then tick(), before stopping when complete GPU data is
+required.)doc";
+
+static const char *__doc_sgl_Profiler_tick =
+R"doc(Poll submitted GPU timestamp queries and queue resolved measurements
+for the collector.
+
+The poll does not deliberately wait for profiled submissions or
+unresolved queries. Refreshing timestamp calibration can nevertheless
+synchronize queued GPU work on some backends, notably CUDA.)doc";
+
+static const char *__doc_sgl_Profiler_to_string = R"doc()doc";
 
 static const char *__doc_sgl_ProgramLayout = R"doc()doc";
 
@@ -9744,6 +10387,10 @@ Throws if the stack is empty.
 Returns:
     The current device.)doc";
 
+static const char *__doc_sgl_current_profiler = R"doc(Return the current thread's profiler or throw if none is active.)doc";
+
+static const char *__doc_sgl_current_profiler_or_null = R"doc(Return the current thread's profiler, or nullptr if none is active.)doc";
+
 static const char *__doc_sgl_cursor_utils_CursorWriterTypeInfo =
 R"doc(Native registry entry for one cursor-writable value type.
 
@@ -9846,6 +10493,34 @@ static const char *__doc_sgl_detail_HostTypeToFormat_16 = R"doc()doc";
 static const char *__doc_sgl_detail_HostTypeToFormat_17 = R"doc()doc";
 
 static const char *__doc_sgl_detail_HostTypeToFormat_18 = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerFrameGuard = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerFrameGuard_ProfilerFrameGuard = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerFrameGuard_ProfilerFrameGuard_2 = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerFrameGuard_ProfilerFrameGuard_3 = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerFrameGuard_m_token = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerFrameGuard_operator_assign = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerFrameGuard_operator_assign_2 = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerZoneGuard = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerZoneGuard_ProfilerZoneGuard = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerZoneGuard_ProfilerZoneGuard_2 = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerZoneGuard_ProfilerZoneGuard_3 = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerZoneGuard_m_token = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerZoneGuard_operator_assign = R"doc()doc";
+
+static const char *__doc_sgl_detail_ProfilerZoneGuard_operator_assign_2 = R"doc()doc";
 
 static const char *__doc_sgl_detail_build_slang_error_message = R"doc()doc";
 
@@ -10072,6 +10747,12 @@ static const char *__doc_sgl_find_enum_info_adl_78 = R"doc()doc";
 static const char *__doc_sgl_find_enum_info_adl_79 = R"doc()doc";
 
 static const char *__doc_sgl_find_enum_info_adl_80 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_81 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_82 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_83 = R"doc()doc";
 
 static const char *__doc_sgl_flags_to_string_list = R"doc(Convert an flags enum value to a list of strings.)doc";
 
@@ -11736,6 +12417,12 @@ stack is empty.
 Returns:
     The popped device.)doc";
 
+static const char *__doc_sgl_pop_current_profiler = R"doc()doc";
+
+static const char *__doc_sgl_profiler_frame_name = R"doc()doc";
+
+static const char *__doc_sgl_profiler_frame_name_2 = R"doc()doc";
+
 static const char *__doc_sgl_push_current_device =
 R"doc(Push a device onto the thread-local current device stack.
 
@@ -11749,6 +12436,8 @@ device is kept alive (refcount > 0) until popped.
 
 Parameter ``device``:
     Device to push (must not be null).)doc";
+
+static const char *__doc_sgl_push_current_profiler = R"doc()doc";
 
 static const char *__doc_sgl_ref = R"doc()doc";
 
@@ -14145,6 +14834,13 @@ static const char *__doc_sgl_ui_operator_iand_2 = R"doc()doc";
 static const char *__doc_sgl_ui_operator_ior = R"doc()doc";
 
 static const char *__doc_sgl_ui_operator_ior_2 = R"doc()doc";
+
+static const char *__doc_sgl_ui_render_profiler_window =
+R"doc(Render real-time frame-aligned profiler statistics from cached
+snapshots.
+
+Parameter ``profiler``:
+    Profiler to display, or nullptr to use the current profiler.)doc";
 
 static const char *__doc_std_hash = R"doc()doc";
 

--- a/src/slangpy_ext/slangpy_ext.cpp
+++ b/src/slangpy_ext/slangpy_ext.cpp
@@ -65,6 +65,7 @@ SGL_PY_DECLARE(native_refl);
 
 SGL_PY_DECLARE(utils_crashpad);
 SGL_PY_DECLARE(utils_renderdoc);
+SGL_PY_DECLARE(utils_profiler);
 SGL_PY_DECLARE(utils_slangpy);
 SGL_PY_DECLARE(utils_slangpy_function);
 SGL_PY_DECLARE(utils_slangpy_packedarg);
@@ -156,6 +157,7 @@ NB_MODULE(slangpy_ext, m_)
 
     SGL_PY_IMPORT(utils_crashpad);
     SGL_PY_IMPORT(utils_renderdoc);
+    SGL_PY_IMPORT(utils_profiler);
 
     SGL_PY_IMPORT(native_refl);
     SGL_PY_IMPORT(native_func);

--- a/src/slangpy_ext/ui/ui.cpp
+++ b/src/slangpy_ext/ui/ui.cpp
@@ -4,6 +4,8 @@
 
 #include "sgl/ui/ui.h"
 #include "sgl/ui/widgets.h"
+#include "sgl/utils/profiler.h"
+#include "sgl/utils/profiler_ui.h"
 
 #include "sgl/core/error.h"
 #include "sgl/core/input.h"
@@ -208,6 +210,13 @@ SGL_PY_EXPORT(ui)
     using namespace sgl;
 
     nb::module_ ui = nb::module_::import_("slangpy.ui");
+
+    ui.def(
+        "render_profiler_window",
+        &sgl::ui::render_profiler_window,
+        "profiler"_a = nullptr,
+        D(render_profiler_window)
+    );
 
     nb::class_<ui::Context, Object>(ui, "Context", gc_helper_type_slots<ui::Context>(), D(Context))
         .def(nb::init<ref<Device>>(), "device"_a)

--- a/src/slangpy_ext/utils/profiler.cpp
+++ b/src/slangpy_ext/utils/profiler.cpp
@@ -499,7 +499,7 @@ SGL_PY_EXPORT(utils_profiler)
             "start_ns",
             [](ProfilerZoneChunk& self)
             {
-                return readonly_array(self.start_ns, nb::cast(&self, nb::rv_policy::reference));
+                return readonly_array(self.start_ns(), nb::cast(&self, nb::rv_policy::reference));
             },
             D(ProfilerZoneChunk, start_ns)
         )
@@ -507,7 +507,7 @@ SGL_PY_EXPORT(utils_profiler)
             "duration_ns",
             [](ProfilerZoneChunk& self)
             {
-                return readonly_array(self.duration_ns, nb::cast(&self, nb::rv_policy::reference));
+                return readonly_array(self.duration_ns(), nb::cast(&self, nb::rv_policy::reference));
             },
             D(ProfilerZoneChunk, duration_ns)
         )
@@ -515,7 +515,7 @@ SGL_PY_EXPORT(utils_profiler)
             "correlation_id",
             [](ProfilerZoneChunk& self)
             {
-                return readonly_array(self.correlation_id, nb::cast(&self, nb::rv_policy::reference));
+                return readonly_array(self.correlation_id(), nb::cast(&self, nb::rv_policy::reference));
             },
             D(ProfilerZoneChunk, correlation_id)
         )
@@ -523,7 +523,7 @@ SGL_PY_EXPORT(utils_profiler)
             "timeline_id",
             [](ProfilerZoneChunk& self)
             {
-                return readonly_array(self.timeline_id, nb::cast(&self, nb::rv_policy::reference));
+                return readonly_array(self.timeline_id(), nb::cast(&self, nb::rv_policy::reference));
             },
             D(ProfilerZoneChunk, timeline_id)
         )
@@ -531,7 +531,7 @@ SGL_PY_EXPORT(utils_profiler)
             "site_id",
             [](ProfilerZoneChunk& self)
             {
-                return readonly_array(self.site_id, nb::cast(&self, nb::rv_policy::reference));
+                return readonly_array(self.site_id(), nb::cast(&self, nb::rv_policy::reference));
             },
             D(ProfilerZoneChunk, site_id)
         )
@@ -539,7 +539,7 @@ SGL_PY_EXPORT(utils_profiler)
             "parent_index",
             [](ProfilerZoneChunk& self)
             {
-                return readonly_array(self.parent_index, nb::cast(&self, nb::rv_policy::reference));
+                return readonly_array(self.parent_index(), nb::cast(&self, nb::rv_policy::reference));
             },
             D(ProfilerZoneChunk, parent_index)
         )
@@ -547,7 +547,7 @@ SGL_PY_EXPORT(utils_profiler)
             "frame_index",
             [](ProfilerZoneChunk& self)
             {
-                return readonly_array(self.frame_index, nb::cast(&self, nb::rv_policy::reference));
+                return readonly_array(self.frame_index(), nb::cast(&self, nb::rv_policy::reference));
             },
             D(ProfilerZoneChunk, frame_index)
         );

--- a/src/slangpy_ext/utils/profiler.cpp
+++ b/src/slangpy_ext/utils/profiler.cpp
@@ -1,0 +1,755 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "nanobind.h"
+
+#include "sgl/device/command.h"
+#include "sgl/utils/profiler.h"
+
+#include <array>
+#include <memory>
+
+namespace {
+
+sgl::ref<sgl::Profiler> current_profiler_ref()
+{
+    if (sgl::Profiler* current = sgl::current_profiler_or_null())
+        return sgl::ref<sgl::Profiler>(current);
+    return {};
+}
+
+int python_frame_instruction_offset(PyFrameObject* frame)
+{
+#if PY_VERSION_HEX >= 0x030b0000
+    return PyFrame_GetLasti(frame);
+#else
+    return frame->f_lasti;
+#endif
+}
+
+std::string python_function_name(nb::handle code, PyFrameObject* frame)
+{
+    nb::object qualname = nb::getattr(code, "co_qualname", nb::none());
+    if (!qualname.is_none())
+        return nb::cast<std::string>(qualname);
+
+    std::string function = nb::cast<std::string>(nb::getattr(code, "co_name"));
+    nb::object frame_object = nb::borrow<nb::object>(reinterpret_cast<PyObject*>(frame));
+    nb::dict locals = nb::cast<nb::dict>(nb::getattr(frame_object, "f_locals"));
+    if (locals.contains("self")) {
+        nb::handle self = locals["self"];
+        function = nb::cast<std::string>(nb::getattr(self.type(), "__qualname__")) + "." + function;
+    } else if (locals.contains("cls")) {
+        nb::handle cls = locals["cls"];
+        nb::object class_qualname = nb::getattr(cls, "__qualname__", nb::none());
+        if (!class_qualname.is_none())
+            function = nb::cast<std::string>(class_qualname) + "." + function;
+    }
+    return function;
+}
+
+class PyProfilerSiteCache {
+public:
+    uint32_t resolve(PyFrameObject* frame, nb::object code, int instruction_offset, nb::handle name = {})
+    {
+        const Py_hash_t name_hash = hash_name(name);
+        const uint64_t hash = hash_key(code, instruction_offset, name_hash);
+        std::array<Entry, way_count>& set = m_entries[hash % set_count];
+        for (Entry& entry : set) {
+            if (entry.site_id != 0 && entry.code.ptr() == code.ptr() && entry.instruction_offset == instruction_offset
+                && entry.name_hash == name_hash && names_equal(entry.name, name)) {
+                entry.last_use = ++m_clock;
+                return entry.site_id;
+            }
+        }
+
+        const std::string file = nb::cast<std::string>(nb::getattr(code, "co_filename"));
+        const int line_number = PyFrame_GetLineNumber(frame);
+        const uint32_t line = line_number > 0 ? uint32_t(line_number) : 0;
+        const std::string function = python_function_name(code, frame);
+        const std::string site_name = name.is_valid() ? nb::cast<std::string>(name) : function;
+        const uint32_t site_id = sgl::Profiler::register_site(file, line, function, site_name);
+
+        Entry* victim = &set.front();
+        for (Entry& entry : set) {
+            if (entry.site_id == 0) {
+                victim = &entry;
+                break;
+            }
+            if (entry.last_use < victim->last_use)
+                victim = &entry;
+        }
+        victim->code = std::move(code);
+        victim->name = name.is_valid() ? nb::borrow<nb::object>(name) : nb::object();
+        victim->instruction_offset = instruction_offset;
+        victim->name_hash = name_hash;
+        victim->site_id = site_id;
+        victim->last_use = ++m_clock;
+        return site_id;
+    }
+
+private:
+    static constexpr size_t set_count = 64;
+    static constexpr size_t way_count = 4;
+
+    struct Entry {
+        nb::object code;
+        nb::object name;
+        int instruction_offset{0};
+        Py_hash_t name_hash{0};
+        uint32_t site_id{0};
+        uint64_t last_use{0};
+    };
+
+    static Py_hash_t hash_name(nb::handle name)
+    {
+        if (!name.is_valid())
+            return 0;
+        const Py_hash_t result = PyObject_Hash(name.ptr());
+        if (result == -1 && PyErr_Occurred())
+            nb::raise_python_error();
+        return result;
+    }
+
+    static uint64_t hash_key(nb::handle code, int instruction_offset, Py_hash_t name_hash)
+    {
+        uint64_t value = uint64_t(reinterpret_cast<uintptr_t>(code.ptr()));
+        auto combine = [&](uint64_t next)
+        {
+            value ^= next + 0x9e3779b97f4a7c15ull + (value << 6) + (value >> 2);
+        };
+        combine(uint64_t(uint32_t(instruction_offset)));
+        combine(uint64_t(name_hash));
+        return value;
+    }
+
+    static bool names_equal(const nb::object& cached, nb::handle requested)
+    {
+        if (!cached.is_valid() || !requested.is_valid())
+            return cached.is_valid() == requested.is_valid();
+        if (cached.ptr() == requested.ptr())
+            return true;
+        const int result = PyObject_RichCompareBool(cached.ptr(), requested.ptr(), Py_EQ);
+        if (result < 0)
+            nb::raise_python_error();
+        return result != 0;
+    }
+
+    std::array<std::array<Entry, way_count>, set_count> m_entries;
+    uint64_t m_clock{0};
+};
+
+struct PyProfilerCallSite {
+    PyFrameObject* frame{nullptr};
+    nb::object code;
+    int instruction_offset{0};
+};
+
+PyProfilerCallSite python_caller_site()
+{
+    PyFrameObject* frame = PyEval_GetFrame();
+    SGL_CHECK(frame, "Could not determine the Python profiler callsite");
+    nb::object code = nb::steal<nb::object>(reinterpret_cast<PyObject*>(PyFrame_GetCode(frame)));
+    return {frame, std::move(code), python_frame_instruction_offset(frame)};
+}
+
+class PyProfilerZoneScope {
+public:
+    PyProfilerZoneScope() = default;
+
+    PyProfilerZoneScope(sgl::ref<sgl::Profiler> profiler, uint32_t site_id, sgl::CommandEncoder* command_encoder)
+        : m_profiler(std::move(profiler))
+        , m_command_encoder(m_profiler ? command_encoder : nullptr)
+        , m_site_id(site_id)
+    {
+    }
+
+    PyProfilerZoneScope* enter()
+    {
+        SGL_CHECK(!m_entered, "Profiler zone context cannot be entered more than once");
+        if (m_profiler)
+            m_token = m_profiler->begin_zone(m_site_id, m_command_encoder);
+        m_entered = true;
+        return this;
+    }
+
+    void exit(nb::object, nb::object, nb::object)
+    {
+        if (!m_entered)
+            return;
+        if (m_token.profiler)
+            m_token.profiler->end_zone(m_token);
+        m_token = {};
+        m_entered = false;
+    }
+
+private:
+    sgl::ref<sgl::Profiler> m_profiler;
+    sgl::ref<sgl::CommandEncoder> m_command_encoder;
+    uint32_t m_site_id{0};
+    sgl::ProfilerZoneToken m_token;
+    bool m_entered{false};
+};
+
+class PyProfilerFrameScope {
+public:
+    PyProfilerFrameScope() = default;
+
+    PyProfilerFrameScope(sgl::ref<sgl::Profiler> profiler, uint32_t site_id)
+        : m_profiler(std::move(profiler))
+        , m_site_id(site_id)
+    {
+    }
+
+    PyProfilerFrameScope* enter()
+    {
+        SGL_CHECK(!m_entered, "Profiler frame context cannot be entered more than once");
+        if (m_profiler) {
+            m_token = m_profiler->begin_frame(m_site_id);
+            if (m_profiler->enabled() && !m_token.profiler)
+                SGL_THROW("A profiler frame is already active or closing");
+        }
+        m_entered = true;
+        return this;
+    }
+
+    void exit(nb::object, nb::object, nb::object)
+    {
+        if (!m_entered)
+            return;
+        if (m_token.profiler)
+            m_token.profiler->end_frame(m_token);
+        m_token = {};
+        m_entered = false;
+    }
+
+private:
+    sgl::ref<sgl::Profiler> m_profiler;
+    uint32_t m_site_id{0};
+    sgl::ProfilerFrameToken m_token;
+    bool m_entered{false};
+};
+
+template<typename T>
+nb::ndarray<nb::numpy, const T> readonly_array(const std::vector<T>& values, nb::handle owner)
+{
+    size_t shape[1] = {values.size()};
+    return nb::ndarray<nb::numpy, const T>(values.data(), 1, shape, owner);
+}
+
+template<typename T>
+nb::ndarray<nb::numpy, const T>
+readonly_matrix(const std::vector<T>& values, size_t row_count, size_t column_count, nb::handle owner)
+{
+    SGL_ASSERT(values.size() == row_count * column_count);
+    size_t shape[2] = {row_count, column_count};
+    return nb::ndarray<nb::numpy, const T>(values.data(), 2, shape, owner);
+}
+
+nb::ndarray<nb::numpy, const uint8_t> readonly_gpu_status_matrix(
+    const std::vector<sgl::ProfilerFrameGpuStatus>& values,
+    size_t row_count,
+    size_t column_count,
+    nb::handle owner
+)
+{
+    static_assert(sizeof(sgl::ProfilerFrameGpuStatus) == sizeof(uint8_t));
+    SGL_ASSERT(values.size() == row_count * column_count);
+    size_t shape[2] = {row_count, column_count};
+    return nb::ndarray<nb::numpy, const uint8_t>(reinterpret_cast<const uint8_t*>(values.data()), 2, shape, owner);
+}
+
+} // namespace
+
+SGL_PY_EXPORT(utils_profiler)
+{
+    using namespace sgl;
+
+    nb::sgl_enum<ProfilerTimelineType>(m, "ProfilerTimelineType", D(ProfilerTimelineType));
+    nb::sgl_enum<ProfilerCaptureStopReason>(m, "ProfilerCaptureStopReason", D(ProfilerCaptureStopReason));
+    nb::sgl_enum<ProfilerFrameGpuStatus>(m, "ProfilerFrameGpuStatus", D(ProfilerFrameGpuStatus));
+
+    nb::class_<ProfilerDesc>(m, "ProfilerDesc", D(ProfilerDesc))
+        .def(
+            nb::init<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, bool, bool>(),
+            "thread_event_capacity"_a = 8192,
+            "live_frame_count"_a = 120,
+            "live_event_capacity"_a = 100000,
+            "frame_stats_window_size"_a = 120,
+            "gpu_query_pool_size"_a = 16384,
+            "enable_auto_zones"_a = true,
+            "enable_debug_groups"_a = false
+        )
+        .def_rw("thread_event_capacity", &ProfilerDesc::thread_event_capacity, D(ProfilerDesc, thread_event_capacity))
+        .def_rw("live_frame_count", &ProfilerDesc::live_frame_count, D(ProfilerDesc, live_frame_count))
+        .def_rw("live_event_capacity", &ProfilerDesc::live_event_capacity, D(ProfilerDesc, live_event_capacity))
+        .def_rw(
+            "frame_stats_window_size",
+            &ProfilerDesc::frame_stats_window_size,
+            D(ProfilerDesc, frame_stats_window_size)
+        )
+        .def_rw("gpu_query_pool_size", &ProfilerDesc::gpu_query_pool_size, D(ProfilerDesc, gpu_query_pool_size))
+        .def_rw("enable_auto_zones", &ProfilerDesc::enable_auto_zones, D(ProfilerDesc, enable_auto_zones))
+        .def_rw("enable_debug_groups", &ProfilerDesc::enable_debug_groups, D(ProfilerDesc, enable_debug_groups));
+
+    nb::class_<ProfilerCaptureDesc>(m, "ProfilerCaptureDesc", D(ProfilerCaptureDesc))
+        .def(nb::init<uint64_t>(), "max_memory_bytes"_a = 256ull * 1024ull * 1024ull)
+        .def_rw("max_memory_bytes", &ProfilerCaptureDesc::max_memory_bytes, D(ProfilerCaptureDesc, max_memory_bytes));
+
+    nb::class_<ProfilerSite>(m, "ProfilerSite", D(ProfilerSite))
+        .def_ro("id", &ProfilerSite::id, D(ProfilerSite, id))
+        .def_ro("file", &ProfilerSite::file, D(ProfilerSite, file))
+        .def_ro("line", &ProfilerSite::line, D(ProfilerSite, line))
+        .def_ro("function", &ProfilerSite::function, D(ProfilerSite, function))
+        .def_ro("name", &ProfilerSite::name, D(ProfilerSite, name));
+
+    nb::class_<ProfilerTimeline>(m, "ProfilerTimeline", D(ProfilerTimeline))
+        .def_ro("type", &ProfilerTimeline::type, D(ProfilerTimeline, type))
+        .def_ro("name", &ProfilerTimeline::name, D(ProfilerTimeline, name))
+        .def_ro("thread_id", &ProfilerTimeline::thread_id, D(ProfilerTimeline, thread_id))
+        .def_ro("device_id", &ProfilerTimeline::device_id, D(ProfilerTimeline, device_id))
+        .def_ro("queue", &ProfilerTimeline::queue, D(ProfilerTimeline, queue));
+
+    nb::class_<ProfilerFrame>(m, "ProfilerFrame", D(ProfilerFrame))
+        .def_ro("index", &ProfilerFrame::index, D(ProfilerFrame, index))
+        .def_ro("site_id", &ProfilerFrame::site_id, D(ProfilerFrame, site_id))
+        .def_ro("timeline_id", &ProfilerFrame::timeline_id, D(ProfilerFrame, timeline_id))
+        .def_ro("start_ns", &ProfilerFrame::start_ns, D(ProfilerFrame, start_ns))
+        .def_ro("duration_ns", &ProfilerFrame::duration_ns, D(ProfilerFrame, duration_ns));
+
+    nb::class_<ProfilerDurationStatistics>(m, "ProfilerDurationStatistics", D(ProfilerDurationStatistics))
+        .def_ro("count", &ProfilerDurationStatistics::count, D(ProfilerDurationStatistics, count))
+        .def_ro("total_ms", &ProfilerDurationStatistics::total_ms, D(ProfilerDurationStatistics, total_ms))
+        .def_ro("minimum_ms", &ProfilerDurationStatistics::minimum_ms, D(ProfilerDurationStatistics, minimum_ms))
+        .def_ro("maximum_ms", &ProfilerDurationStatistics::maximum_ms, D(ProfilerDurationStatistics, maximum_ms))
+        .def_ro("mean_ms", &ProfilerDurationStatistics::mean_ms, D(ProfilerDurationStatistics, mean_ms))
+        .def_ro(
+            "standard_deviation_ms",
+            &ProfilerDurationStatistics::standard_deviation_ms,
+            D(ProfilerDurationStatistics, standard_deviation_ms)
+        )
+        .def_ro("p50_ms", &ProfilerDurationStatistics::p50_ms, D(ProfilerDurationStatistics, p50_ms))
+        .def_ro("p90_ms", &ProfilerDurationStatistics::p90_ms, D(ProfilerDurationStatistics, p90_ms))
+        .def_ro("p95_ms", &ProfilerDurationStatistics::p95_ms, D(ProfilerDurationStatistics, p95_ms))
+        .def_ro("p99_ms", &ProfilerDurationStatistics::p99_ms, D(ProfilerDurationStatistics, p99_ms));
+
+    nb::class_<ProfilerCallStatistics>(m, "ProfilerCallStatistics", D(ProfilerCallStatistics))
+        .def_ro("count", &ProfilerCallStatistics::count, D(ProfilerCallStatistics, count))
+        .def_ro("total_ms", &ProfilerCallStatistics::total_ms, D(ProfilerCallStatistics, total_ms))
+        .def_ro("minimum_ms", &ProfilerCallStatistics::minimum_ms, D(ProfilerCallStatistics, minimum_ms))
+        .def_ro("maximum_ms", &ProfilerCallStatistics::maximum_ms, D(ProfilerCallStatistics, maximum_ms))
+        .def_ro("mean_ms", &ProfilerCallStatistics::mean_ms, D(ProfilerCallStatistics, mean_ms))
+        .def_ro(
+            "standard_deviation_ms",
+            &ProfilerCallStatistics::standard_deviation_ms,
+            D(ProfilerCallStatistics, standard_deviation_ms)
+        );
+
+    nb::class_<ProfilerDiagnostics>(m, "ProfilerDiagnostics", D(ProfilerDiagnostics))
+        .def_ro(
+            "producer_drop_count",
+            &ProfilerDiagnostics::producer_drop_count,
+            D(ProfilerDiagnostics, producer_drop_count)
+        )
+        .def_ro(
+            "thread_event_queue_high_water_mark",
+            &ProfilerDiagnostics::thread_event_queue_high_water_mark,
+            D(ProfilerDiagnostics, thread_event_queue_high_water_mark)
+        )
+        .def_ro(
+            "hierarchy_loss_count",
+            &ProfilerDiagnostics::hierarchy_loss_count,
+            D(ProfilerDiagnostics, hierarchy_loss_count)
+        )
+        .def_ro(
+            "gpu_query_exhaustion_count",
+            &ProfilerDiagnostics::gpu_query_exhaustion_count,
+            D(ProfilerDiagnostics, gpu_query_exhaustion_count)
+        )
+        .def_ro(
+            "pending_gpu_zone_count",
+            &ProfilerDiagnostics::pending_gpu_zone_count,
+            D(ProfilerDiagnostics, pending_gpu_zone_count)
+        );
+
+    nb::class_<ProfilerFrameStatsEntry>(m, "ProfilerFrameStatsEntry", D(ProfilerFrameStatsEntry))
+        .def_ro("parent_index", &ProfilerFrameStatsEntry::parent_index, D(ProfilerFrameStatsEntry, parent_index))
+        .def_ro("site_id", &ProfilerFrameStatsEntry::site_id, D(ProfilerFrameStatsEntry, site_id))
+        .def_ro("name", &ProfilerFrameStatsEntry::name, D(ProfilerFrameStatsEntry, name))
+        .def_ro(
+            "cpu_time_per_frame",
+            &ProfilerFrameStatsEntry::cpu_time_per_frame,
+            D(ProfilerFrameStatsEntry, cpu_time_per_frame)
+        )
+        .def_ro(
+            "gpu_time_per_frame",
+            &ProfilerFrameStatsEntry::gpu_time_per_frame,
+            D(ProfilerFrameStatsEntry, gpu_time_per_frame)
+        )
+        .def_ro(
+            "cpu_time_per_call",
+            &ProfilerFrameStatsEntry::cpu_time_per_call,
+            D(ProfilerFrameStatsEntry, cpu_time_per_call)
+        )
+        .def_ro(
+            "gpu_time_per_call",
+            &ProfilerFrameStatsEntry::gpu_time_per_call,
+            D(ProfilerFrameStatsEntry, gpu_time_per_call)
+        );
+
+    nb::class_<ProfilerFrameStats, Object>(m, "ProfilerFrameStats", D(ProfilerFrameStats))
+        .def_prop_ro("sample_count", &ProfilerFrameStats::sample_count, D(ProfilerFrameStats, sample_count))
+        .def_prop_ro("entry_count", &ProfilerFrameStats::entry_count, D(ProfilerFrameStats, entry_count))
+        .def_prop_ro(
+            "pending_frame_count",
+            &ProfilerFrameStats::pending_frame_count,
+            D(ProfilerFrameStats, pending_frame_count)
+        )
+        .def_prop_ro("latest_frame_ms", &ProfilerFrameStats::latest_frame_ms, D(ProfilerFrameStats, latest_frame_ms))
+        .def_prop_ro(
+            "frame_time",
+            &ProfilerFrameStats::frame_time,
+            nb::rv_policy::reference_internal,
+            D(ProfilerFrameStats, frame_time)
+        )
+        .def_prop_ro(
+            "entries",
+            &ProfilerFrameStats::entries,
+            nb::rv_policy::reference_internal,
+            D(ProfilerFrameStats, entries)
+        )
+        .def_prop_ro(
+            "sample_frame_index",
+            [](ProfilerFrameStats& self)
+            {
+                return readonly_array(self.sample_frame_index(), nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerFrameStats, sample_frame_index)
+        )
+        .def_prop_ro(
+            "sample_frame_time_ms",
+            [](ProfilerFrameStats& self)
+            {
+                return readonly_array(self.sample_frame_time_ms(), nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerFrameStats, sample_frame_time_ms)
+        )
+        .def_prop_ro(
+            "sample_call_count",
+            [](ProfilerFrameStats& self)
+            {
+                return readonly_matrix(
+                    self.sample_call_count(),
+                    self.sample_count(),
+                    self.entry_count(),
+                    nb::cast(&self, nb::rv_policy::reference)
+                );
+            },
+            D(ProfilerFrameStats, sample_call_count)
+        )
+        .def_prop_ro(
+            "sample_cpu_time_ms",
+            [](ProfilerFrameStats& self)
+            {
+                return readonly_matrix(
+                    self.sample_cpu_time_ms(),
+                    self.sample_count(),
+                    self.entry_count(),
+                    nb::cast(&self, nb::rv_policy::reference)
+                );
+            },
+            D(ProfilerFrameStats, sample_cpu_time_ms)
+        )
+        .def_prop_ro(
+            "sample_gpu_time_ms",
+            [](ProfilerFrameStats& self)
+            {
+                return readonly_matrix(
+                    self.sample_gpu_time_ms(),
+                    self.sample_count(),
+                    self.entry_count(),
+                    nb::cast(&self, nb::rv_policy::reference)
+                );
+            },
+            D(ProfilerFrameStats, sample_gpu_time_ms)
+        )
+        .def_prop_ro(
+            "sample_gpu_status",
+            [](ProfilerFrameStats& self)
+            {
+                return readonly_gpu_status_matrix(
+                    self.sample_gpu_status(),
+                    self.sample_count(),
+                    self.entry_count(),
+                    nb::cast(&self, nb::rv_policy::reference)
+                );
+            },
+            D(ProfilerFrameStats, sample_gpu_status)
+        )
+        .def_prop_ro(
+            "diagnostics",
+            &ProfilerFrameStats::diagnostics,
+            nb::rv_policy::reference_internal,
+            D(ProfilerFrameStats, diagnostics)
+        )
+        .def("__str__", &ProfilerFrameStats::to_string, D(ProfilerFrameStats, to_string));
+
+    nb::class_<ProfilerZoneChunk, Object>(m, "ProfilerZoneChunk", D(ProfilerZoneChunk))
+        .def_prop_ro("count", &ProfilerZoneChunk::size, D(ProfilerZoneChunk, size))
+        .def_prop_ro(
+            "start_ns",
+            [](ProfilerZoneChunk& self)
+            {
+                return readonly_array(self.start_ns, nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneChunk, start_ns)
+        )
+        .def_prop_ro(
+            "duration_ns",
+            [](ProfilerZoneChunk& self)
+            {
+                return readonly_array(self.duration_ns, nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneChunk, duration_ns)
+        )
+        .def_prop_ro(
+            "correlation_id",
+            [](ProfilerZoneChunk& self)
+            {
+                return readonly_array(self.correlation_id, nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneChunk, correlation_id)
+        )
+        .def_prop_ro(
+            "timeline_id",
+            [](ProfilerZoneChunk& self)
+            {
+                return readonly_array(self.timeline_id, nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneChunk, timeline_id)
+        )
+        .def_prop_ro(
+            "site_id",
+            [](ProfilerZoneChunk& self)
+            {
+                return readonly_array(self.site_id, nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneChunk, site_id)
+        )
+        .def_prop_ro(
+            "parent_index",
+            [](ProfilerZoneChunk& self)
+            {
+                return readonly_array(self.parent_index, nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneChunk, parent_index)
+        )
+        .def_prop_ro(
+            "frame_index",
+            [](ProfilerZoneChunk& self)
+            {
+                return readonly_array(self.frame_index, nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneChunk, frame_index)
+        );
+
+    nb::class_<ProfilerZoneSelection, Object>(m, "ProfilerZoneSelection", D(ProfilerZoneSelection))
+        .def_prop_ro("count", &ProfilerZoneSelection::count, D(ProfilerZoneSelection, count))
+        .def_prop_ro(
+            "indices",
+            [](ProfilerZoneSelection& self)
+            {
+                return readonly_array(self.indices(), nb::cast(&self, nb::rv_policy::reference));
+            },
+            D(ProfilerZoneSelection, indices)
+        )
+        .def("statistics", &ProfilerZoneSelection::statistics, D(ProfilerZoneSelection, statistics));
+
+    nb::class_<ProfilerTrace, Object>(m, "ProfilerTrace", D(ProfilerTrace))
+        .def_prop_ro("start_ns", &ProfilerTrace::start_ns, D(ProfilerTrace, start_ns))
+        .def_prop_ro("stop_ns", &ProfilerTrace::stop_ns, D(ProfilerTrace, stop_ns))
+        .def_prop_ro("stop_reason", &ProfilerTrace::stop_reason, D(ProfilerTrace, stop_reason))
+        .def_prop_ro("truncated", &ProfilerTrace::truncated, D(ProfilerTrace, truncated))
+        .def_prop_ro("memory_bytes", &ProfilerTrace::memory_bytes, D(ProfilerTrace, memory_bytes))
+        .def_prop_ro(
+            "diagnostics",
+            &ProfilerTrace::diagnostics,
+            nb::rv_policy::reference_internal,
+            D(ProfilerTrace, diagnostics)
+        )
+        .def_prop_ro("sites", &ProfilerTrace::sites, nb::rv_policy::reference_internal, D(ProfilerTrace, sites))
+        .def_prop_ro(
+            "timelines",
+            &ProfilerTrace::timelines,
+            nb::rv_policy::reference_internal,
+            D(ProfilerTrace, timelines)
+        )
+        .def_prop_ro("frames", &ProfilerTrace::frames, nb::rv_policy::reference_internal, D(ProfilerTrace, frames))
+        .def_prop_ro(
+            "zone_chunks",
+            &ProfilerTrace::zone_chunks,
+            nb::rv_policy::reference_internal,
+            D(ProfilerTrace, zone_chunks)
+        )
+        .def_prop_ro("zone_count", &ProfilerTrace::zone_count, D(ProfilerTrace, zone_count))
+        .def(
+            "query_zones",
+            &ProfilerTrace::query_zones,
+            "name"_a = nb::none(),
+            "timeline_type"_a = nb::none(),
+            "frame_begin"_a = nb::none(),
+            "frame_end"_a = nb::none(),
+            "start_ns"_a = nb::none(),
+            "end_ns"_a = nb::none(),
+            D(ProfilerTrace, query_zones)
+        )
+        .def("write_to_json", &ProfilerTrace::write_to_json, "path"_a, D(ProfilerTrace, write_to_json));
+
+    nb::class_<PyProfilerZoneScope>(m, "ProfilerZoneScope", D_NA(ProfilerZoneScope))
+        .def("__enter__", &PyProfilerZoneScope::enter, nb::rv_policy::reference, D_NA(ProfilerZoneScope, enter))
+        .def(
+            "__exit__",
+            &PyProfilerZoneScope::exit,
+            "exc_type"_a.none(),
+            "exc_val"_a.none(),
+            "exc_tb"_a.none(),
+            D_NA(ProfilerZoneScope, exit)
+        );
+    nb::class_<PyProfilerFrameScope>(m, "ProfilerFrameScope", D_NA(ProfilerFrameScope))
+        .def("__enter__", &PyProfilerFrameScope::enter, nb::rv_policy::reference, D_NA(ProfilerFrameScope, enter))
+        .def(
+            "__exit__",
+            &PyProfilerFrameScope::exit,
+            "exc_type"_a.none(),
+            "exc_val"_a.none(),
+            "exc_tb"_a.none(),
+            D_NA(ProfilerFrameScope, exit)
+        );
+
+    nb::class_<Profiler, Object>(m, "Profiler", D(Profiler))
+        .def(nb::init<ProfilerDesc>(), "desc"_a = ProfilerDesc())
+        .def(
+            "__enter__",
+            [](Profiler* self)
+            {
+                push_current_profiler(self);
+                return self;
+            },
+            nb::rv_policy::reference,
+            D_NA(Profiler, enter)
+        )
+        .def(
+            "__exit__",
+            [](Profiler* self, nb::object, nb::object, nb::object)
+            {
+                SGL_CHECK(current_profiler_or_null() == self, "Profiler activation stack changed before context exit");
+                pop_current_profiler();
+            },
+            "exc_type"_a.none(),
+            "exc_val"_a.none(),
+            "exc_tb"_a.none(),
+            D_NA(Profiler, exit)
+        )
+        .def_prop_rw("enabled", &Profiler::enabled, &Profiler::set_enabled, D(Profiler, enabled))
+        .def_prop_rw(
+            "enable_auto_zones",
+            &Profiler::enable_auto_zones,
+            &Profiler::set_enable_auto_zones,
+            D(Profiler, enable_auto_zones)
+        )
+        .def_prop_rw(
+            "enable_debug_groups",
+            &Profiler::enable_debug_groups,
+            &Profiler::set_enable_debug_groups,
+            D(Profiler, enable_debug_groups)
+        )
+        .def_prop_ro("capture_active", &Profiler::capture_active, D(Profiler, capture_active))
+        .def_prop_ro(
+            "desc",
+            [](const Profiler& self) -> ProfilerDesc
+            {
+                return self.desc();
+            },
+            D(Profiler, desc)
+        )
+        .def("start_capture", &Profiler::start_capture, "desc"_a = ProfilerCaptureDesc(), D(Profiler, start_capture))
+        .def("stop_capture", &Profiler::stop_capture, D(Profiler, stop_capture))
+        .def("discard_capture", &Profiler::discard_capture, D(Profiler, discard_capture))
+        .def(
+            "live_snapshot",
+            [](Profiler* self)
+            {
+                self->release_retired_snapshots();
+                return self->live_snapshot();
+            },
+            D(Profiler, live_snapshot)
+        )
+        .def(
+            "frame_stats_snapshot",
+            [](Profiler* self)
+            {
+                self->release_retired_snapshots();
+                return self->frame_stats_snapshot();
+            },
+            D(Profiler, frame_stats_snapshot)
+        )
+        .def("clear_frame_stats", &Profiler::clear_frame_stats, D(Profiler, clear_frame_stats))
+        .def("tick", &Profiler::tick, D(Profiler, tick))
+        .def("flush", &Profiler::flush, D(Profiler, flush));
+
+    m.def("current_profiler", &current_profiler, nb::rv_policy::reference, D(current_profiler));
+    m.def(
+        "current_profiler_or_null",
+        &current_profiler_or_null,
+        nb::rv_policy::reference,
+        nb::sig("def current_profiler_or_null() -> Profiler | None"),
+        D(current_profiler_or_null)
+    );
+
+    auto profiler_site_cache = std::make_shared<PyProfilerSiteCache>();
+    m.def(
+        "profile_zone",
+        [profiler_site_cache](nb::str name, CommandEncoder* command_encoder)
+        {
+            ref<Profiler> profiler = current_profiler_ref();
+            if (!profiler)
+                return PyProfilerZoneScope();
+            PyProfilerCallSite site = python_caller_site();
+            const uint32_t site_id
+                = profiler_site_cache->resolve(site.frame, std::move(site.code), site.instruction_offset, name);
+            return PyProfilerZoneScope(std::move(profiler), site_id, command_encoder);
+        },
+        "name"_a,
+        "command_encoder"_a = nb::none(),
+        "Profile a named CPU zone and optional command-encoder GPU zone using the current profiler."
+    );
+    m.def(
+        "profile_function",
+        [profiler_site_cache](CommandEncoder* command_encoder)
+        {
+            ref<Profiler> profiler = current_profiler_ref();
+            if (!profiler)
+                return PyProfilerZoneScope();
+            PyProfilerCallSite site = python_caller_site();
+            const uint32_t site_id
+                = profiler_site_cache->resolve(site.frame, std::move(site.code), site.instruction_offset);
+            return PyProfilerZoneScope(std::move(profiler), site_id, command_encoder);
+        },
+        "command_encoder"_a = nb::none(),
+        "Profile the calling Python function and optional command-encoder GPU work using the current profiler."
+    );
+    m.def(
+        "profile_frame",
+        [profiler_site_cache](nb::str name)
+        {
+            ref<Profiler> profiler = current_profiler_ref();
+            if (!profiler)
+                return PyProfilerFrameScope();
+            PyProfilerCallSite site = python_caller_site();
+            const uint32_t site_id
+                = profiler_site_cache->resolve(site.frame, std::move(site.code), site.instruction_offset, name);
+            return PyProfilerFrameScope(std::move(profiler), site_id);
+        },
+        "name"_a = "frame",
+        "Record a named frame boundary using the current profiler."
+    );
+}

--- a/src/slangpy_ext/utils/profiler.cpp
+++ b/src/slangpy_ext/utils/profiler.cpp
@@ -711,7 +711,7 @@ SGL_PY_EXPORT(utils_profiler)
         [profiler_site_cache](nb::str name, CommandEncoder* command_encoder)
         {
             ref<Profiler> profiler = current_profiler_ref();
-            if (!profiler)
+            if (!profiler || !profiler->enabled())
                 return PyProfilerZoneScope();
             PyProfilerCallSite site = python_caller_site();
             const uint32_t site_id
@@ -727,7 +727,7 @@ SGL_PY_EXPORT(utils_profiler)
         [profiler_site_cache](CommandEncoder* command_encoder)
         {
             ref<Profiler> profiler = current_profiler_ref();
-            if (!profiler)
+            if (!profiler || !profiler->enabled())
                 return PyProfilerZoneScope();
             PyProfilerCallSite site = python_caller_site();
             const uint32_t site_id
@@ -742,7 +742,7 @@ SGL_PY_EXPORT(utils_profiler)
         [profiler_site_cache](nb::str name)
         {
             ref<Profiler> profiler = current_profiler_ref();
-            if (!profiler)
+            if (!profiler || !profiler->enabled())
                 return PyProfilerFrameScope();
             PyProfilerCallSite site = python_caller_site();
             const uint32_t site_id

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -11,6 +11,7 @@
 #include "sgl/core/macros.h"
 #include "sgl/core/logger.h"
 #include "sgl/utils/slangpy.h"
+#include "sgl/utils/profiler.h"
 #include "sgl/device/device.h"
 #include "sgl/device/pipeline.h"
 #include "sgl/device/command.h"
@@ -424,6 +425,17 @@ void NativeBoundCallRuntime::write_raw_dispatch_data(nb::dict call_data, nb::dic
     }
 }
 
+void NativeCallData::set_debug_name(std::string debug_name)
+{
+    m_debug_name = std::move(debug_name);
+    m_profiler_site_id = Profiler::register_site(
+        __FILE__,
+        __LINE__,
+        "SlangPy functional dispatch",
+        m_debug_name.empty() ? "SlangPy dispatch" : m_debug_name.c_str()
+    );
+}
+
 nb::object NativeCallData::find_torch_tensors_recurse(nb::object arg, nb::list& pairs, size_t& access_idx)
 {
     auto& bridge = TorchBridge::instance();
@@ -774,7 +786,7 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
             auto& context = m_cached_context;
             ref<NativeBoundVariableRuntime> rv_node = m_runtime->find_kwarg("_result");
             if (rv_node && (!kwargs.contains("_result") || kwargs["_result"].is_none())) {
-                nb::object output = rv_node->python_type()->create_output(context, rv_node.get());
+                nb::object output = rv_node->python_type()->create_output(context, rv_node);
                 kwargs["_result"] = output;
                 unpacked_kwargs["_result"] = output;
             }
@@ -798,7 +810,7 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
     if (!command_encoder && m_call_mode == CallMode::prim) {
         ref<NativeBoundVariableRuntime> rv_node = m_runtime->find_kwarg("_result");
         if (rv_node && (!kwargs.contains("_result") || kwargs["_result"].is_none())) {
-            nb::object output = rv_node->python_type()->create_output(context, rv_node.get());
+            nb::object output = rv_node->python_type()->create_output(context, rv_node);
             kwargs["_result"] = output;
             unpacked_kwargs["_result"] = output;
             // Make a mutable copy of call_shape for populate_call_shape
@@ -972,29 +984,45 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
     ref<CommandEncoder> temp_command_encoder;
     if (command_encoder == nullptr) {
         temp_command_encoder = m_device->create_command_encoder();
-        command_encoder = temp_command_encoder.get();
+        command_encoder = temp_command_encoder;
     }
 
-    bool is_ray_tracing = opts.is_ray_tracing;
+    auto record_dispatch = [&]
+    {
+        if (!opts.is_ray_tracing) {
+            ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
+            ComputePipeline* pipeline = dynamic_cast<ComputePipeline*>(m_pipeline.get());
+            SGL_ASSERT(pipeline != nullptr);
+            ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline));
+            bind_call_data(cursor);
+            uint3 dispatch_thread_count
+                = dispatch_thread_count_from_total_threads(m_device, pipeline->thread_group_size(), total_threads);
+            pass_encoder->dispatch(dispatch_thread_count);
+            pass_encoder->end();
+        } else {
+            ref<RayTracingPassEncoder> pass_encoder = command_encoder->begin_ray_tracing_pass();
+            RayTracingPipeline* pipeline = dynamic_cast<RayTracingPipeline*>(m_pipeline.get());
+            SGL_ASSERT(pipeline != nullptr);
+            ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline, m_shader_table));
+            bind_call_data(cursor);
+            pass_encoder->dispatch_rays(0, uint3(total_threads, 1, 1));
+            pass_encoder->end();
+        }
+    };
 
-    if (!is_ray_tracing) {
-        ref<ComputePassEncoder> pass_encoder = command_encoder->begin_compute_pass();
-        ComputePipeline* pipeline = dynamic_cast<ComputePipeline*>(m_pipeline.get());
-        SGL_ASSERT(pipeline != nullptr);
-        ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline));
-        bind_call_data(cursor);
-        uint3 dispatch_thread_count
-            = dispatch_thread_count_from_total_threads(m_device.get(), pipeline->thread_group_size(), total_threads);
-        pass_encoder->dispatch(dispatch_thread_count);
-        pass_encoder->end();
+    if (Profiler* profiler = current_profiler_or_null(); profiler && profiler->enable_auto_zones()) {
+        if (m_profiler_site_id == 0) {
+            m_profiler_site_id = Profiler::register_site(
+                __FILE__,
+                __LINE__,
+                "SlangPy functional dispatch",
+                m_debug_name.empty() ? "SlangPy dispatch" : m_debug_name.c_str()
+            );
+        }
+        ::sgl::detail::ProfilerZoneGuard zone(m_profiler_site_id, command_encoder);
+        record_dispatch();
     } else {
-        ref<RayTracingPassEncoder> pass_encoder = command_encoder->begin_ray_tracing_pass();
-        RayTracingPipeline* pipeline = dynamic_cast<RayTracingPipeline*>(m_pipeline.get());
-        SGL_ASSERT(pipeline != nullptr);
-        ShaderCursor cursor(pass_encoder->bind_pipeline(pipeline, m_shader_table));
-        bind_call_data(cursor);
-        pass_encoder->dispatch_rays(0, uint3(total_threads, 1, 1));
-        pass_encoder->end();
+        record_dispatch();
     }
 
     // If we created a temporary command encoder, we need to submit it.
@@ -1015,7 +1043,7 @@ NativeCallData::exec(NativeCallRuntimeOptions& opts, CommandEncoder* command_enc
         auto bvr = nb::cast<ref<NativeBoundVariableRuntime>>(t[0]);
         auto rb_val = t[1];
         auto rb_data = t[2];
-        bvr->python_type()->read_calldata(context, bvr.get(), rb_val, rb_data);
+        bvr->python_type()->read_calldata(context, bvr, rb_val, rb_data);
     }
 
     // Pack updated 'this' values back (skip if no args needed unpacking).

--- a/src/slangpy_ext/utils/slangpy.h
+++ b/src/slangpy_ext/utils/slangpy.h
@@ -683,7 +683,7 @@ public:
     std::string debug_name() const { return m_debug_name; }
 
     /// Set the debug name
-    void set_debug_name(std::string debug_name) { m_debug_name = debug_name; }
+    void set_debug_name(std::string debug_name);
 
     /// Get the logger
     ref<Logger> logger() const { return m_logger; }
@@ -845,6 +845,7 @@ private:
     CallMode m_call_mode{CallMode::prim};
     Shape m_last_call_shape;
     std::string m_debug_name;
+    uint32_t m_profiler_site_id{0};
     ref<Logger> m_logger;
     Shape m_call_group_shape;
     bool m_torch_integration{false};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ if(SGL_BUILD_TESTS)
         sgl/device/test_formats.cpp
         sgl/device/test_shader.cpp
         sgl/device/test_persistent_cache.cpp
+        sgl/device/test_profiler.cpp
         sgl/func/test_base_objects.cpp
         sgl/func/test_tensor.cpp
         sgl/refl/test_lookup.cpp

--- a/tests/sgl/core/test_platform.cpp
+++ b/tests/sgl/core/test_platform.cpp
@@ -3,6 +3,8 @@
 #include "testing.h"
 #include "sgl/core/platform.h"
 
+#include <thread>
+
 using namespace sgl::platform;
 
 TEST_SUITE_BEGIN("platform");
@@ -82,6 +84,22 @@ TEST_CASE("set_current_thread_name")
 {
     CHECK(set_current_thread_name("sgl-test"));
     CHECK(set_current_thread_name("sgl-test-thread-name"));
+}
+
+TEST_CASE("current_thread_id")
+{
+    const sgl::ThreadID main_thread_id = current_thread_id();
+    sgl::ThreadID worker_thread_id{0};
+    std::thread worker(
+        [&]
+        {
+            worker_thread_id = current_thread_id();
+        }
+    );
+    worker.join();
+    CHECK(main_thread_id != 0);
+    CHECK(worker_thread_id != 0);
+    CHECK(worker_thread_id != main_thread_id);
 }
 
 TEST_CASE("backtrace")

--- a/tests/sgl/device/test_profiler.cpp
+++ b/tests/sgl/device/test_profiler.cpp
@@ -128,10 +128,18 @@ TEST_CASE("site metadata is interned and native function names are compact")
         "void example::Widget::update(int) [with T = float]",
         "update"
     );
+    const uint32_t apple_clang_site = Profiler::register_site(
+        "shared-profiler-source.cpp",
+        13,
+        "void (anonymous namespace)::example::Widget::update(int)",
+        "update"
+    );
     profiler->start_capture();
     profiler->end_zone(profiler->begin_zone(gcc_site));
+    profiler->end_zone(profiler->begin_zone(apple_clang_site));
     trace = profiler->stop_capture();
     CHECK(trace->sites().at(gcc_site - 1).function == "example::Widget::update");
+    CHECK(trace->sites().at(apple_clang_site - 1).function == "example::Widget::update");
 }
 
 TEST_CASE("capture records hierarchy frames queries and immutable chunks")

--- a/tests/sgl/device/test_profiler.cpp
+++ b/tests/sgl/device/test_profiler.cpp
@@ -2,6 +2,7 @@
 
 #include "testing.h"
 
+#include "sgl/core/platform.h"
 #include "sgl/device/command.h"
 #include "sgl/device/device.h"
 #include "sgl/utils/profiler.h"
@@ -152,8 +153,11 @@ TEST_CASE("capture records hierarchy frames queries and immutable chunks")
     REQUIRE(trace->frames().size() == 1);
     REQUIRE(trace->zone_chunks().size() == 1);
     const auto& chunk = trace->zone_chunks().front();
-    CHECK(chunk->parent_index[0] == 1);
-    CHECK(chunk->parent_index[1] == -1);
+    CHECK(chunk->parent_index()[0] == 1);
+    CHECK(chunk->parent_index()[1] == -1);
+    CHECK(chunk->frame_index().front() != ~uint32_t{0});
+    REQUIRE(trace->timelines().size() == 1);
+    CHECK(trace->timelines().front().thread_id == platform::current_thread_id());
 
     ref<ProfilerZoneSelection> selection = trace->query_zones("inner");
     CHECK(selection->count() == 1);
@@ -493,7 +497,7 @@ TEST_CASE_GPU("GPU hierarchy is scoped to a command recording")
         uint32_t base = 0;
         for (const auto& chunk : trace->zone_chunks()) {
             if (index < base + chunk->size()) {
-                if (chunk->parent_index[index - base] >= 0)
+                if (chunk->parent_index()[index - base] >= 0)
                     ++gpu_child_count;
                 break;
             }

--- a/tests/sgl/device/test_profiler.cpp
+++ b/tests/sgl/device/test_profiler.cpp
@@ -1,0 +1,614 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "testing.h"
+
+#include "sgl/device/command.h"
+#include "sgl/device/device.h"
+#include "sgl/utils/profiler.h"
+
+#include <algorithm>
+#include <atomic>
+#include <fstream>
+#include <thread>
+
+using namespace sgl;
+
+TEST_SUITE_BEGIN("profiler");
+
+namespace {
+
+void record_nested()
+{
+    SGL_PROFILE_FRAME("frame");
+    SGL_PROFILE_ZONE("outer");
+    {
+        SGL_PROFILE_ZONE("inner");
+    }
+}
+
+void record_native_function_site()
+{
+    SGL_PROFILE_FUNCTION();
+}
+
+bool supports_gpu_timestamps(Device* device)
+{
+    return device->has_feature(Feature::timestamp_query) && device->has_feature(Feature::timestamp_calibration);
+}
+
+} // namespace
+
+TEST_CASE("descriptor validation")
+{
+    ProfilerDesc invalid_desc;
+    invalid_desc.thread_event_capacity = 3;
+    CHECK_THROWS_WITH_AS(Profiler{invalid_desc}, doctest::Contains("power of two"), std::runtime_error);
+    invalid_desc.thread_event_capacity = 8;
+    invalid_desc.frame_stats_window_size = 0;
+    CHECK_THROWS_WITH_AS(Profiler{invalid_desc}, doctest::Contains("frame_stats_window_size"), std::runtime_error);
+    invalid_desc.frame_stats_window_size = 120;
+    invalid_desc.gpu_query_pool_size = 3;
+    CHECK_THROWS_WITH_AS(Profiler{invalid_desc}, doctest::Contains("even"), std::runtime_error);
+}
+
+TEST_CASE("current profiler stack is nested and thread local")
+{
+    CHECK(current_profiler_or_null() == nullptr);
+    ref<Profiler> profiler = make_ref<Profiler>();
+    CHECK(current_profiler() == profiler);
+    ref<Profiler> secondary = make_ref<Profiler>();
+    CHECK(current_profiler() == profiler);
+    {
+        ProfilerScope outer(secondary);
+        CHECK(current_profiler() == secondary);
+        {
+            ProfilerScope inner(secondary);
+            CHECK(current_profiler() == secondary);
+        }
+        Profiler* worker_current = profiler;
+        std::thread worker(
+            [&]
+            {
+                worker_current = current_profiler_or_null();
+            }
+        );
+        worker.join();
+        CHECK(worker_current == nullptr);
+    }
+    CHECK(current_profiler() == profiler);
+    secondary = nullptr;
+    CHECK(current_profiler() == profiler);
+    profiler = nullptr;
+    CHECK(current_profiler_or_null() == nullptr);
+}
+
+TEST_CASE("site metadata is interned and native function names are compact")
+{
+    std::string file = "shared-profiler-source.cpp";
+    std::string function = "public: static void __cdecl example::Widget::render(class sgl::CommandEncoder *)";
+    std::string name = function;
+    const uint32_t function_site = Profiler::register_site(file, 10, function, name);
+    const uint32_t zone_site = Profiler::register_site(file, 11, function, "render zone");
+    CHECK(Profiler::register_site(file, 10, function, name) == function_site);
+
+    file.assign("replaced file");
+    function.assign("replaced function");
+    name.assign("replaced name");
+
+    ref<Profiler> profiler = make_ref<Profiler>();
+    profiler->start_capture();
+    profiler->end_zone(profiler->begin_zone(function_site));
+    profiler->end_zone(profiler->begin_zone(zone_site));
+    record_native_function_site();
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+
+    const ProfilerSite& function_metadata = trace->sites().at(function_site - 1);
+    const ProfilerSite& zone_metadata = trace->sites().at(zone_site - 1);
+    CHECK(function_metadata.file == "shared-profiler-source.cpp");
+    CHECK(function_metadata.function == "example::Widget::render");
+    CHECK(function_metadata.name == "example::Widget::render");
+    CHECK(zone_metadata.name == "render zone");
+    CHECK(function_metadata.file.data() == zone_metadata.file.data());
+    CHECK(function_metadata.function.data() == zone_metadata.function.data());
+    const auto native_function = std::find_if(
+        trace->sites().begin(),
+        trace->sites().end(),
+        [](const ProfilerSite& site)
+        {
+            return site.name.ends_with("record_native_function_site");
+        }
+    );
+    REQUIRE(native_function != trace->sites().end());
+    CHECK(native_function->name == native_function->function);
+    CHECK(native_function->name.find('(') == std::string_view::npos);
+
+    const uint32_t gcc_site = Profiler::register_site(
+        "shared-profiler-source.cpp",
+        12,
+        "void example::Widget::update(int) [with T = float]",
+        "update"
+    );
+    profiler->start_capture();
+    profiler->end_zone(profiler->begin_zone(gcc_site));
+    trace = profiler->stop_capture();
+    CHECK(trace->sites().at(gcc_site - 1).function == "example::Widget::update");
+}
+
+TEST_CASE("capture records hierarchy frames queries and immutable chunks")
+{
+    ref<Profiler> profiler = make_ref<Profiler>();
+    profiler->start_capture();
+    record_nested();
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    REQUIRE(trace->zone_count() == 2);
+    REQUIRE(trace->frames().size() == 1);
+    REQUIRE(trace->zone_chunks().size() == 1);
+    const auto& chunk = trace->zone_chunks().front();
+    CHECK(chunk->parent_index[0] == 1);
+    CHECK(chunk->parent_index[1] == -1);
+
+    ref<ProfilerZoneSelection> selection = trace->query_zones("inner");
+    CHECK(selection->count() == 1);
+    CHECK(selection->statistics().count == 1);
+
+    const uint64_t original_count = trace->zone_count();
+    {
+        SGL_PROFILE_ZONE("later");
+    }
+    profiler->flush();
+    CHECK(trace->zone_count() == original_count);
+    CHECK(profiler->live_snapshot()->zone_count() == 3);
+}
+
+TEST_CASE("disabled profiler does not record")
+{
+    ref<Profiler> profiler = make_ref<Profiler>();
+    const uint32_t site = Profiler::register_site(__FILE__, __LINE__, __func__, "deep");
+    profiler->start_capture();
+    profiler->set_enabled(false);
+    CHECK(!profiler->begin_zone(site).profiler);
+    CHECK(profiler->stop_capture()->zone_count() == 0);
+}
+
+TEST_CASE("zone stack overflow drops only the excess zone")
+{
+    ref<Profiler> profiler = make_ref<Profiler>();
+    const uint32_t site = Profiler::register_site(__FILE__, __LINE__, __func__, "deep");
+    profiler->start_capture();
+    std::vector<ProfilerZoneToken> tokens;
+    for (uint32_t i = 0; i < 65; ++i)
+        tokens.push_back(profiler->begin_zone(site));
+    CHECK(!tokens.back().profiler);
+    for (auto it = tokens.rbegin(); it != tokens.rend(); ++it)
+        profiler->end_zone(*it);
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    CHECK(trace->zone_count() == 64);
+    CHECK(trace->diagnostics().producer_drop_count == 1);
+}
+
+TEST_CASE("capture collects concurrent producers without drops")
+{
+    ProfilerDesc desc;
+    desc.thread_event_capacity = 1024;
+    desc.live_event_capacity = 10000;
+    ref<Profiler> profiler = make_ref<Profiler>(desc);
+    profiler->start_capture();
+    std::vector<std::thread> workers;
+    for (uint32_t thread_index = 0; thread_index < 4; ++thread_index) {
+        workers.emplace_back(
+            [&]
+            {
+                ProfilerScope scope(profiler);
+                for (uint32_t i = 0; i < 200; ++i) {
+                    SGL_PROFILE_ZONE("parallel");
+                }
+            }
+        );
+    }
+    for (std::thread& worker : workers)
+        worker.join();
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    CHECK(trace->zone_count() == 800);
+    CHECK(trace->diagnostics().producer_drop_count == 0);
+    CHECK(trace->timelines().size() == 4);
+}
+
+TEST_CASE("frame statistics align repeated and intermittent zones")
+{
+    ProfilerDesc desc;
+    desc.frame_stats_window_size = 2;
+    ref<Profiler> profiler = make_ref<Profiler>(desc);
+    const uint32_t frame_site = Profiler::register_site(__FILE__, __LINE__, __func__, "stats frame");
+    const uint32_t outer_site = Profiler::register_site(__FILE__, __LINE__, __func__, "stats outer");
+    const uint32_t inner_site = Profiler::register_site(__FILE__, __LINE__, __func__, "stats inner");
+
+    auto record_frame = [&](uint32_t child_count)
+    {
+        ProfilerFrameToken frame = profiler->begin_frame(frame_site);
+        ProfilerZoneToken outer = profiler->begin_zone(outer_site);
+        for (uint32_t i = 0; i < child_count; ++i)
+            profiler->end_zone(profiler->begin_zone(inner_site));
+        profiler->end_zone(outer);
+        profiler->end_frame(frame);
+    };
+
+    record_frame(4);
+    record_frame(0);
+    profiler->flush();
+
+    ref<ProfilerFrameStats> first_snapshot = profiler->frame_stats_snapshot();
+    const ProfilerFrameStats& first = *first_snapshot;
+    CHECK(first.sample_count() == 2);
+    REQUIRE(first.entries().size() == 2);
+    const ProfilerFrameStatsEntry& outer = first.entries()[0];
+    const ProfilerFrameStatsEntry& inner = first.entries()[1];
+    CHECK(outer.name == "stats outer");
+    CHECK(inner.name == "stats inner");
+    CHECK(inner.parent_index == 0);
+    CHECK(inner.cpu_time_per_frame.count == 2);
+    CHECK(inner.cpu_time_per_call.count == 4);
+    CHECK(inner.gpu_time_per_frame.count == 0);
+    CHECK(first.diagnostics().producer_drop_count == 0);
+    CHECK(first.sample_frame_index().size() == 2);
+    CHECK(first.sample_frame_index()[0] < first.sample_frame_index()[1]);
+    CHECK(first.sample_call_count().size() == first.sample_count() * first.entry_count());
+    CHECK(first.sample_cpu_time_ms().size() == first.sample_count() * first.entry_count());
+    CHECK(first.sample_gpu_time_ms().size() == first.sample_count() * first.entry_count());
+    CHECK(first.sample_gpu_status().size() == first.sample_count() * first.entry_count());
+    const ProfilerFrameStatsSampleView first_sample = first.sample(0);
+    const ProfilerFrameStatsSampleView second_sample = first.sample(1);
+    CHECK(first_sample.call_count[1] == 4);
+    CHECK(second_sample.call_count[1] == 0);
+    CHECK(first_sample.cpu_time_ms[1] >= 0.0);
+    CHECK(second_sample.cpu_time_ms[1] == 0.0);
+    CHECK(first_sample.gpu_status[1] == ProfilerFrameGpuStatus::unavailable);
+    CHECK(second_sample.gpu_status[1] == ProfilerFrameGpuStatus::absent);
+
+    record_frame(2);
+    profiler->flush();
+    ref<ProfilerFrameStats> second_snapshot = profiler->frame_stats_snapshot();
+    CHECK(first_snapshot->entries()[1].cpu_time_per_call.count == 4);
+    CHECK(second_snapshot->sample_count() == 2);
+    CHECK(second_snapshot->entries()[1].cpu_time_per_call.count == 2);
+    CHECK(second_snapshot->sample(0).frame_index == first.sample(1).frame_index);
+    CHECK(second_snapshot->sample(0).call_count[1] == 0);
+    CHECK(second_snapshot->sample(1).call_count[1] == 2);
+    CHECK(first_snapshot->sample(0).call_count[1] == 4);
+
+    const std::string text = second_snapshot->to_string();
+    CHECK(text.find("ProfilerFrameStats(pending_frame_count=0") != std::string::npos);
+    CHECK(text.find("sample_count=2") != std::string::npos);
+    CHECK(text.find("stats inner: calls/frame mean=1") != std::string::npos);
+
+    profiler->clear_frame_stats();
+    CHECK(profiler->frame_stats_snapshot()->sample_count() == 0);
+    CHECK(first_snapshot->sample(0).call_count[1] == 4);
+}
+
+TEST_CASE("frame statistics hierarchy ordering is deterministic preorder")
+{
+    ref<Profiler> profiler = make_ref<Profiler>();
+    const uint32_t frame_site = Profiler::register_site(__FILE__, __LINE__, __func__, "ordered frame");
+    const uint32_t root_b_site = Profiler::register_site(__FILE__, __LINE__, __func__, "root b");
+    const uint32_t root_a_site = Profiler::register_site(__FILE__, __LINE__, __func__, "root a");
+    const uint32_t child_z_site = Profiler::register_site(__FILE__, __LINE__, __func__, "child z");
+    const uint32_t child_a_site = Profiler::register_site(__FILE__, __LINE__, __func__, "child a");
+
+    ProfilerFrameToken frame = profiler->begin_frame(frame_site);
+    ProfilerZoneToken root_b = profiler->begin_zone(root_b_site);
+    profiler->end_zone(profiler->begin_zone(child_z_site));
+    profiler->end_zone(profiler->begin_zone(child_a_site));
+    profiler->end_zone(root_b);
+    profiler->end_zone(profiler->begin_zone(root_a_site));
+    profiler->end_frame(frame);
+    profiler->flush();
+
+    ref<ProfilerFrameStats> stats = profiler->frame_stats_snapshot();
+    const ProfilerFrameStats& ordered = *stats;
+    REQUIRE(ordered.entries().size() == 4);
+    CHECK(ordered.entries()[0].name == "root a");
+    CHECK(ordered.entries()[0].parent_index == -1);
+    CHECK(ordered.entries()[1].name == "root b");
+    CHECK(ordered.entries()[1].parent_index == -1);
+    CHECK(ordered.entries()[2].name == "child a");
+    CHECK(ordered.entries()[2].parent_index == 1);
+    CHECK(ordered.entries()[3].name == "child z");
+    CHECK(ordered.entries()[3].parent_index == 1);
+}
+
+TEST_CASE("global frames include zones from other threads and exclude unframed zones")
+{
+    ref<Profiler> profiler = make_ref<Profiler>();
+    const uint32_t frame_a = Profiler::register_site(__FILE__, __LINE__, __func__, "frame a");
+    const uint32_t frame_b = Profiler::register_site(__FILE__, __LINE__, __func__, "frame b");
+    const uint32_t zone = Profiler::register_site(__FILE__, __LINE__, __func__, "framed zone");
+    profiler->end_zone(profiler->begin_zone(zone));
+
+    ProfilerFrameToken frame = profiler->begin_frame(frame_a);
+    REQUIRE(frame.profiler == profiler);
+    std::atomic<bool> worker_started{false};
+    std::atomic<bool> finish_worker{false};
+    std::atomic<bool> worker_frame_rejected{false};
+    std::thread worker(
+        [&]
+        {
+            worker_frame_rejected.store(!profiler->begin_frame(frame_b).profiler, std::memory_order_relaxed);
+            ProfilerZoneToken token = profiler->begin_zone(zone);
+            worker_started.store(true, std::memory_order_release);
+            while (!finish_worker.load(std::memory_order_acquire))
+                std::this_thread::yield();
+            profiler->end_zone(token);
+        }
+    );
+    while (!worker_started.load(std::memory_order_acquire))
+        std::this_thread::yield();
+    CHECK(worker_frame_rejected.load(std::memory_order_relaxed));
+    profiler->end_frame(frame);
+    CHECK(!profiler->begin_frame(frame_b).profiler);
+    finish_worker.store(true, std::memory_order_release);
+    worker.join();
+
+    frame = profiler->begin_frame(frame_b);
+    REQUIRE(frame.profiler == profiler);
+    profiler->end_zone(profiler->begin_zone(zone));
+    profiler->end_frame(frame);
+    profiler->flush();
+    ref<ProfilerFrameStats> stats = profiler->frame_stats_snapshot();
+    CHECK(stats->sample_count() == 2);
+    REQUIRE(stats->entries().size() == 1);
+    CHECK(stats->entries().front().cpu_time_per_call.count == 2);
+    CHECK(stats->sample(0).call_count.front() == 1);
+    CHECK(stats->sample(1).call_count.front() == 1);
+}
+
+TEST_CASE("capture stops at its memory bound")
+{
+    ref<Profiler> profiler = make_ref<Profiler>();
+    profiler->start_capture({64});
+    const uint32_t site = Profiler::register_site(__FILE__, __LINE__, __func__, "bounded");
+    for (uint32_t i = 0; i < 32; ++i) {
+        ProfilerZoneToken token = profiler->begin_zone(site);
+        profiler->end_zone(token);
+    }
+    profiler->flush();
+    CHECK(!profiler->capture_active());
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    CHECK(trace->truncated());
+    CHECK(trace->stop_reason() == ProfilerCaptureStopReason::memory_limit);
+    CHECK(trace->memory_bytes() <= 64);
+}
+
+TEST_CASE("trace JSON is streamed with escaping")
+{
+    ref<Profiler> profiler = make_ref<Profiler>();
+    profiler->start_capture();
+    const uint32_t site = Profiler::register_site(__FILE__, __LINE__, __func__, "json \"zone\"");
+    profiler->end_zone(profiler->begin_zone(site));
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    const auto path = testing::get_case_temp_directory() / "trace.json";
+    trace->write_to_json(path);
+    std::ifstream stream(path);
+    const std::string contents((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
+    CHECK(contents.find("json \\\"zone\\\"") != std::string::npos);
+    CHECK(contents.find("\"ph\":\"X\"") != std::string::npos);
+}
+
+TEST_CASE_GPU("GPU timestamps follow command recording submission")
+{
+    if (!supports_gpu_timestamps(ctx.device))
+        return;
+
+    ref<Profiler> profiler = make_ref<Profiler>();
+    profiler->start_capture();
+    ref<CommandEncoder> encoder = ctx.device->create_command_encoder();
+    const uint32_t frame_site = Profiler::register_site(__FILE__, __LINE__, __func__, "gpu frame");
+    const uint32_t site = Profiler::register_site(__FILE__, __LINE__, __func__, "gpu");
+    ProfilerFrameToken frame = profiler->begin_frame(frame_site);
+    ProfilerZoneToken token = profiler->begin_zone(site, encoder);
+    profiler->end_zone(token);
+    profiler->end_frame(frame);
+    profiler->flush();
+    ref<ProfilerFrameStats> pending_stats = profiler->frame_stats_snapshot();
+    CHECK(pending_stats->pending_frame_count() == 1);
+    CHECK(pending_stats->sample_count() == 0);
+    profiler->tick();
+    ctx.device->submit_command_buffer(encoder->finish());
+    ctx.device->wait();
+    profiler->tick();
+
+    encoder = ctx.device->create_command_encoder();
+    token = profiler->begin_zone(site, encoder);
+    profiler->end_zone(token);
+    ctx.device->submit_command_buffer(encoder->finish());
+    ctx.device->wait();
+    profiler->tick();
+
+    std::thread later_cpu_thread(
+        [&]
+        {
+            const uint32_t cpu_site = Profiler::register_site(__FILE__, __LINE__, __func__, "later cpu timeline");
+            profiler->end_zone(profiler->begin_zone(cpu_site));
+        }
+    );
+    later_cpu_thread.join();
+
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    CHECK(trace->query_zones("gpu", ProfilerTimelineType::cpu)->count() == 2);
+    CHECK(trace->query_zones("gpu", ProfilerTimelineType::gpu)->count() == 2);
+    CHECK(trace->query_zones("later cpu timeline", ProfilerTimelineType::cpu)->count() == 1);
+    CHECK(trace->diagnostics().pending_gpu_zone_count == 0);
+    REQUIRE(trace->timelines().size() == 3);
+    CHECK(trace->timelines()[0].type == ProfilerTimelineType::cpu);
+    CHECK(trace->timelines()[1].type == ProfilerTimelineType::gpu);
+    CHECK(trace->timelines()[2].type == ProfilerTimelineType::cpu);
+    ref<ProfilerFrameStats> stats = profiler->frame_stats_snapshot();
+    CHECK(stats->sample_count() == 1);
+    REQUIRE(stats->entries().size() == 1);
+    CHECK(stats->entries().front().gpu_time_per_call.count == 1);
+    CHECK(stats->entries().front().gpu_time_per_frame.count == 1);
+    CHECK(stats->sample(0).gpu_status.front() == ProfilerFrameGpuStatus::complete);
+}
+
+TEST_CASE_GPU("GPU hierarchy is scoped to a command recording")
+{
+    if (!supports_gpu_timestamps(ctx.device))
+        return;
+
+    ref<Profiler> profiler = make_ref<Profiler>();
+    profiler->start_capture();
+    const uint32_t outer_site = Profiler::register_site(__FILE__, __LINE__, __func__, "gpu outer");
+    const uint32_t inner_site = Profiler::register_site(__FILE__, __LINE__, __func__, "gpu inner");
+
+    ref<CommandEncoder> encoder = ctx.device->create_command_encoder();
+    ProfilerZoneToken outer = profiler->begin_zone(outer_site, encoder);
+    ProfilerZoneToken inner = profiler->begin_zone(inner_site, encoder);
+    profiler->end_zone(inner);
+    profiler->end_zone(outer);
+    ctx.device->submit_command_buffer(encoder->finish());
+
+    ref<CommandEncoder> encoder_a = ctx.device->create_command_encoder();
+    ref<CommandEncoder> encoder_b = ctx.device->create_command_encoder();
+    outer = profiler->begin_zone(outer_site, encoder_a);
+    inner = profiler->begin_zone(inner_site, encoder_b);
+    profiler->end_zone(inner);
+    profiler->end_zone(outer);
+    ctx.device->submit_command_buffer(encoder_a->finish());
+    ctx.device->submit_command_buffer(encoder_b->finish());
+
+    ctx.device->wait();
+    profiler->tick();
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    ref<ProfilerZoneSelection> gpu_zones = trace->query_zones({}, ProfilerTimelineType::gpu);
+    REQUIRE(gpu_zones->count() == 4);
+    uint32_t gpu_child_count = 0;
+    for (uint32_t index : gpu_zones->indices()) {
+        uint32_t base = 0;
+        for (const auto& chunk : trace->zone_chunks()) {
+            if (index < base + chunk->size()) {
+                if (chunk->parent_index[index - base] >= 0)
+                    ++gpu_child_count;
+                break;
+            }
+            base += uint32_t(chunk->size());
+        }
+    }
+    CHECK(gpu_child_count == 1);
+}
+
+TEST_CASE_GPU("GPU query exhaustion preserves CPU zones")
+{
+    if (!supports_gpu_timestamps(ctx.device))
+        return;
+
+    ProfilerDesc desc;
+    desc.gpu_query_pool_size = 2;
+    ref<Profiler> profiler = make_ref<Profiler>(desc);
+    profiler->start_capture();
+    const uint32_t frame_site = Profiler::register_site(__FILE__, __LINE__, __func__, "exhausted frame");
+    const uint32_t site = Profiler::register_site(__FILE__, __LINE__, __func__, "exhausted gpu");
+    ref<CommandEncoder> encoder = ctx.device->create_command_encoder();
+    ProfilerFrameToken frame = profiler->begin_frame(frame_site);
+    ProfilerZoneToken outer = profiler->begin_zone(site, encoder);
+    ProfilerZoneToken inner = profiler->begin_zone(site, encoder);
+    profiler->end_zone(inner);
+    profiler->end_zone(outer);
+    profiler->end_frame(frame);
+    ctx.device->submit_command_buffer(encoder->finish());
+    ctx.device->wait();
+    profiler->tick();
+    ref<ProfilerTrace> trace = profiler->stop_capture();
+    CHECK(trace->query_zones("exhausted gpu", ProfilerTimelineType::cpu)->count() == 2);
+    CHECK(trace->query_zones("exhausted gpu", ProfilerTimelineType::gpu)->count() == 1);
+    CHECK(trace->diagnostics().gpu_query_exhaustion_count == 1);
+    ref<ProfilerFrameStats> stats = profiler->frame_stats_snapshot();
+    REQUIRE(stats->entries().size() == 2);
+    uint64_t gpu_call_count = 0;
+    for (const ProfilerFrameStatsEntry& entry : stats->entries())
+        gpu_call_count += entry.gpu_time_per_call.count;
+    CHECK(gpu_call_count == 1);
+    const ProfilerFrameStatsSampleView sample = stats->sample(0);
+    REQUIRE(sample.gpu_status.size() == 2);
+    CHECK(std::count(sample.gpu_status.begin(), sample.gpu_status.end(), ProfilerFrameGpuStatus::complete) == 1);
+    CHECK(std::count(sample.gpu_status.begin(), sample.gpu_status.end(), ProfilerFrameGpuStatus::incomplete) == 1);
+}
+
+TEST_CASE_GPU("discarded GPU work and pending bounds complete frame statistics")
+{
+    if (!supports_gpu_timestamps(ctx.device))
+        return;
+
+    ProfilerDesc desc;
+    desc.frame_stats_window_size = 1;
+    ref<Profiler> profiler = make_ref<Profiler>(desc);
+    const uint32_t frame_site = Profiler::register_site(__FILE__, __LINE__, __func__, "pending frame");
+    const uint32_t zone_site = Profiler::register_site(__FILE__, __LINE__, __func__, "pending gpu");
+    auto record_pending_frame = [&]()
+    {
+        ref<CommandEncoder> encoder = ctx.device->create_command_encoder();
+        ProfilerFrameToken frame = profiler->begin_frame(frame_site);
+        profiler->end_zone(profiler->begin_zone(zone_site, encoder));
+        profiler->end_frame(frame);
+        return encoder->finish();
+    };
+
+    ref<CommandBuffer> first = record_pending_frame();
+    profiler->flush();
+    CHECK(profiler->frame_stats_snapshot()->pending_frame_count() == 1);
+    ref<CommandBuffer> second = record_pending_frame();
+    profiler->flush();
+    ref<ProfilerFrameStats> bounded = profiler->frame_stats_snapshot();
+    CHECK(bounded->sample_count() == 1);
+    CHECK(bounded->pending_frame_count() == 1);
+    REQUIRE(bounded->entries().size() == 1);
+    CHECK(bounded->sample(0).gpu_status.front() == ProfilerFrameGpuStatus::incomplete);
+
+    first = nullptr;
+    second = nullptr;
+    profiler->flush();
+    ref<ProfilerFrameStats> discarded = profiler->frame_stats_snapshot();
+    CHECK(discarded->sample_count() == 1);
+    CHECK(discarded->pending_frame_count() == 0);
+    REQUIRE(discarded->entries().size() == 1);
+    CHECK(discarded->sample(0).gpu_status.front() == ProfilerFrameGpuStatus::incomplete);
+
+    ref<CommandBuffer> third = record_pending_frame();
+    profiler->flush();
+    CHECK(profiler->frame_stats_snapshot()->pending_frame_count() == 1);
+    profiler->clear_frame_stats();
+    CHECK(profiler->frame_stats_snapshot()->sample_count() == 0);
+    third = nullptr;
+    profiler->flush();
+    CHECK(profiler->frame_stats_snapshot()->sample_count() == 0);
+}
+
+TEST_CASE_GPU("device close settles pending frame statistics")
+{
+    DeviceDesc device_desc = ctx.device->desc();
+    device_desc.label = "profiler-device-close";
+    ref<Device> device = Device::create(device_desc);
+    if (!supports_gpu_timestamps(device)) {
+        device->close();
+        return;
+    }
+
+    ref<Profiler> profiler = make_ref<Profiler>();
+    const uint32_t frame_site = Profiler::register_site(__FILE__, __LINE__, __func__, "device close frame");
+    const uint32_t zone_site = Profiler::register_site(__FILE__, __LINE__, __func__, "device close gpu");
+    ref<CommandEncoder> encoder = device->create_command_encoder();
+    ProfilerFrameToken frame = profiler->begin_frame(frame_site);
+    profiler->end_zone(profiler->begin_zone(zone_site, encoder));
+    profiler->end_frame(frame);
+    ref<CommandBuffer> command_buffer = encoder->finish();
+    profiler->flush();
+    CHECK(profiler->frame_stats_snapshot()->pending_frame_count() == 1);
+
+    device->close();
+    profiler->flush();
+    ref<ProfilerFrameStats> stats = profiler->frame_stats_snapshot();
+    CHECK(stats->pending_frame_count() == 0);
+    REQUIRE(stats->entries().size() == 1);
+    CHECK(stats->sample(0).gpu_status.front() == ProfilerFrameGpuStatus::incomplete);
+    command_buffer = nullptr;
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
Adds a bounded CPU/GPU instrumentation profiler to SlangPy.
- Provides C++ macros and Python context managers for profiling frames, functions, and zones.
- Automatically profiles functional API dispatches and supports GPU timestamps for command-buffer work.
- Adds live frame statistics, bounded captures, diagnostics, trace queries, and Perfetto-compatible JSON export.
- Includes an ImGui profiler window, path tracer integrations, documentation, and comprehensive C++/Python tests.