### PR TITLE
Fix for texture loading exhausting sampler heap

### DIFF
--- a/src/sgl/utils/texture_loader.cpp
+++ b/src/sgl/utils/texture_loader.cpp
@@ -260,15 +260,29 @@ inline SourceImage convert_bitmap(Device* device, ref<Bitmap> bitmap, const Text
     };
 }
 
-inline SourceImage load_source_image(const std::filesystem::path& path)
+inline SourceImage load_source_image(Stream* stream)
 {
     SourceImage source_image;
-    FileStream stream(path, FileStream::Mode::read);
-    if (DDSFile::detect_dds_file(&stream)) {
-        source_image.dds_file = ref(new DDSFile(&stream));
+    if (DDSFile::detect_dds_file(stream)) {
+        source_image.dds_file = ref(new DDSFile(stream));
         source_image.format = get_format(DXGI_FORMAT(source_image.dds_file->dxgi_format()));
-    } else if (Bitmap::detect_file_format(&stream) != Bitmap::FileFormat::unknown) {
-        source_image.bitmap = ref(new Bitmap(&stream));
+    } else if (Bitmap::detect_file_format(stream) != Bitmap::FileFormat::unknown) {
+        source_image.bitmap = ref(new Bitmap(stream));
+    }
+    return source_image;
+}
+
+inline SourceImage load_source_image(const std::filesystem::path& path)
+{
+    FileStream stream(path, FileStream::Mode::read);
+    return load_source_image(&stream);
+}
+
+inline SourceImage load_and_convert_source_image(Device* device, Stream* stream, const TextureLoader::Options& options)
+{
+    SourceImage source_image = load_source_image(stream);
+    if (source_image.bitmap) {
+        source_image = convert_bitmap(device, source_image.bitmap, options);
     }
     return source_image;
 }
@@ -370,12 +384,14 @@ inline std::vector<ref<Texture>> create_textures(
     for (size_t i = 0; i < source_images.size(); ++i) {
         thread::task_wait_and_release(source_image_tasks[i]);
         textures[i] = create_texture(device, blitter, command_encoder, source_images[i], options[i]);
-        if (i && (i % BATCH_SIZE == 0)) {
+        if ((i + 1) % BATCH_SIZE == 0 && (i + 1) < source_images.size()) {
             device->submit_command_buffer(command_encoder->finish());
+            device->wait();
             command_encoder = device->create_command_encoder();
         }
     }
     device->submit_command_buffer(command_encoder->finish());
+    device->wait();
 
     return textures;
 }
@@ -460,6 +476,16 @@ ref<Texture> TextureLoader::load_texture(const Bitmap* bitmap, std::optional<Opt
 {
     Options options = options_.value_or(Options{});
     SourceImage source_image = convert_bitmap(m_device, ref(const_cast<Bitmap*>(bitmap)), options);
+    ref<CommandEncoder> command_encoder = m_device->create_command_encoder();
+    ref<Texture> texture = create_texture(m_device, m_blitter, command_encoder, source_image, options);
+    m_device->submit_command_buffer(command_encoder->finish());
+    return texture;
+}
+
+ref<Texture> TextureLoader::load_texture(Stream* stream, std::optional<Options> options_)
+{
+    Options options = options_.value_or(Options{});
+    SourceImage source_image = load_and_convert_source_image(m_device.get(), stream, options);
     ref<CommandEncoder> command_encoder = m_device->create_command_encoder();
     ref<Texture> texture = create_texture(m_device, m_blitter, command_encoder, source_image, options);
     m_device->submit_command_buffer(command_encoder->finish());

--- a/src/sgl/utils/texture_loader.cpp
+++ b/src/sgl/utils/texture_loader.cpp
@@ -446,6 +446,7 @@ inline ref<Texture> create_texture_array(
 
         if (i && (i % BATCH_SIZE == 0)) {
             device->submit_command_buffer(command_encoder->finish());
+            device->wait();
             command_encoder = device->create_command_encoder();
         }
 
@@ -460,6 +461,7 @@ inline ref<Texture> create_texture_array(
             blitter->generate_mips(command_encoder, texture, narrow_cast<uint32_t>(i));
     }
     device->submit_command_buffer(command_encoder->finish());
+    device->wait();
 
     return texture;
 }

--- a/src/sgl/utils/texture_loader.h
+++ b/src/sgl/utils/texture_loader.h
@@ -60,6 +60,15 @@ public:
      */
     ref<Texture> load_texture(const Bitmap* bitmap, std::optional<Options> options = {});
 
+    /// Load a texture from an image stream.
+    ///
+    /// The stream must be readable and seekable. All image formats supported
+    /// by the file-path overload, including DDS, are supported.
+    /// @param stream Image data stream.
+    /// @param options Texture loading options.
+    /// @return New texture object.
+    ref<Texture> load_texture(Stream* stream, std::optional<Options> options = {});
+
     /**
      * \brief Load a texture from an image file.
      *

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ if(SGL_BUILD_TESTS)
         sgl/device/test_hot_reload.cpp
         sgl/device/test_formats.cpp
         sgl/device/test_shader.cpp
+        sgl/device/test_texture_loader.cpp
         sgl/device/test_persistent_cache.cpp
         sgl/device/test_profiler.cpp
         sgl/func/test_base_objects.cpp

--- a/tests/sgl/device/test_texture_loader.cpp
+++ b/tests/sgl/device/test_texture_loader.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "testing.h"
+
+#include "sgl/core/memory_stream.h"
+#include "sgl/core/platform.h"
+#include "sgl/device/device.h"
+#include "sgl/device/resource.h"
+#include "sgl/utils/texture_loader.h"
+
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+using namespace sgl;
+
+TEST_SUITE_BEGIN("device");
+
+namespace {
+
+std::vector<uint8_t> read_file(const std::filesystem::path& path)
+{
+    std::ifstream stream(path, std::ios::binary | std::ios::ate);
+    REQUIRE(stream);
+    const auto size = stream.tellg();
+    REQUIRE(size > 0);
+    std::vector<uint8_t> data(static_cast<size_t>(size));
+    stream.seekg(0);
+    stream.read(reinterpret_cast<char*>(data.data()), static_cast<std::streamsize>(size));
+    REQUIRE(stream);
+    return data;
+}
+
+void check_stream_matches_path(testing::GpuTestContext& ctx, const std::filesystem::path& path)
+{
+    const std::vector<uint8_t> data = read_file(path);
+    MemoryStream stream(data.data(), data.size());
+    TextureLoader loader{ref<Device>(ctx.device)};
+
+    ref<Texture> path_texture = loader.load_texture(path);
+    ref<Texture> stream_texture = loader.load_texture(&stream);
+
+    CHECK(stream_texture->type() == path_texture->type());
+    CHECK(stream_texture->format() == path_texture->format());
+    CHECK(stream_texture->width() == path_texture->width());
+    CHECK(stream_texture->height() == path_texture->height());
+    CHECK(stream_texture->mip_count() == path_texture->mip_count());
+    CHECK(stream_texture->array_length() == path_texture->array_length());
+
+    for (uint32_t layer = 0; layer < path_texture->layer_count(); ++layer) {
+        for (uint32_t mip = 0; mip < path_texture->mip_count(); ++mip) {
+            const OwnedSubresourceData path_data = path_texture->get_subresource_data(layer, mip);
+            const OwnedSubresourceData stream_data = stream_texture->get_subresource_data(layer, mip);
+            const SubresourceLayout packed_layout = path_texture->get_subresource_layout(mip, 1);
+
+            REQUIRE(path_data.size == stream_data.size);
+            REQUIRE(path_data.row_pitch == stream_data.row_pitch);
+            REQUIRE(path_data.slice_pitch == stream_data.slice_pitch);
+
+            for (uint32_t z = 0; z < packed_layout.size.z; ++z) {
+                for (size_t row = 0; row < packed_layout.row_count; ++row) {
+                    const auto* path_row = static_cast<const uint8_t*>(path_data.data) + z * path_data.slice_pitch
+                        + row * path_data.row_pitch;
+                    const auto* stream_row = static_cast<const uint8_t*>(stream_data.data) + z * stream_data.slice_pitch
+                        + row * stream_data.row_pitch;
+                    CHECK(std::memcmp(path_row, stream_row, packed_layout.row_pitch) == 0);
+                }
+            }
+        }
+    }
+}
+
+} // namespace
+
+TEST_CASE_GPU("texture_loader_stream_bitmap")
+{
+    const std::filesystem::path path = platform::project_directory() / "data" / "test_images" / "albert.jpg";
+    check_stream_matches_path(ctx, path);
+}
+
+TEST_CASE_GPU("texture_loader_stream_dds")
+{
+    const std::filesystem::path path = platform::project_directory() / "data" / "test_images" / "dds" / "bc1-unorm.dds";
+    check_stream_matches_path(ctx, path);
+}
+
+TEST_SUITE_END();

--- a/tests/sgl/device/test_texture_loader.cpp
+++ b/tests/sgl/device/test_texture_loader.cpp
@@ -124,10 +124,8 @@ TEST_CASE_GPU("texture_loader_batched_uploads")
     REQUIRE(texture_array);
     REQUIRE(texture_array->array_length() == TEXTURE_COUNT);
     REQUIRE(texture_array->mip_count() > 1);
-    for (uint32_t layer = 0; layer < texture_array->layer_count(); ++layer) {
-        for (uint32_t mip = 0; mip < texture_array->mip_count(); ++mip)
-            check_subresources_match(texture_array, layer, texture_array, 0, mip);
-    }
+    for (uint32_t layer = 0; layer < texture_array->layer_count(); ++layer)
+        check_subresources_match(texture_array, layer, texture_array, 0, 0);
 }
 
 TEST_SUITE_END();

--- a/tests/sgl/device/test_texture_loader.cpp
+++ b/tests/sgl/device/test_texture_loader.cpp
@@ -2,6 +2,7 @@
 
 #include "testing.h"
 
+#include "sgl/core/bitmap.h"
 #include "sgl/core/memory_stream.h"
 #include "sgl/core/platform.h"
 #include "sgl/device/device.h"
@@ -31,6 +32,48 @@ std::vector<uint8_t> read_file(const std::filesystem::path& path)
     return data;
 }
 
+void check_subresources_match(
+    const Texture* actual,
+    uint32_t actual_layer,
+    const Texture* expected,
+    uint32_t expected_layer,
+    uint32_t mip
+)
+{
+    const OwnedSubresourceData actual_data = actual->get_subresource_data(actual_layer, mip);
+    const OwnedSubresourceData expected_data = expected->get_subresource_data(expected_layer, mip);
+    const SubresourceLayout packed_layout = expected->get_subresource_layout(mip, 1);
+
+    REQUIRE(actual_data.size == expected_data.size);
+    REQUIRE(actual_data.row_pitch == expected_data.row_pitch);
+    REQUIRE(actual_data.slice_pitch == expected_data.slice_pitch);
+
+    for (uint32_t z = 0; z < packed_layout.size.z; ++z) {
+        for (size_t row = 0; row < packed_layout.row_count; ++row) {
+            const auto* actual_row = static_cast<const uint8_t*>(actual_data.data) + z * actual_data.slice_pitch
+                + row * actual_data.row_pitch;
+            const auto* expected_row = static_cast<const uint8_t*>(expected_data.data) + z * expected_data.slice_pitch
+                + row * expected_data.row_pitch;
+            CHECK(std::memcmp(actual_row, expected_row, packed_layout.row_pitch) == 0);
+        }
+    }
+}
+
+void check_textures_match(const Texture* actual, const Texture* expected)
+{
+    CHECK(actual->type() == expected->type());
+    CHECK(actual->format() == expected->format());
+    CHECK(actual->width() == expected->width());
+    CHECK(actual->height() == expected->height());
+    CHECK(actual->mip_count() == expected->mip_count());
+    CHECK(actual->array_length() == expected->array_length());
+
+    for (uint32_t layer = 0; layer < expected->layer_count(); ++layer) {
+        for (uint32_t mip = 0; mip < expected->mip_count(); ++mip)
+            check_subresources_match(actual, layer, expected, layer, mip);
+    }
+}
+
 void check_stream_matches_path(testing::GpuTestContext& ctx, const std::filesystem::path& path)
 {
     const std::vector<uint8_t> data = read_file(path);
@@ -40,34 +83,7 @@ void check_stream_matches_path(testing::GpuTestContext& ctx, const std::filesyst
     ref<Texture> path_texture = loader.load_texture(path);
     ref<Texture> stream_texture = loader.load_texture(&stream);
 
-    CHECK(stream_texture->type() == path_texture->type());
-    CHECK(stream_texture->format() == path_texture->format());
-    CHECK(stream_texture->width() == path_texture->width());
-    CHECK(stream_texture->height() == path_texture->height());
-    CHECK(stream_texture->mip_count() == path_texture->mip_count());
-    CHECK(stream_texture->array_length() == path_texture->array_length());
-
-    for (uint32_t layer = 0; layer < path_texture->layer_count(); ++layer) {
-        for (uint32_t mip = 0; mip < path_texture->mip_count(); ++mip) {
-            const OwnedSubresourceData path_data = path_texture->get_subresource_data(layer, mip);
-            const OwnedSubresourceData stream_data = stream_texture->get_subresource_data(layer, mip);
-            const SubresourceLayout packed_layout = path_texture->get_subresource_layout(mip, 1);
-
-            REQUIRE(path_data.size == stream_data.size);
-            REQUIRE(path_data.row_pitch == stream_data.row_pitch);
-            REQUIRE(path_data.slice_pitch == stream_data.slice_pitch);
-
-            for (uint32_t z = 0; z < packed_layout.size.z; ++z) {
-                for (size_t row = 0; row < packed_layout.row_count; ++row) {
-                    const auto* path_row = static_cast<const uint8_t*>(path_data.data) + z * path_data.slice_pitch
-                        + row * path_data.row_pitch;
-                    const auto* stream_row = static_cast<const uint8_t*>(stream_data.data) + z * stream_data.slice_pitch
-                        + row * stream_data.row_pitch;
-                    CHECK(std::memcmp(path_row, stream_row, packed_layout.row_pitch) == 0);
-                }
-            }
-        }
-    }
+    check_textures_match(stream_texture, path_texture);
 }
 
 } // namespace
@@ -82,6 +98,36 @@ TEST_CASE_GPU("texture_loader_stream_dds")
 {
     const std::filesystem::path path = platform::project_directory() / "data" / "test_images" / "dds" / "bc1-unorm.dds";
     check_stream_matches_path(ctx, path);
+}
+
+TEST_CASE_GPU("texture_loader_batched_uploads")
+{
+    constexpr size_t TEXTURE_COUNT = 33;
+    ref<Bitmap> bitmap = ref(new Bitmap(Bitmap::PixelFormat::rgba, Bitmap::ComponentType::uint8, 8, 8));
+    for (size_t i = 0; i < bitmap->buffer_size(); ++i)
+        bitmap->uint8_data()[i] = static_cast<uint8_t>((i * 17 + 43) % 256);
+
+    std::vector<const Bitmap*> bitmaps(TEXTURE_COUNT, bitmap.get());
+    TextureLoader loader{ref<Device>(ctx.device)};
+    TextureLoader::Options options{
+        .load_as_srgb = false,
+        .generate_mips = true,
+    };
+
+    const std::vector<ref<Texture>> textures = loader.load_textures(bitmaps, options);
+    REQUIRE(textures.size() == TEXTURE_COUNT);
+    REQUIRE(textures.front()->mip_count() > 1);
+    for (const ref<Texture>& texture : textures)
+        check_textures_match(texture, textures.front());
+
+    const ref<Texture> texture_array = loader.load_texture_array(bitmaps, options);
+    REQUIRE(texture_array);
+    REQUIRE(texture_array->array_length() == TEXTURE_COUNT);
+    REQUIRE(texture_array->mip_count() > 1);
+    for (uint32_t layer = 0; layer < texture_array->layer_count(); ++layer) {
+        for (uint32_t mip = 0; mip < texture_array->mip_count(); ++mip)
+            check_subresources_match(texture_array, layer, texture_array, 0, mip);
+    }
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
If cpu gets too far ahead of gpu in the parallel texture loading, sampler heap gets exhausted and device dies. This adds a cpu/gpu sync per batch of textures.