### PR TITLE
Forward CUDA downstream compiler arguments

### DIFF
--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -320,7 +320,7 @@ public:
     /// Check if the device supports a given feature.
     bool has_feature(Feature feature) const;
 
-    /// List of slang capabilities supported by the device.
+    /// List of capabilities reported by the device backend.
     const std::vector<std::string>& capabilities() const { return m_capabilities; }
 
     /// Check if the device supports a given capability.

--- a/src/sgl/device/shader.cpp
+++ b/src/sgl/device/shader.cpp
@@ -377,10 +377,13 @@ void SlangSession::create_session(SlangSessionBuild& build)
     session_options.add(slang::CompilerOptionName::DebugInformation, int(options.debug_info));
     session_options.add(slang::CompilerOptionName::Optimization, int(options.optimization));
 
-    // Set downstream arguments.
+    // Set downstream arguments. Only DXC (D3D12) and NVRTC (CUDA) consume pass-through arguments.
     if (device_type == DeviceType::d3d12) {
         for (const auto& arg : options.downstream_args)
             session_options.add(slang::CompilerOptionName::DownstreamArgs, "dxc", arg);
+    } else if (device_type == DeviceType::cuda) {
+        for (const auto& arg : options.downstream_args)
+            session_options.add(slang::CompilerOptionName::DownstreamArgs, "nvrtc", arg);
     }
 
     // Set downstream argument for optix include path.
@@ -1630,6 +1633,9 @@ void ShaderProgram::link(SlangSessionBuild& build_data) const
             if (device->type() == DeviceType::d3d12) {
                 for (const auto& arg : *link_options.downstream_args)
                     link_option_entries.add(slang::CompilerOptionName::DownstreamArgs, "dxc", arg);
+            } else if (device->type() == DeviceType::cuda) {
+                for (const auto& arg : *link_options.downstream_args)
+                    link_option_entries.add(slang::CompilerOptionName::DownstreamArgs, "nvrtc", arg);
             }
         }
         if (link_options.dump_intermediates)

--- a/src/sgl/device/shader.h
+++ b/src/sgl/device/shader.h
@@ -184,6 +184,8 @@ struct SlangCompilerOptions {
     SlangOptimizationLevel optimization{SlangOptimizationLevel::default_};
 
     /// Specifies a list of additional arguments to be passed to the downstream compiler.
+    /// Only forwarded to downstream compilers that accept pass-through arguments: DXC (D3D12)
+    /// and NVRTC (CUDA). Ignored for other backends.
     std::vector<std::string> downstream_args;
 
     /// When set will dump the intermediate source output.
@@ -209,6 +211,8 @@ struct SlangLinkOptions {
     std::optional<SlangOptimizationLevel> optimization;
 
     /// Specifies a list of additional arguments to be passed to the downstream compiler.
+    /// Only forwarded to downstream compilers that accept pass-through arguments: DXC (D3D12)
+    /// and NVRTC (CUDA). Ignored for other backends.
     std::optional<std::vector<std::string>> downstream_args;
 
     /// When set will dump the intermediate source output.

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -3023,7 +3023,7 @@ static const char *__doc_sgl_Device_builtin_layout = R"doc(Return the cached ref
 
 static const char *__doc_sgl_Device_cache_writer = R"doc()doc";
 
-static const char *__doc_sgl_Device_capabilities = R"doc(List of slang capabilities supported by the device.)doc";
+static const char *__doc_sgl_Device_capabilities = R"doc(List of capabilities reported by the device backend.)doc";
 
 static const char *__doc_sgl_Device_class_name = R"doc()doc";
 
@@ -8225,7 +8225,9 @@ static const char *__doc_sgl_SlangCompilerOptions_disable_warnings = R"doc(Speci
 
 static const char *__doc_sgl_SlangCompilerOptions_downstream_args =
 R"doc(Specifies a list of additional arguments to be passed to the
-downstream compiler.)doc";
+downstream compiler. Only forwarded to downstream compilers that accept
+pass-through arguments: DXC (D3D12) and NVRTC (CUDA). Ignored for other
+backends.)doc";
 
 static const char *__doc_sgl_SlangCompilerOptions_dump_intermediates = R"doc(When set will dump the intermediate source output.)doc";
 
@@ -8378,7 +8380,9 @@ code.)doc";
 
 static const char *__doc_sgl_SlangLinkOptions_downstream_args =
 R"doc(Specifies a list of additional arguments to be passed to the
-downstream compiler.)doc";
+downstream compiler. Only forwarded to downstream compilers that accept
+pass-through arguments: DXC (D3D12) and NVRTC (CUDA). Ignored for other
+backends.)doc";
 
 static const char *__doc_sgl_SlangLinkOptions_dump_intermediates = R"doc(When set will dump the intermediate source output.)doc";
 


### PR DESCRIPTION
Updates slang-rhi to expose modern CUDA device capabilities and forwards existing `downstream_args` to NVRTC during CUDA session creation and program linking. This lets applications select and pass a CUDA target.