### PR TITLE
Temporarily disable intermittent profiler tests

### DIFF
--- a/tests/sgl/device/test_profiler.cpp
+++ b/tests/sgl/device/test_profiler.cpp
@@ -328,7 +328,8 @@ TEST_CASE("frame statistics hierarchy ordering is deterministic preorder")
     CHECK(ordered.entries()[3].parent_index == 1);
 }
 
-TEST_CASE("global frames include zones from other threads and exclude unframed zones")
+// TODO: Re-enable when https://github.com/shader-slang/slangpy/pull/1073 is merged.
+TEST_CASE("global frames include zones from other threads and exclude unframed zones" * doctest::skip())
 {
     ref<Profiler> profiler = make_ref<Profiler>();
     const uint32_t frame_a = Profiler::register_site(__FILE__, __LINE__, __func__, "frame a");
@@ -593,7 +594,8 @@ TEST_CASE_GPU("discarded GPU work and pending bounds complete frame statistics")
     CHECK(profiler->frame_stats_snapshot()->sample_count() == 0);
 }
 
-TEST_CASE_GPU("device close settles pending frame statistics")
+// TODO: Re-enable when https://github.com/shader-slang/slangpy/pull/1073 is merged.
+TEST_CASE_GPU("device close settles pending frame statistics" * doctest::skip())
 {
     DeviceDesc device_desc = ctx.device->desc();
     device_desc.label = "profiler-device-close";


### PR DESCRIPTION
## Motivation

The asynchronous profiler collector can finalize a frame before consuming an attached zone. Until the ordering fix in #1073 is reviewed and merged, this race can intermittently fail the scheduled latest-Slang workflow on different platforms.

The observed failures affect `global frames include zones from other threads and exclude unframed zones` and `device close settles pending frame statistics` in `tests/sgl/device/test_profiler.cpp`.

## Proposed solution

Temporarily mark the two known regression guards with `doctest::skip()`. Each skip includes a TODO referencing #1073 so it has a clear removal condition.

## Change summary

- Skip the cross-thread global-frame statistics test at `tests/sgl/device/test_profiler.cpp:332`.
- Skip the device-close pending-frame statistics GPU test at `tests/sgl/device/test_profiler.cpp:598`.

## Process report

Both tests exercise the collector ordering corrected by #1073 and have failed independently in scheduled CI. The workflow history since the profiler landed shows no other test failures attributable to the same race. Keeping the disable list limited to these two cases preserves the rest of the profiler coverage while the implementation fix is under review.
