### PR TITLE
Add Device::create_buffer_from_native_handle for buffer imports

### DIFF
--- a/slangpy/tests/device/test_buffer_from_native_handle.py
+++ b/slangpy/tests/device/test_buffer_from_native_handle.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import numpy as np
+
+import slangpy as spy
+from slangpy.testing import helpers
+
+
+# Native handle type accepted by Device.create_buffer_from_native_handle, per device type.
+# Device types missing from this table have no buffer import in slang-rhi.
+NATIVE_BUFFER_HANDLE_TYPES = {
+    spy.DeviceType.d3d12: spy.NativeHandleType.D3D12Resource,
+    spy.DeviceType.vulkan: spy.NativeHandleType.VkBuffer,
+    spy.DeviceType.metal: spy.NativeHandleType.MTLBuffer,
+    spy.DeviceType.cuda: spy.NativeHandleType.CUdeviceptr,
+    spy.DeviceType.wgpu: spy.NativeHandleType.WGPUBuffer,
+}
+
+BUFFER_USAGE = spy.BufferUsage.shader_resource | spy.BufferUsage.unordered_access
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_buffer_from_native_handle(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+
+    data = np.random.randint(0, 0xFFFFFFFF, size=1024, dtype=np.uint32)
+    buffer = device.create_buffer(usage=BUFFER_USAGE, data=data)
+    desc = {"size": buffer.size, "usage": BUFFER_USAGE}
+    handle = buffer.native_handle
+
+    if device_type not in NATIVE_BUFFER_HANDLE_TYPES:
+        with pytest.raises(RuntimeError, match="not implemented"):
+            device.create_buffer_from_native_handle(desc, handle)
+        return
+
+    assert handle
+    assert handle.type == NATIVE_BUFFER_HANDLE_TYPES[device_type]
+
+    # Wrapping the handle must alias the original allocation, not copy it.
+    imported = device.create_buffer_from_native_handle(desc, handle)
+    assert imported.size == buffer.size
+    assert imported.native_handle.value == handle.value
+    assert np.all(imported.to_numpy().view(np.uint32) == data)
+
+    # Writes through the imported buffer are visible through the original one.
+    new_data = np.random.randint(0, 0xFFFFFFFF, size=1024, dtype=np.uint32)
+    encoder = device.create_command_encoder()
+    encoder.upload_buffer_data(imported, 0, new_data)
+    device.submit_command_buffer(encoder.finish())
+    assert np.all(buffer.to_numpy().view(np.uint32) == new_data)
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_buffer_from_native_handle_invalid(device_type: spy.DeviceType):
+    device = helpers.get_device(device_type)
+
+    if device_type not in NATIVE_BUFFER_HANDLE_TYPES:
+        pytest.skip(f"{device_type} cannot import native buffers")
+
+    data = np.random.randint(0, 0xFFFFFFFF, size=1024, dtype=np.uint32)
+    buffer = device.create_buffer(usage=BUFFER_USAGE, data=data)
+    desc = {"size": buffer.size, "usage": BUFFER_USAGE}
+
+    # A default constructed handle carries no resource.
+    with pytest.raises(RuntimeError, match="Invalid native handle"):
+        device.create_buffer_from_native_handle(desc, spy.NativeHandle())
+
+    # The device handle is valid, but it is not a buffer.
+    with pytest.raises(RuntimeError, match="Expected a native handle of type"):
+        device.create_buffer_from_native_handle(desc, device.native_handles[0])
+
+
+@pytest.mark.parametrize("device_type", [spy.DeviceType.cuda])
+def test_native_handle_from_cuda_device_ptr(device_type: spy.DeviceType):
+    if device_type not in helpers.DEFAULT_DEVICE_TYPES:
+        pytest.skip("CUDA is not available")
+    device = helpers.get_device(device_type)
+
+    buffer = device.create_buffer(size=1024, usage=BUFFER_USAGE)
+
+    # On CUDA a buffer handle is nothing but the device pointer, so a handle built from a raw
+    # pointer (e.g. torch.Tensor.data_ptr()) is interchangeable with the buffer's own handle.
+    handle = spy.NativeHandle.from_cuda_device_ptr(buffer.device_address)
+    assert handle.type == spy.NativeHandleType.CUdeviceptr
+    assert handle == buffer.native_handle
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -579,6 +579,11 @@ ref<Buffer> Device::create_buffer(BufferDesc desc)
     return make_ref<Buffer>(ref<Device>(this), std::move(desc));
 }
 
+ref<Buffer> Device::create_buffer_from_native_handle(BufferDesc desc, NativeHandle handle)
+{
+    return make_ref<Buffer>(ref<Device>(this), std::move(desc), handle);
+}
+
 ref<BufferView> Device::create_buffer_view(Buffer* buffer, BufferViewDesc desc)
 {
     return make_ref<BufferView>(ref<Device>(this), ref<Buffer>(buffer), std::move(desc));

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -415,6 +415,19 @@ public:
      */
     ref<Buffer> create_buffer(BufferDesc desc);
 
+    /**
+     * \brief Create a new buffer wrapping an existing native buffer without copying.
+     *
+     * The expected handle type depends on the device type: \c D3D12Resource on D3D12,
+     * \c VkBuffer on Vulkan, \c MTLBuffer on Metal, \c CUdeviceptr on CUDA and
+     * \c WGPUBuffer on WGPU.
+     *
+     * \param desc Buffer description. The size must not exceed the native allocation.
+     * \param handle Native buffer handle to wrap.
+     * \return New buffer object.
+     */
+    ref<Buffer> create_buffer_from_native_handle(BufferDesc desc, NativeHandle handle);
+
     /// Create a new buffer view.
     ref<BufferView> create_buffer_view(Buffer* buffer, BufferViewDesc desc);
 

--- a/src/sgl/device/native_handle_traits.h
+++ b/src/sgl/device/native_handle_traits.h
@@ -78,6 +78,7 @@ SGL_NATIVE_HANDLE(VkSampler, NativeHandleType::VkSampler);
 #endif // SGL_HAS_VULKAN
 
 SGL_NATIVE_HANDLE_32(CUdevice, NativeHandleType::CUdevice);
+SGL_NATIVE_HANDLE(CUdeviceptr, NativeHandleType::CUdeviceptr);
 SGL_NATIVE_HANDLE(CUcontext, NativeHandleType::CUcontext);
 SGL_NATIVE_HANDLE(CUstream, NativeHandleType::CUstream);
 

--- a/src/sgl/device/resource.cpp
+++ b/src/sgl/device/resource.cpp
@@ -63,63 +63,94 @@ NativeHandle Resource::native_handle() const
 // Buffer
 // ----------------------------------------------------------------------------
 
-Buffer::Buffer(ref<Device> device, BufferDesc desc)
-    : Resource(std::move(device))
-    , m_desc(std::move(desc))
+inline void process_buffer_desc(BufferDesc& desc)
 {
-    SGL_CHECK(m_desc.size == 0 || m_desc.element_count == 0, "Only one of 'size' or 'element_count' must be set.");
+    SGL_CHECK(desc.size == 0 || desc.element_count == 0, "Only one of 'size' or 'element_count' must be set.");
     SGL_CHECK(
-        m_desc.struct_size == 0 || m_desc.resource_type_layout == nullptr,
+        desc.struct_size == 0 || desc.resource_type_layout == nullptr,
         "Only one of 'struct_size' or 'resource_type_layout' must be set."
     );
 
     // Derive buffer size from initial data.
-    if (m_desc.size == 0 && m_desc.element_count == 0 && m_desc.data && m_desc.data_size > 0)
-        m_desc.size = m_desc.data_size;
+    if (desc.size == 0 && desc.element_count == 0 && desc.data && desc.data_size > 0)
+        desc.size = desc.data_size;
 
     // Derive struct size from the resource type layout.
-    if (m_desc.resource_type_layout) {
+    if (desc.resource_type_layout) {
         SGL_CHECK(
-            m_desc.resource_type_layout->kind() == TypeReflection::Kind::resource
-                && m_desc.resource_type_layout->type()->resource_shape()
+            desc.resource_type_layout->kind() == TypeReflection::Kind::resource
+                && desc.resource_type_layout->type()->resource_shape()
                     == TypeReflection::ResourceShape::structured_buffer,
             "Struct type layout must describe a structured buffer."
         );
-        m_desc.struct_size = m_desc.resource_type_layout->element_type_layout()->stride();
-        m_desc.resource_type_layout = nullptr;
+        desc.struct_size = desc.resource_type_layout->element_type_layout()->stride();
+        desc.resource_type_layout = nullptr;
     }
 
     // Derive buffer size from element count and struct size.
     SGL_CHECK(
-        m_desc.element_count == 0 || m_desc.struct_size > 0,
+        desc.element_count == 0 || desc.struct_size > 0,
         "'element_count' can only be used with 'struct_size' or 'resource_type_layout' set."
     );
-    if (m_desc.element_count > 0) {
-        m_desc.size = m_desc.element_count * m_desc.struct_size;
-        m_desc.element_count = 0;
+    if (desc.element_count > 0) {
+        desc.size = desc.element_count * desc.struct_size;
+        desc.element_count = 0;
     }
 
     // TODO check init_data size
-    SGL_ASSERT(m_desc.size > 0);
+    SGL_ASSERT(desc.size > 0);
 
     SGL_CHECK(
-        (m_desc.data == nullptr && m_desc.data_size == 0) || m_desc.data_size == m_desc.size,
+        (desc.data == nullptr && desc.data_size == 0) || desc.data_size == desc.size,
         "Invalid data size (got {} bytes, expected {} bytes)",
-        m_desc.data_size,
-        m_desc.size
+        desc.data_size,
+        desc.size
     );
+}
 
+inline rhi::BufferDesc to_rhi_buffer_desc(const BufferDesc& desc)
+{
     rhi::BufferDesc rhi_desc;
-    rhi_desc.size = static_cast<uint64_t>(m_desc.size);
-    rhi_desc.elementSize = static_cast<uint32_t>(m_desc.struct_size);
-    rhi_desc.format = static_cast<rhi::Format>(m_desc.format);
-    rhi_desc.memoryType = static_cast<rhi::MemoryType>(m_desc.memory_type);
-    rhi_desc.usage = static_cast<rhi::BufferUsage>(m_desc.usage);
-    rhi_desc.defaultState = static_cast<rhi::ResourceState>(m_desc.default_state);
-    rhi_desc.label = m_desc.label.empty() ? nullptr : m_desc.label.c_str();
+    rhi_desc.size = static_cast<uint64_t>(desc.size);
+    rhi_desc.elementSize = static_cast<uint32_t>(desc.struct_size);
+    rhi_desc.format = static_cast<rhi::Format>(desc.format);
+    rhi_desc.memoryType = static_cast<rhi::MemoryType>(desc.memory_type);
+    rhi_desc.usage = static_cast<rhi::BufferUsage>(desc.usage);
+    rhi_desc.defaultState = static_cast<rhi::ResourceState>(desc.default_state);
+    rhi_desc.label = desc.label.empty() ? nullptr : desc.label.c_str();
 
-    if (m_desc.memory_type == MemoryType::device_local)
+    if (desc.memory_type == MemoryType::device_local)
         rhi_desc.usage |= rhi::BufferUsage::CopySource | rhi::BufferUsage::CopyDestination;
+
+    return rhi_desc;
+}
+
+/// Returns the native handle type expected when importing a buffer on the given device type.
+/// Returns NativeHandleType::undefined for backends that don't implement buffer import.
+inline NativeHandleType native_buffer_handle_type(DeviceType device_type)
+{
+    switch (device_type) {
+    case DeviceType::d3d12:
+        return NativeHandleType::D3D12Resource;
+    case DeviceType::vulkan:
+        return NativeHandleType::VkBuffer;
+    case DeviceType::metal:
+        return NativeHandleType::MTLBuffer;
+    case DeviceType::cuda:
+        return NativeHandleType::CUdeviceptr;
+    case DeviceType::wgpu:
+        return NativeHandleType::WGPUBuffer;
+    default:
+        return NativeHandleType::undefined;
+    }
+}
+
+Buffer::Buffer(ref<Device> device, BufferDesc desc)
+    : Resource(std::move(device))
+    , m_desc(std::move(desc))
+{
+    process_buffer_desc(m_desc);
+    rhi::BufferDesc rhi_desc = to_rhi_buffer_desc(m_desc);
 
     SLANG_RHI_CALL(m_device->rhi_device()->createBuffer(rhi_desc, nullptr, m_rhi_buffer.writeRef()), m_device);
 
@@ -130,6 +161,38 @@ Buffer::Buffer(ref<Device> device, BufferDesc desc)
     // Clear initial data fields in desc.
     m_desc.data = nullptr;
     m_desc.data_size = 0;
+}
+
+Buffer::Buffer(ref<Device> device, BufferDesc desc, NativeHandle handle)
+    : Resource(std::move(device))
+    , m_desc(std::move(desc))
+{
+    NativeHandleType expected_handle_type = native_buffer_handle_type(m_device->type());
+    SGL_CHECK(
+        expected_handle_type != NativeHandleType::undefined,
+        "Creating a buffer from a native handle is not implemented for {} devices.",
+        m_device->type()
+    );
+    SGL_CHECK(handle.is_valid(), "Invalid native handle.");
+    SGL_CHECK(
+        handle.type() == expected_handle_type,
+        "Expected a native handle of type {} on a {} device (got {}).",
+        expected_handle_type,
+        m_device->type(),
+        handle.type()
+    );
+    SGL_CHECK(
+        m_desc.data == nullptr && m_desc.data_size == 0,
+        "Initial data cannot be uploaded when wrapping an existing native buffer."
+    );
+
+    process_buffer_desc(m_desc);
+    rhi::BufferDesc rhi_desc = to_rhi_buffer_desc(m_desc);
+
+    SLANG_RHI_CALL(
+        m_device->rhi_device()->createBufferFromNativeHandle(handle.to_rhi(), rhi_desc, m_rhi_buffer.writeRef()),
+        m_device
+    );
 }
 
 Buffer::~Buffer()

--- a/src/sgl/device/resource.h
+++ b/src/sgl/device/resource.h
@@ -295,6 +295,8 @@ class SGL_API Buffer : public Resource {
 public:
     Buffer(ref<Device> device, BufferDesc desc);
 
+    Buffer(ref<Device> device, BufferDesc desc, NativeHandle handle);
+
     ~Buffer();
 
     virtual void _release_rhi_resources() override { m_rhi_buffer.setNull(); }

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -713,6 +713,14 @@ SGL_PY_EXPORT(device_device)
     device.def("create_buffer", &Device::create_buffer, "desc"_a, D(Device, create_buffer));
 
     device.def(
+        "create_buffer_from_native_handle",
+        &Device::create_buffer_from_native_handle,
+        "desc"_a,
+        "handle"_a,
+        D(Device, create_buffer_from_native_handle)
+    );
+
+    device.def(
         "create_texture",
         [](Device* self,
            TextureType type,

--- a/src/slangpy_ext/device/native_handle.cpp
+++ b/src/slangpy_ext/device/native_handle.cpp
@@ -34,5 +34,13 @@ SGL_PY_EXPORT(device_native_handle)
                 return NativeHandle(reinterpret_cast<CUstream>(stream));
             },
             "stream"_a
+        )
+        .def_static(
+            "from_cuda_device_ptr",
+            [](uint64_t device_ptr)
+            {
+                return NativeHandle(static_cast<CUdeviceptr>(device_ptr));
+            },
+            "device_ptr"_a
         );
 }

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -66,6 +66,8 @@ static const char *__doc_formatter_format = R"doc()doc";
 
 static const char *__doc_formatter_format_2 = R"doc()doc";
 
+static const char *__doc_rhi_ITaskPool = R"doc()doc";
+
 static const char *__doc_sgl_AccelerationStructure = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructure_2 = R"doc()doc";
@@ -1354,6 +1356,8 @@ static const char *__doc_sgl_BufferView_to_string = R"doc()doc";
 static const char *__doc_sgl_BufferView_write_to_cursor = R"doc(Bind a nullable buffer view value to a shader cursor.)doc";
 
 static const char *__doc_sgl_Buffer_Buffer = R"doc()doc";
+
+static const char *__doc_sgl_Buffer_Buffer_2 = R"doc()doc";
 
 static const char *__doc_sgl_Buffer_class_name = R"doc()doc";
 
@@ -3095,6 +3099,24 @@ Parameter ``data``:
 
 Parameter ``data_size``:
     Size of the initial data in bytes.
+
+Returns:
+    New buffer object.)doc";
+
+static const char *__doc_sgl_Device_create_buffer_from_native_handle =
+R"doc(Create a new buffer wrapping an existing native buffer without
+copying.
+
+The expected handle type depends on the device type: ``D3D12Resource``
+on D3D12, ``VkBuffer`` on Vulkan, ``MTLBuffer`` on Metal,
+``CUdeviceptr`` on CUDA and ``WGPUBuffer`` on WGPU.
+
+Parameter ``desc``:
+    Buffer description. The size must not exceed the native
+    allocation.
+
+Parameter ``handle``:
+    Native buffer handle to wrap.
 
 Returns:
     New buffer object.)doc";
@@ -5886,6 +5908,8 @@ static const char *__doc_sgl_NativeHandleTrait_21 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_22 = R"doc()doc";
 
+static const char *__doc_sgl_NativeHandleTrait_23 = R"doc()doc";
+
 static const char *__doc_sgl_NativeHandleTrait_pack = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_pack_2 = R"doc()doc";
@@ -5926,6 +5950,8 @@ static const char *__doc_sgl_NativeHandleTrait_pack_19 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_pack_20 = R"doc()doc";
 
+static const char *__doc_sgl_NativeHandleTrait_pack_21 = R"doc()doc";
+
 static const char *__doc_sgl_NativeHandleTrait_unpack = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_unpack_2 = R"doc()doc";
@@ -5965,6 +5991,8 @@ static const char *__doc_sgl_NativeHandleTrait_unpack_18 = R"doc()doc";
 static const char *__doc_sgl_NativeHandleTrait_unpack_19 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_unpack_20 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_21 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleType = R"doc()doc";
 
@@ -14164,6 +14192,10 @@ static const char *__doc_sgl_thread_blocked_range_m_block_size = R"doc()doc";
 
 static const char *__doc_sgl_thread_blocked_range_m_end = R"doc()doc";
 
+static const char *__doc_sgl_thread_current_thread_id =
+R"doc(Return the nanothread worker ID for the current thread, or zero for a
+non-worker thread.)doc";
+
 static const char *__doc_sgl_thread_do_async =
 R"doc(Run a function asynchronously in a new task. See nanothread
 documentation on `task_submit_dep` for details.
@@ -14244,6 +14276,8 @@ Parameter ``parents``:
 
 Returns:
     The new task.)doc";
+
+static const char *__doc_sgl_thread_rhi_task_pool = R"doc(Get the nanothread-backed task pool installed in slang-rhi.)doc";
 
 static const char *__doc_sgl_thread_static_init = R"doc()doc";
 


### PR DESCRIPTION
Wrap an existing native Buffer without copying, so a buffer allocated by another framework (torch) can be bound directly instead of round-tripping through host memory.