### PR TITLE
Make Crashpad an optional vcpkg dependency

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,8 +19,8 @@ env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
   CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
   CIBW_TEST_COMMAND: "python -c \"import slangpy\""
-  # zip required for vcpkg, rest for glfw
-  CIBW_BEFORE_ALL_LINUX: yum install -y epel-release && yum install -y zip wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel ninja-build perl-IPC-Cmd kernel-headers perl-FindBin perl-Time-Piece perl-lib clang
+  # zip/ninja are build tools; Wayland/X11 packages are for GLFW.
+  CIBW_BEFORE_ALL_LINUX: yum install -y zip wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel ninja-build
   CIBW_ENVIRONMENT: "BUILD_RELEASE_WHEEL=1"
   CIBW_ENVIRONMENT_LINUX: "BUILD_RELEASE_WHEEL=1 CMAKE_ARGS=-DSGL_SLANG_GLIBC_COMPAT=ON"
   MACOSX_DEPLOYMENT_TARGET: 14.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,13 @@ include(mt-retry)
 
 set(VCPKG_INSTALL_OPTIONS "--no-print-usage" "--allow-unsupported" "--x-buildtrees-root=${CMAKE_CURRENT_SOURCE_DIR}/build/buildtrees")
 
+# This option must be declared before project() so the vcpkg toolchain can use
+# it to select the matching manifest feature during dependency installation.
+option(SGL_ENABLE_CRASHPAD "Enable Crashpad integration" OFF)
+if(SGL_ENABLE_CRASHPAD)
+    list(APPEND VCPKG_MANIFEST_FEATURES crashpad)
+endif()
+
 project(sgl)
 
 set(CTEST_OUTPUT_ON_FAILURE TRUE)
@@ -74,9 +81,6 @@ option(SGL_ENABLE_HEADER_VALIDATION "Enable header validation" OFF)
 # Enable/disable build metrics.
 # When enabled, adds compiler timing flags (/Bt+ for MSVC, -ftime-trace for Clang, -ftime-report for GCC).
 option(SGL_ENABLE_BUILD_METRICS "Enable build metrics (compiler timing flags)" OFF)
-
-# Enable/disable Crashpad integration.
-option(SGL_ENABLE_CRASHPAD "Enable Crashpad integration" OFF)
 
 set(SGL_PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE STRING "Project directory (defaults to CMAKE_CURRENT_SOURCE_DIR)")
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,9 +5,16 @@
         "libjpeg-turbo",
         "libpng",
         "openexr",
-        "asmjit",
-        "crashpad"
+        "asmjit"
     ],
+    "features": {
+        "crashpad": {
+            "description": "Enable Crashpad integration",
+            "dependencies": [
+                "crashpad"
+            ]
+        }
+    },
     "vcpkg-configuration": {
         "overlay-ports": [
             "./external/vcpkg-overlays"


### PR DESCRIPTION
## Summary

- Move Crashpad from the unconditional vcpkg dependencies into an opt-in manifest feature.
- Use `SGL_ENABLE_CRASHPAD` to select the Crashpad feature before vcpkg resolves dependencies.
- Avoid building Crashpad, curl, and OpenSSL for wheels, where Crashpad support is disabled.
- Remove the now-unnecessary Perl, kernel headers, Clang, and EPEL setup from the manylinux wheel environment.

## Motivation

The manylinux 2.28 wheel builds were installing Perl and OpenSSL solely because Crashpad was listed as an unconditional vcpkg dependency, despite `SGL_ENABLE_CRASHPAD` being disabled.

After resolving the AlmaLinux Perl package issue, Linux ARM64 builds progressed further but failed while building Crashpad. Making the dependency conditional avoids building unused Crashpad and OpenSSL components and keeps `SGL_ENABLE_CRASHPAD` as the single switch controlling both dependency installation and integration.