### PR TITLE
Logger deadlock fix

### DIFF
--- a/src/sgl/core/logger.cpp
+++ b/src/sgl/core/logger.cpp
@@ -259,16 +259,25 @@ void Logger::set_level(LogLevel level)
 
 void Logger::log(LogLevel level, const std::string_view msg, LogFrequency frequency)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::set<ref<LoggerOutput>> outputs;
+    std::string name;
 
-    if (level != LogLevel::none && level < m_level)
-        return;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
 
-    if (frequency == LogFrequency::once && is_duplicate(msg))
-        return;
+        if (level != LogLevel::none && level < m_level)
+            return;
 
-    for (const auto& output : m_outputs)
-        output->write(level, m_name, msg);
+        if (frequency == LogFrequency::once && is_duplicate(msg))
+            return;
+
+        // Outputs may re-enter the logger or call into another runtime such as Python.
+        outputs = m_outputs;
+        name = m_name;
+    }
+
+    for (const auto& output : outputs)
+        output->write(level, name, msg);
 }
 
 static ref<Logger> s_logger;

--- a/src/sgl/core/logger.h
+++ b/src/sgl/core/logger.h
@@ -39,6 +39,7 @@ public:
     virtual ~LoggerOutput() = default;
 
     /// Write a log message.
+    /// Implementations must support calls from multiple threads.
     /// \param level The log level.
     /// \param module The module name.
     /// \param msg The message.

--- a/src/sgl/core/logger.h
+++ b/src/sgl/core/logger.h
@@ -33,13 +33,15 @@ enum class LogFrequency {
 };
 
 /// Abstract base class for logger outputs.
+///
+/// Implementations must be thread-safe. A LoggerOutput can be shared by multiple loggers, and
+/// write() may be called concurrently from multiple threads.
 class SGL_API LoggerOutput : public Object {
     SGL_OBJECT(LoggerOutput)
 public:
     virtual ~LoggerOutput() = default;
 
     /// Write a log message.
-    /// Implementations must support calls from multiple threads.
     /// \param level The log level.
     /// \param module The module name.
     /// \param msg The message.
@@ -59,6 +61,7 @@ public:
 
     // pytest's stdout/stderr capturing sometimes leads to bad file descriptor exceptions
     // when logging in sgl. By setting IGNORE_PRINT_EXCEPTION, we ignore those exceptions.
+    // Configure this flag before concurrent logging starts; concurrent mutation is not supported.
     static bool IGNORE_PRINT_EXCEPTION;
 
 private:
@@ -198,6 +201,8 @@ private:
     LogLevel m_level{LogLevel::info};
     std::string m_name;
 
+    // Access to the output registry is protected by m_mutex. log() takes a snapshot and calls
+    // LoggerOutput::write() after releasing the mutex, so output implementations must be thread-safe.
     std::set<ref<LoggerOutput>> m_outputs;
     std::set<std::string, std::less<>> m_messages;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ if(SGL_BUILD_TESTS)
         sgl/core/test_enum.cpp
         sgl/core/test_file_system_watcher.cpp
         sgl/core/test_lmdb_cache.cpp
+        sgl/core/test_logger.cpp
         sgl/core/test_maths.cpp
         sgl/core/test_memory_mapped_file.cpp
         sgl/core/test_object.cpp

--- a/tests/sgl/core/test_logger.cpp
+++ b/tests/sgl/core/test_logger.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "testing.h"
+#include "sgl/core/logger.h"
+
+using namespace sgl;
+
+TEST_SUITE_BEGIN("logger");
+
+class ReentrantLoggerOutput : public LoggerOutput {
+    SGL_OBJECT(ReentrantLoggerOutput)
+public:
+    explicit ReentrantLoggerOutput(Logger* logger)
+        : m_logger(logger)
+    {
+    }
+
+    void write(LogLevel level, const std::string_view module, const std::string_view msg) override
+    {
+        m_level = level;
+        m_module = module;
+        m_msg = msg;
+        m_logger_name = m_logger->name();
+        m_write_count++;
+    }
+
+    Logger* m_logger;
+    LogLevel m_level{LogLevel::none};
+    std::string m_module;
+    std::string m_msg;
+    std::string m_logger_name;
+    size_t m_write_count{0};
+};
+
+TEST_CASE("output callback can re-enter logger")
+{
+    auto logger = Logger::create(LogLevel::info, "test", false);
+    auto output = make_ref<ReentrantLoggerOutput>(logger.get());
+    logger->add_output(output);
+
+    logger->warn("message");
+
+    CHECK_EQ(output->m_write_count, 1);
+    CHECK_EQ(output->m_level, LogLevel::warn);
+    CHECK_EQ(output->m_module, "test");
+    CHECK_EQ(output->m_msg, "message");
+    CHECK_EQ(output->m_logger_name, "test");
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
Deadlock was caused when:
- MainT: has gil locked, tries to log, tries to lock logger mutex
- SecondT: tries to log something, locks logger mutex, python output exists so tries to take gil

This fixes it by releasing the log mutex before attempting to ouput, so outputs can safely take the gil. 