### PR TITLE
Improve persistent cache robustness

### DIFF
--- a/src/sgl/core/lmdb_cache.cpp
+++ b/src/sgl/core/lmdb_cache.cpp
@@ -9,6 +9,8 @@
 
 #include <lmdb.h>
 
+#include <memory>
+
 // Brief overview on how the cache works:
 // - The cache is backed by an LMDB database stored on disk.
 // - There are two databases:
@@ -464,6 +466,10 @@ LMDBCache::DB LMDBCache::open_db(const std::filesystem::path& path, const Option
 
     if (int result = mdb_env_create(&db.env); result != MDB_SUCCESS)
         LMDB_THROW("Failed to create environment", result);
+
+    // Close the environment if initialization fails before ownership is transferred to the returned DB.
+    std::unique_ptr<MDB_env, decltype(&mdb_env_close)> env(db.env, &mdb_env_close);
+
     if (int result = mdb_env_set_maxreaders(db.env, 126); result != MDB_SUCCESS)
         LMDB_THROW("Failed to set max readers", result);
     if (int result = mdb_env_set_maxdbs(db.env, 2); result != MDB_SUCCESS)
@@ -492,6 +498,9 @@ LMDBCache::DB LMDBCache::open_db(const std::filesystem::path& path, const Option
             .db = db,
         }
     );
+
+    // Release ownership of the environment since it is now managed by the returned DB.
+    env.release();
 
     return db;
 }

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -116,8 +116,16 @@ Device::Device(const DeviceDesc& desc)
 
     // Setup shader cache.
     if (!m_shader_cache_path.empty()) {
-        m_persistent_cache
-            = make_ref<PersistentCache>(m_shader_cache_path / "rhi", m_desc.shader_cache_size, m_cache_writer);
+        try {
+            m_persistent_cache
+                = make_ref<PersistentCache>(m_shader_cache_path / "rhi", m_desc.shader_cache_size, m_cache_writer);
+        } catch (const std::exception& e) {
+            log_warn(
+                "Failed to initialize persistent shader cache in \"{}\": {}. Continuing without it.",
+                m_shader_cache_path,
+                e.what()
+            );
+        }
     }
 
     // Invalidate CUDA interop if using CUDA

--- a/src/sgl/device/persistent_cache.cpp
+++ b/src/sgl/device/persistent_cache.cpp
@@ -5,10 +5,14 @@
 #include "sgl/core/error.h"
 #include "sgl/core/logger.h"
 #include "sgl/core/lmdb_cache.h"
+#include "sgl/core/platform.h"
 #include "sgl/device/cache_writer.h"
 
+#include <chrono>
 #include <cstring>
 #include <memory>
+#include <string>
+#include <thread>
 #include <vector>
 
 namespace sgl {
@@ -29,25 +33,33 @@ PersistentCache::PersistentCache(const std::filesystem::path& path, size_t max_s
     LMDBCache::Options options{
         .max_size = max_size,
     };
-    const int MAX_ATTEMPTS = 3;
+    constexpr int MAX_ATTEMPTS = 6;
+    constexpr auto initial_retry_delay = std::chrono::milliseconds(20);
+    const auto retry_jitter = std::chrono::milliseconds(platform::current_process_id() % 17);
+    std::string last_error;
     for (int attempt = 1; attempt <= MAX_ATTEMPTS; ++attempt) {
         try {
             m_cache = make_ref<LMDBCache>(m_path, options);
             break;
         } catch (const std::exception& e) {
-            log_error("Failed to open cache in \"{}\" (attempt {}/{}): {} ", m_path, attempt, MAX_ATTEMPTS, e.what());
-            if (attempt < MAX_ATTEMPTS) {
-                // Try deleting the cache directory so next attempt creates a new cache.
-                std::error_code ec;
-                std::filesystem::remove_all(m_path, ec);
-                if (ec) {
-                    log_warn("Failed to delete cache directory \"{}\": {}", m_path, ec.message());
-                }
-            }
+            last_error = e.what();
+            if (attempt == MAX_ATTEMPTS)
+                break;
+
+            const auto retry_delay = initial_retry_delay * (1 << (attempt - 1)) + retry_jitter;
+            log_warn(
+                "Failed to open cache in \"{}\" (attempt {}/{}): {}; retrying in {} ms.",
+                m_path,
+                attempt,
+                MAX_ATTEMPTS,
+                e.what(),
+                retry_delay.count()
+            );
+            std::this_thread::sleep_for(retry_delay);
         }
     }
     if (!m_cache) {
-        SGL_THROW("Failed to open cache in \"{}\" after {} attempts!", m_path, MAX_ATTEMPTS);
+        SGL_THROW("Failed to open cache in \"{}\" after {} attempts: {}", m_path, MAX_ATTEMPTS, last_error);
     }
 }
 

--- a/tests/sgl/device/test_device.cpp
+++ b/tests/sgl/device/test_device.cpp
@@ -6,6 +6,9 @@
 #include "sgl/device/resource.h"
 #include "sgl/device/shader.h"
 
+#include <array>
+#include <fstream>
+
 using namespace sgl;
 
 TEST_SUITE_BEGIN("device");
@@ -54,6 +57,44 @@ TEST_CASE("enumerate_adapters")
 TEST_CASE_GPU("init")
 {
     CHECK(ctx.device);
+}
+
+TEST_CASE_GPU("invalid_shader_cache_is_disabled_without_deleting_cache")
+{
+    const std::filesystem::path cache_dir
+        = testing::get_case_temp_directory() / std::to_string(static_cast<uint32_t>(ctx.device->type()));
+    const std::filesystem::path rhi_cache_dir = cache_dir / "rhi";
+    const std::filesystem::path data_path = rhi_cache_dir / "data.mdb";
+    const std::filesystem::path marker_path = rhi_cache_dir / "marker";
+    std::filesystem::create_directories(rhi_cache_dir);
+
+    std::array<uint8_t, 8192> invalid_data;
+    invalid_data.fill(0xff);
+    {
+        std::ofstream data_file(data_path, std::ios::binary);
+        REQUIRE(data_file);
+        data_file.write(
+            reinterpret_cast<const char*>(invalid_data.data()),
+            static_cast<std::streamsize>(invalid_data.size())
+        );
+        REQUIRE(data_file.good());
+    }
+    {
+        std::ofstream marker_file(marker_path);
+        REQUIRE(marker_file);
+        marker_file << "keep";
+        REQUIRE(marker_file.good());
+    }
+
+    DeviceDesc desc = ctx.device->desc();
+    desc.shader_cache_path = cache_dir;
+    ref<Device> device;
+    CHECK_NOTHROW(device = Device::create(desc));
+    REQUIRE(device);
+    CHECK(device->shader_cache_stats().entry_count == 0);
+    CHECK(std::filesystem::exists(marker_path));
+    CHECK(std::filesystem::file_size(data_path) == invalid_data.size());
+    device->close();
 }
 
 TEST_CASE_GPU("close_all_devices_keeps_snapshot_alive")


### PR DESCRIPTION
- Use RAII for DB handle when creating LMDB database
- Make persistent cache creation more robust through exponential backoff when retrying
- Warn if shader cache cannot be created/initialized and run without it
- Remove deleting of the shader cache if it fails to initialize as this was not save across processes