### PR TITLE
Torch tensors supply vector dims

### DIFF
--- a/slangpy/tests/slangpy_tests/test_torchintegration.py
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.py
@@ -4,9 +4,13 @@ import pytest
 import sys
 import numpy as np
 
-from slangpy import DeviceType, Device, Module, grid
+from slangpy import DeviceType, Device, Module, diff_pair, grid
 from slangpy.core.callsignature import ResolveException
-from slangpy.core.native import NativeCallDataCache, SignatureBuilder
+from slangpy.core.native import (
+    NativeCallDataCache,
+    NativeTorchTensorDiffPair,
+    SignatureBuilder,
+)
 from slangpy.testing import helpers
 
 try:
@@ -96,6 +100,34 @@ def test_torch_signature_shape_compatibility() -> None:
     assert _torch_signature(mixed) == "torch\n[D3,S6,V234]"
 
 
+def _diff_pair_signature(pair: NativeTorchTensorDiffPair) -> str:
+    cache = NativeCallDataCache()
+    signature = SignatureBuilder()
+    cache.get_value_signature(signature, pair)
+    return signature.str
+
+
+def test_diff_pair_signature_includes_marshaller_configuration() -> None:
+    float_value = torch.empty((8, 8), dtype=torch.float32, device="cuda")
+    half_value = torch.empty((8, 8), dtype=torch.float16, device="cuda")
+
+    signatures = {
+        _diff_pair_signature(NativeTorchTensorDiffPair(float_value, float_value, is_input=True)),
+        _diff_pair_signature(NativeTorchTensorDiffPair(float_value, float_value, is_input=False)),
+        _diff_pair_signature(NativeTorchTensorDiffPair(float_value, None, is_input=True)),
+        _diff_pair_signature(NativeTorchTensorDiffPair(None, float_value, is_input=False)),
+    }
+    assert len(signatures) == 4
+
+    float_grad_signature = _diff_pair_signature(
+        NativeTorchTensorDiffPair(None, float_value, is_input=False)
+    )
+    half_grad_signature = _diff_pair_signature(
+        NativeTorchTensorDiffPair(None, half_value, is_input=False)
+    )
+    assert float_grad_signature != half_grad_signature
+
+
 @pytest.mark.parametrize("device_type", DEVICE_TYPES)
 @pytest.mark.parametrize(
     "shape,dtype,expected",
@@ -139,6 +171,82 @@ def test_select_vector_overload_reuses_resolution_compatible_call_data(
 
     assert rgba_small_call_data == rgba_large_call_data
     assert rgba_small_call_data != rgb_call_data
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_diff_pair_vector_overload_uses_shape_specific_call_data(
+    device_type: DeviceType,
+) -> None:
+    module = load_test_module(device_type)
+    function = module.select_differentiable_vector_overload.bwds
+
+    float3 = torch.zeros((8, 16, 3), dtype=torch.float32, device="cuda")
+    float4 = torch.zeros((8, 16, 4), dtype=torch.float32, device="cuda")
+
+    float3_call_data = function.debug_build_call_data(
+        diff_pair(float3, torch.zeros_like(float3)),
+        _result=diff_pair(float3, torch.ones_like(float3)),
+    )
+    float4_call_data = function.debug_build_call_data(
+        diff_pair(float4, torch.zeros_like(float4)),
+        _result=diff_pair(float4, torch.ones_like(float4)),
+    )
+
+    assert float3_call_data != float4_call_data
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_diff_pair_scalar_call_data_is_rank_specific(
+    device_type: DeviceType,
+) -> None:
+    module = load_test_module(device_type)
+    function = module.differentiable_identity.bwds
+
+    rank1 = torch.zeros((8,), dtype=torch.float32, device="cuda")
+    rank2 = torch.zeros((8, 8), dtype=torch.float32, device="cuda")
+
+    rank1_call_data = function.debug_build_call_data(
+        diff_pair(rank1, torch.zeros_like(rank1)),
+        _result=diff_pair(rank1, torch.ones_like(rank1)),
+    )
+    rank2_call_data = function.debug_build_call_data(
+        diff_pair(rank2, torch.zeros_like(rank2)),
+        _result=diff_pair(rank2, torch.ones_like(rank2)),
+    )
+
+    assert rank1_call_data != rank2_call_data
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+@pytest.mark.parametrize(
+    "first_dtype,second_dtype",
+    [
+        (torch.float32, torch.float16),
+        (torch.float16, torch.float32),
+    ],
+    ids=["float_then_half", "half_then_float"],
+)
+def test_diff_pair_scalar_overload_uses_dtype_specific_call_data(
+    device_type: DeviceType,
+    first_dtype: torch.dtype,
+    second_dtype: torch.dtype,
+) -> None:
+    module = load_test_module(device_type)
+    function = module.select_differentiable_scalar_overload.bwds
+
+    first_value = torch.zeros((8, 8), dtype=first_dtype, device="cuda")
+    second_value = torch.zeros((8, 8), dtype=second_dtype, device="cuda")
+
+    first_call_data = function.debug_build_call_data(
+        diff_pair(first_value, torch.zeros_like(first_value)),
+        _result=diff_pair(first_value, torch.ones_like(first_value)),
+    )
+    second_call_data = function.debug_build_call_data(
+        diff_pair(second_value, torch.zeros_like(second_value)),
+        _result=diff_pair(second_value, torch.ones_like(second_value)),
+    )
+
+    assert first_call_data != second_call_data
 
 
 @pytest.mark.parametrize("device_type", DEVICE_TYPES)

--- a/slangpy/tests/slangpy_tests/test_torchintegration.py
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.py
@@ -5,6 +5,7 @@ import sys
 import numpy as np
 
 from slangpy import DeviceType, Device, Module, grid
+from slangpy.core.callsignature import ResolveException
 from slangpy.core.native import NativeCallDataCache, SignatureBuilder
 from slangpy.testing import helpers
 
@@ -61,12 +62,12 @@ def setup_bridge_mode(torch_bridge_mode: str):
 @pytest.mark.parametrize(
     "pair",
     [
-        (torch.empty((1,), dtype=torch.float32).cuda(), "D1,S6"),
-        (torch.empty((1,), dtype=torch.float32, requires_grad=True).cuda(), "D1,S6"),
-        (torch.empty((1,), dtype=torch.float16).cuda(), "D1,S5"),
-        (torch.empty((1,), dtype=torch.int32).cuda(), "D1,S3"),
-        (torch.empty((1,), dtype=torch.uint8).cuda(), "D1,S0"),
-        (torch.empty((1, 1, 1), dtype=torch.uint8).cuda(), "D3,S0"),
+        (torch.empty((1,), dtype=torch.float32).cuda(), "D1,S6,V1"),
+        (torch.empty((1,), dtype=torch.float32, requires_grad=True).cuda(), "D1,S6,V1"),
+        (torch.empty((1,), dtype=torch.float16).cuda(), "D1,S5,V1"),
+        (torch.empty((1,), dtype=torch.int32).cuda(), "D1,S3,V1"),
+        (torch.empty((1,), dtype=torch.uint8).cuda(), "D1,S0,V1"),
+        (torch.empty((1, 1, 1), dtype=torch.uint8).cuda(), "D3,S0,V111"),
     ],
 )
 def test_torch_signature(pair: tuple[torch.Tensor, str]):
@@ -74,6 +75,98 @@ def test_torch_signature(pair: tuple[torch.Tensor, str]):
     sig = SignatureBuilder()
     cd.get_value_signature(sig, pair[0])
     assert sig.str == f"torch\n[{pair[1]}]"
+
+
+def _torch_signature(tensor: torch.Tensor) -> str:
+    cache = NativeCallDataCache()
+    signature = SignatureBuilder()
+    cache.get_value_signature(signature, tensor)
+    return signature.str
+
+
+def test_torch_signature_shape_compatibility() -> None:
+    rgba_small = torch.empty((720, 1280, 4), dtype=torch.float32, device="cuda")
+    rgba_large = torch.empty((1080, 1920, 4), dtype=torch.float32, device="cuda")
+    rgb = torch.empty((720, 1280, 3), dtype=torch.float32, device="cuda")
+    mixed = torch.empty((2, 3, 4), dtype=torch.float32, device="cuda")
+
+    rgba_small_signature = _torch_signature(rgba_small)
+    assert rgba_small_signature == _torch_signature(rgba_large)
+    assert rgba_small_signature != _torch_signature(rgb)
+    assert _torch_signature(mixed) == "torch\n[D3,S6,V234]"
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+@pytest.mark.parametrize(
+    "shape,dtype,expected",
+    [
+        ((2, 3, 3), torch.float32, 3.0),
+        ((2, 3, 4), torch.float32, 4.0),
+        ((2, 3, 4), torch.float16, 8.0),
+    ],
+)
+def test_select_vector_overload(
+    device_type: DeviceType,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    expected: float,
+) -> None:
+    module = load_test_module(device_type)
+    value = torch.zeros(shape, dtype=dtype, device="cuda")
+
+    result = module.select_vector_overload(value)
+
+    assert isinstance(result, torch.Tensor)
+    assert result.shape == value.shape
+    assert result.dtype == value.dtype
+    assert torch.all(result == expected)
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_select_vector_overload_reuses_resolution_compatible_call_data(
+    device_type: DeviceType,
+) -> None:
+    module = load_test_module(device_type)
+    function = module.select_vector_overload.as_func()
+
+    rgba_small = torch.empty((8, 16, 4), dtype=torch.float32, device="cuda")
+    rgba_large = torch.empty((12, 20, 4), dtype=torch.float32, device="cuda")
+    rgb = torch.empty((8, 16, 3), dtype=torch.float32, device="cuda")
+
+    rgba_small_call_data = function.debug_build_call_data(rgba_small)
+    rgba_large_call_data = function.debug_build_call_data(rgba_large)
+    rgb_call_data = function.debug_build_call_data(rgb)
+
+    assert rgba_small_call_data == rgba_large_call_data
+    assert rgba_small_call_data != rgb_call_data
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+def test_select_vector_overload_with_explicit_mapping(device_type: DeviceType) -> None:
+    module = load_test_module(device_type)
+    value = torch.zeros((2, 3, 4), dtype=torch.float32, device="cuda")
+
+    result = module.select_vector_overload.map((1, 0))(value)
+
+    assert isinstance(result, torch.Tensor)
+    assert result.shape == (3, 2, 4)
+    assert torch.all(result == 4.0)
+
+
+@pytest.mark.parametrize("device_type", DEVICE_TYPES)
+@pytest.mark.parametrize("matrix_shape", [(2, 3), (3, 2)])
+def test_select_matrix_overload(
+    device_type: DeviceType,
+    matrix_shape: tuple[int, int],
+) -> None:
+    module = load_test_module(device_type)
+    value = torch.randn((5,) + matrix_shape, dtype=torch.float32, device="cuda")
+
+    result = module.select_matrix_overload(value)
+
+    assert isinstance(result, torch.Tensor)
+    assert result.shape == value.shape
+    assert torch.all(result == value)
 
 
 ADD_TESTS = [
@@ -163,7 +256,7 @@ def test_add_values_fail(
     a = torch.randn(extra_shape + val_shape, dtype=torch.float32, device=torch.device("cuda"))
     b = torch.randn(extra_shape + val_shape, dtype=torch.float32, device=torch.device("cuda"))
 
-    with pytest.raises(ValueError, match="does not match expected shape"):
+    with pytest.raises(ResolveException, match="does not match slang type"):
         res = module.add_vectors(a, b)
 
 

--- a/slangpy/tests/slangpy_tests/test_torchintegration.slang
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.slang
@@ -23,6 +23,31 @@ half4 select_vector_overload(half4 value) {
     return half4(8.0h);
 }
 
+[Differentiable]
+float differentiable_identity(float value) {
+    return value;
+}
+
+[Differentiable]
+float select_differentiable_scalar_overload(float value) {
+    return value;
+}
+
+[Differentiable]
+half select_differentiable_scalar_overload(half value) {
+    return value;
+}
+
+[Differentiable]
+float3 select_differentiable_vector_overload(float3 value) {
+    return value;
+}
+
+[Differentiable]
+float4 select_differentiable_vector_overload(float4 value) {
+    return value;
+}
+
 float2x3 select_matrix_overload(float2x3 value) {
     return value;
 }

--- a/slangpy/tests/slangpy_tests/test_torchintegration.slang
+++ b/slangpy/tests/slangpy_tests/test_torchintegration.slang
@@ -11,6 +11,26 @@ float3 add_vectors(float3 a, float3 b) {
     return a + b;
 }
 
+float3 select_vector_overload(float3 value) {
+    return float3(3.0);
+}
+
+float4 select_vector_overload(float4 value) {
+    return float4(4.0);
+}
+
+half4 select_vector_overload(half4 value) {
+    return half4(8.0h);
+}
+
+float2x3 select_matrix_overload(float2x3 value) {
+    return value;
+}
+
+float3x2 select_matrix_overload(float3x2 value) {
+    return value;
+}
+
 [Differentiable]
 vector<float,N> add_vectors_generic<let N:int>(vector<float,N> a, vector<float,N> b) {
     return a + b;

--- a/slangpy/tests/utils/test_torch_bridge.py
+++ b/slangpy/tests/utils/test_torch_bridge.py
@@ -10,6 +10,7 @@ the torch_bridge_mode fixture.
 
 import pytest
 import sys
+import ctypes
 
 try:
     import torch
@@ -67,6 +68,43 @@ class TestTorchBridgeAvailability:
         assert slangpy.is_torch_tensor("hello") is False
         assert slangpy.is_torch_tensor(42) is False
         # Note: None is not accepted by the function (nanobind rejects it)
+
+    def test_native_signature_buffer_size_contract(self):
+        """The native C API requires its fixed allowance plus the tensor rank."""
+        import slangpy_torch
+
+        class TensorBridgeAPI(ctypes.Structure):
+            _fields_ = [
+                ("api_version", ctypes.c_int),
+                ("info_struct_size", ctypes.c_size_t),
+                ("extract", ctypes.c_void_p),
+                ("is_tensor", ctypes.c_void_p),
+                ("get_signature", ctypes.c_void_p),
+            ]
+
+        api = ctypes.cast(
+            slangpy_torch.get_api_ptr(),
+            ctypes.POINTER(TensorBridgeAPI),
+        ).contents
+        get_signature = ctypes.PYFUNCTYPE(
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_char),
+            ctypes.c_size_t,
+        )(api.get_signature)
+
+        tensor = torch.empty((4, 3, 2), dtype=torch.float32)
+        required_size = 64 + tensor.ndim
+
+        buffer = ctypes.create_string_buffer(required_size - 1)
+        result = get_signature(ctypes.c_void_p(id(tensor)), buffer, len(buffer))
+        assert result == -5
+        assert buffer.value == b""
+
+        buffer = ctypes.create_string_buffer(required_size)
+        result = get_signature(ctypes.c_void_p(id(tensor)), buffer, len(buffer))
+        assert result == 0
+        assert buffer.value == b"[D3,S6,V432]"
 
 
 class TestTorchTensorExtraction:
@@ -225,11 +263,25 @@ class TestTorchTensorExtraction:
         assert arr[2] == 3.0
         assert arr[3] == 4.0
 
-    def test_extract_tensor_signature(self):
-        """Test extraction of tensor signature."""
-        t = torch.zeros(4, 4, dtype=torch.float32)
-        signature = slangpy.extract_torch_tensor_signature(t)
-        assert signature == "[D2,S6]"
+    @pytest.mark.parametrize(
+        "shape,expected",
+        [
+            ((), "[D0,S6,V]"),
+            ((1, 2, 3, 4), "[D4,S6,V1234]"),
+            ((0, 4), "[D2,S6,Vx4]"),
+            ((5, 1024, 3), "[D3,S6,Vxx3]"),
+            ((2,) * 16, "[D16,S6,V2222222222222222]"),
+        ],
+    )
+    def test_extract_tensor_signature(
+        self,
+        shape: tuple[int, ...],
+        expected: str,
+    ) -> None:
+        """Test bounded shape compatibility in tensor signatures."""
+        tensor = torch.empty(shape, dtype=torch.float32)
+        signature = slangpy.extract_torch_tensor_signature(tensor)
+        assert signature == expected
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/slangpy/tests/utils/test_torch_bridge.py
+++ b/slangpy/tests/utils/test_torch_bridge.py
@@ -71,7 +71,7 @@ class TestTorchBridgeAvailability:
 
     def test_native_signature_buffer_size_contract(self):
         """The native C API requires its fixed allowance plus the tensor rank."""
-        import slangpy_torch
+        slangpy_torch = pytest.importorskip("slangpy_torch")
 
         class TensorBridgeAPI(ctypes.Structure):
             _fields_ = [

--- a/slangpy/torchintegration/bridge_fallback.py
+++ b/slangpy/torchintegration/bridge_fallback.py
@@ -76,7 +76,11 @@ def extract_tensor_info(tensor: torch.Tensor) -> Dict[str, Any]:
 
 def get_signature(tensor: torch.Tensor) -> str:
     """
-    Get tensor signature string: "[Dn,Sm]" where n=ndim, m=scalar_type.
+    Get tensor signature string with bounded shape compatibility.
+
+    The format is "[Dn,Sm,V...]", where each tensor dimension contributes its
+    exact extent when it is 1 through 4, or "x" for zero and extents greater
+    than four.
 
     :param tensor: PyTorch tensor to get signature for.
     :return: Signature string.
@@ -85,7 +89,8 @@ def get_signature(tensor: torch.Tensor) -> str:
     if not isinstance(tensor, torch.Tensor):
         return None
     scalar_type = _SCALAR_TYPE_MAP.get(tensor.dtype, -1)
-    return f"[D{tensor.ndim},S{scalar_type}]"
+    shape_compatibility = "".join(str(size) if 1 <= size <= 4 else "x" for size in tensor.shape)
+    return f"[D{tensor.ndim},S{scalar_type},V{shape_compatibility}]"
 
 
 def get_current_cuda_stream(device_index: int) -> int:

--- a/slangpy/torchintegration/torchtensormarshall.py
+++ b/slangpy/torchintegration/torchtensormarshall.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 from slangpy import DataType, BufferUsage, TypeReflection
 import torch
 import torch.nn
@@ -55,6 +55,13 @@ _torch_to_data_type = {
     torch.bool: DataType.bool,
 }
 
+ShapeCompatibility = tuple[Optional[int], ...]
+
+
+def _shape_compatibility(shape: Sequence[int]) -> ShapeCompatibility:
+    """Classify dimensions without retaining resolution-dependent extents."""
+    return tuple(size if 1 <= size <= 4 else None for size in shape)
+
 
 def _slang_dtype_to_torch(slang_dtype: SlangType) -> Optional["torch.dtype"]:
     if isinstance(slang_dtype, ScalarType):
@@ -99,6 +106,7 @@ class TorchTensorMarshall(NativeTorchTensorMarshall):
         torch_dtype: torch.dtype,
         slang_dtype: SlangType,
         dims: int,
+        shape_compatibility: Optional[ShapeCompatibility],
         d_in: Optional["TorchTensorMarshall"],
         d_out: Optional["TorchTensorMarshall"],
     ):
@@ -141,6 +149,7 @@ class TorchTensorMarshall(NativeTorchTensorMarshall):
         self._layout = layout
         self._torch_dtype = torch_dtype
         self._slang_dtype = slang_dtype
+        self._shape_compatibility = shape_compatibility
 
         # Initialize base class (sets d_in, d_out, dims, writable etc in C++)
         super().__init__(
@@ -180,7 +189,19 @@ class TorchTensorMarshall(NativeTorchTensorMarshall):
         """Resolve types during binding phase."""
         if isinstance(bound_type, DiffTensorViewType):
             return self._resolve_difftensorview(context, bound_type)
+        if isinstance(bound_type, (VectorType, MatrixType)):
+            target_shape = bound_type.shape.as_tuple()
+            if not self._matches_trailing_shape(target_shape):
+                return []
         return spytc.resolve_types(self, context, bound_type)
+
+    def _matches_trailing_shape(self, target_shape: tuple[int, ...]) -> bool:
+        """Check that a concrete vector or matrix fits the source tensor."""
+        if self._shape_compatibility is None:
+            return True
+        if len(target_shape) > len(self._shape_compatibility):
+            return False
+        return self._shape_compatibility[-len(target_shape) :] == target_shape
 
     def _resolve_difftensorview(self, context: BindContext, bound_type: DiffTensorViewType):
         """Resolve DiffTensorView types for torch tensors."""
@@ -265,6 +286,7 @@ def create_torch_tensor_marshall(layout: SlangProgramLayout, value: Any):
             value.bind_context.call_dimensionality,
             None,
             None,
+            None,
         )
     elif isinstance(value, NativeTorchTensorDiffPair):
         # DiffPair: create marshall with gradient support
@@ -276,9 +298,11 @@ def create_torch_tensor_marshall(layout: SlangProgramLayout, value: Any):
         if primal is not None and not (isinstance(primal, type(None))):
             torch_dtype = primal.dtype
             dims = len(primal.shape)
+            shape_compatibility = _shape_compatibility(primal.shape)
         elif grad is not None and not (isinstance(grad, type(None))):
             torch_dtype = grad.dtype
             dims = len(grad.shape)
+            shape_compatibility = _shape_compatibility(grad.shape)
         else:
             raise ValueError("TorchTensorDiffPair must have at least primal or grad tensor")
 
@@ -296,6 +320,7 @@ def create_torch_tensor_marshall(layout: SlangProgramLayout, value: Any):
                 torch_dtype,
                 slang_dtype,
                 dims,
+                shape_compatibility,
                 None,
                 None,
             )
@@ -309,6 +334,7 @@ def create_torch_tensor_marshall(layout: SlangProgramLayout, value: Any):
             torch_dtype,
             slang_dtype,
             dims,
+            shape_compatibility,
             d_in,  # d_in - for reading gradients (output case)
             d_out,  # d_out - for writing gradients (input case)
         )
@@ -323,6 +349,7 @@ def create_torch_tensor_marshall(layout: SlangProgramLayout, value: Any):
             torch_dtype,
             slang_dtype,
             len(value.shape),
+            _shape_compatibility(value.shape),
             None,
             None,
         )

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -1071,6 +1071,24 @@ NativeCallDataCache::NativeCallDataCache()
     m_cache.reserve(1024);
 }
 
+static bool try_append_torch_tensor_signature(SignatureBuffer& builder, nb::handle tensor, std::string_view prefix)
+{
+    auto& bridge = TorchBridge::instance();
+    if (!bridge.is_available())
+        return false;
+
+    char buffer[TENSOR_BRIDGE_SIGNATURE_BUFFER_SIZE];
+    int result = bridge.get_signature(tensor, buffer, sizeof(buffer));
+    if (result == TENSOR_BRIDGE_SUCCESS) {
+        builder << prefix << buffer;
+        return true;
+    }
+    if (result == TENSOR_BRIDGE_ERROR_BUFFER_TOO_SMALL) {
+        throw std::runtime_error("Torch tensor signature exceeds the supported buffer size");
+    }
+    return false;
+}
+
 void NativeCallDataCache::get_value_signature(SignatureBuffer& builder, nb::handle o)
 {
     // Get python type.
@@ -1085,6 +1103,26 @@ void NativeCallDataCache::get_value_signature(SignatureBuffer& builder, nb::hand
             // Native cursor-writer entries own their cache key without requiring simple functional fallback metadata.
             // This is what lets Buffer/Texture keep bespoke marshalls while avoiding the Python signature path.
             writer->info->write_signature(builder, writer->value);
+            return;
+        }
+
+        const NativeTorchTensorDiffPair* diff_pair;
+        if (nb::try_cast<const NativeTorchTensorDiffPair*>(o, diff_pair)) {
+            bool has_primal = diff_pair->primal.is_valid() && !diff_pair->primal.is_none();
+            bool has_grad = diff_pair->grad.is_valid() && !diff_pair->grad.is_none();
+            if (!has_primal && !has_grad) {
+                throw nb::value_error("TorchTensorDiffPair must have at least primal or grad tensor");
+            }
+
+            builder << type_info.name() << "\n";
+            builder << (diff_pair->is_input ? "I1" : "I0");
+            builder << (has_primal ? "P1" : "P0");
+            builder << (has_grad ? "G1\n" : "G0\n");
+
+            nb::handle tensor = has_primal ? diff_pair->primal : diff_pair->grad;
+            if (!try_append_torch_tensor_signature(builder, tensor, "")) {
+                throw nb::value_error("TorchTensorDiffPair primal or grad must be a PyTorch tensor");
+            }
             return;
         }
 
@@ -1137,17 +1175,8 @@ void NativeCallDataCache::get_value_signature(SignatureBuffer& builder, nb::hand
     }
 
     // Fast path: Signature for pytorch tensors via torch bridge
-    if (TorchBridge::instance().is_available()) {
-        char buffer[TENSOR_BRIDGE_SIGNATURE_BUFFER_SIZE];
-        int result = TorchBridge::instance().get_signature(o, buffer, sizeof(buffer));
-        if (result == TENSOR_BRIDGE_SUCCESS) {
-            builder << "torch\n" << buffer;
-            return;
-        }
-        if (result == TENSOR_BRIDGE_ERROR_BUFFER_TOO_SMALL) {
-            throw std::runtime_error("Torch tensor signature exceeds the supported buffer size");
-        }
-    }
+    if (try_append_torch_tensor_signature(builder, o, "torch\n"))
+        return;
 
     // Add type name.
     auto type_name = nb::str(nb::getattr(o.type(), "__name__"));

--- a/src/slangpy_ext/utils/slangpy.cpp
+++ b/src/slangpy_ext/utils/slangpy.cpp
@@ -1138,10 +1138,14 @@ void NativeCallDataCache::get_value_signature(SignatureBuffer& builder, nb::hand
 
     // Fast path: Signature for pytorch tensors via torch bridge
     if (TorchBridge::instance().is_available()) {
-        char buffer[64];
-        if (TorchBridge::instance().get_signature(o, buffer, sizeof(buffer)) == 0) {
+        char buffer[TENSOR_BRIDGE_SIGNATURE_BUFFER_SIZE];
+        int result = TorchBridge::instance().get_signature(o, buffer, sizeof(buffer));
+        if (result == TENSOR_BRIDGE_SUCCESS) {
             builder << "torch\n" << buffer;
             return;
+        }
+        if (result == TENSOR_BRIDGE_ERROR_BUFFER_TOO_SMALL) {
+            throw std::runtime_error("Torch tensor signature exceeds the supported buffer size");
         }
     }
 

--- a/src/slangpy_ext/utils/torch_bridge.cpp
+++ b/src/slangpy_ext/utils/torch_bridge.cpp
@@ -74,7 +74,7 @@ nb::object extract_torch_tensor_info(nb::handle tensor)
 
 /// Extract PyTorch tensor signature string.
 /// @param tensor PyTorch tensor to get signature from.
-/// @return Signature string in format "[Dn,Sm]" where n=ndim, m=scalar_type.
+/// @return Signature string in format "[Dn,Sm,V...]" with bounded shape compatibility.
 /// @throws std::runtime_error if torch bridge is not available.
 /// @throws std::invalid_argument if object is not a PyTorch tensor.
 std::string extract_torch_tensor_signature(nb::handle tensor)
@@ -90,7 +90,7 @@ std::string extract_torch_tensor_signature(nb::handle tensor)
         throw std::invalid_argument("Object is not a PyTorch tensor");
     }
 
-    char buffer[64];
+    char buffer[TENSOR_BRIDGE_SIGNATURE_BUFFER_SIZE];
     int result = bridge.get_signature(tensor, buffer, sizeof(buffer));
     if (result != 0) {
         throw std::runtime_error(std::string("get_signature failed: ") + tensor_bridge_result_to_string(result));

--- a/src/slangpy_ext/utils/torch_bridge.h
+++ b/src/slangpy_ext/utils/torch_bridge.h
@@ -5,6 +5,7 @@
 #include "sgl/core/macros.h"
 
 #include "../nanobind.h"
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -569,11 +570,15 @@ private:
         init_python_fallback();
         auto res = m_py_get_signature(nb::handle(obj));
         if (res.is_none()) {
-            return -1;
+            return TENSOR_BRIDGE_ERROR_NOT_TENSOR;
         } else {
             std::string sig = nb::cast<std::string>(res);
-            snprintf(buffer, buffer_size, "%s", sig.c_str());
-            return 0;
+            if (!buffer)
+                return TENSOR_BRIDGE_ERROR_NULL_OUTPUT;
+            if (sig.size() + 1 > buffer_size)
+                return TENSOR_BRIDGE_ERROR_BUFFER_TOO_SMALL;
+            std::memcpy(buffer, sig.c_str(), sig.size() + 1);
+            return TENSOR_BRIDGE_SUCCESS;
         }
     }
 

--- a/src/slangpy_torch/tensor_bridge_api.h
+++ b/src/slangpy_torch/tensor_bridge_api.h
@@ -27,6 +27,11 @@ extern "C" {
 // Callers needing more dimensions can provide larger buffers
 #define TENSOR_BRIDGE_DEFAULT_DIMS 16
 
+// Tensor cache signatures require a fixed allowance for rank/dtype formatting,
+// plus one compatibility character per tensor dimension.
+#define TENSOR_BRIDGE_SIGNATURE_BASE_SIZE 64
+#define TENSOR_BRIDGE_SIGNATURE_BUFFER_SIZE 128
+
 // Device type codes (matching c10::DeviceType)
 #define TENSOR_BRIDGE_DEVICE_CPU 0
 #define TENSOR_BRIDGE_DEVICE_CUDA 1
@@ -139,9 +144,12 @@ typedef int (*TensorBridge_IsTensorFn)(void* py_tensor_obj);
 // Parameters:
 //   py_tensor_obj: PyObject* that should be a torch.Tensor
 //   buffer: Output buffer for signature string
-//   buffer_size: Size of output buffer in bytes
+//   buffer_size: Size of output buffer in bytes. Must be at least
+//                TENSOR_BRIDGE_SIGNATURE_BASE_SIZE + tensor rank.
 // Returns: TENSOR_BRIDGE_SUCCESS (0) on success, or a negative TensorBridgeResult on error
-// Format: "[Dn,Sm]" where n=ndim, m=scalar_type
+// Format: "[Dn,Sm,V...]" where n=ndim, m=scalar_type, and V contains one
+// shape compatibility character per dimension: '1' through '4' for those
+// exact extents, or 'x' for zero and extents greater than four.
 // This is faster than full extraction when only signature is needed (~15ns)
 typedef int (*TensorBridge_GetSignatureFn)(void* py_tensor_obj, char* buffer, size_t buffer_size);
 
@@ -190,7 +198,7 @@ typedef void* (*TensorBridge_CreateZerosLikeFn)(void* py_tensor_obj);
 // ============================================================================
 // Version info for ABI compatibility checking
 // ============================================================================
-#define TENSOR_BRIDGE_API_VERSION 7
+#define TENSOR_BRIDGE_API_VERSION 8
 
 typedef struct TensorBridgeAPI {
     int api_version;

--- a/src/slangpy_torch/torch_bridge_impl.cpp
+++ b/src/slangpy_torch/torch_bridge_impl.cpp
@@ -102,11 +102,18 @@ static inline char* fast_itoa(char* p, int val)
     return p;
 }
 
+static inline char shape_compatibility_char(int64_t extent)
+{
+    return extent >= 1 && extent <= 4 ? static_cast<char>('0' + extent) : 'x';
+}
+
 // Fast signature extraction - returns TENSOR_BRIDGE_SUCCESS on success
 extern "C" int tensor_bridge_get_signature(void* py_obj, char* buffer, size_t buffer_size)
 {
     if (!py_obj)
         return TENSOR_BRIDGE_ERROR_NULL_OBJECT;
+    if (!buffer)
+        return TENSOR_BRIDGE_ERROR_NULL_OUTPUT;
 
     PyObject* obj = static_cast<PyObject*>(py_obj);
     if (!THPVariable_Check(obj))
@@ -116,8 +123,14 @@ extern "C" int tensor_bridge_get_signature(void* py_obj, char* buffer, size_t bu
 
     int ndim = static_cast<int>(tensor.dim());
     int scalar_type = static_cast<int>(tensor.scalar_type());
+    // The fixed allowance comfortably covers punctuation, the null terminator,
+    // and decimal rank/dtype values. Each dimension then adds one classifier.
+    const size_t required_size = TENSOR_BRIDGE_SIGNATURE_BASE_SIZE + static_cast<size_t>(ndim);
+    if (buffer_size < required_size)
+        return TENSOR_BRIDGE_ERROR_BUFFER_TOO_SMALL;
 
-    // Format: "[Dn,Sm]" - compatible format, no snprintf
+    auto sizes = tensor.sizes();
+
     char* p = buffer;
     *p++ = '[';
     *p++ = 'D';
@@ -125,6 +138,10 @@ extern "C" int tensor_bridge_get_signature(void* py_obj, char* buffer, size_t bu
     *p++ = ',';
     *p++ = 'S';
     p = fast_itoa(p, scalar_type);
+    *p++ = ',';
+    *p++ = 'V';
+    for (int64_t extent : sizes)
+        *p++ = shape_compatibility_char(extent);
     *p++ = ']';
     *p = '\0';
 


### PR DESCRIPTION
This makes a couple of related changes:
- the cache signature of a torch tensor now includes enough information to distinctly identify which, if any, vector types each dimension is compatible with. i.e. it already had the scalar type, now for each dimensions it records a size of 1,2,3,4,N
- this is information is also no passed to the marshall, which allows it to uniquely identify at compile time what vector/matrix types (if any) a tensor is compatible with

Combined this allows us to use torch tensors in vector operations with overloaded functions. i.e. foo(float3 x) and foo(float4 x) can now be passed tensors:
- shape [5,6,3] -> foo(float3)
- shape [5,6,4] -> foo(float4)
- shape [5,6,5] -> fail

