### PR TITLE
Update slang-rhi and expose parallel pipeline compilation

### DIFF
--- a/slangpy/core/utils.py
+++ b/slangpy/core/utils.py
@@ -9,6 +9,7 @@ from slangpy import (
     TypeLayoutReflection,
     TypeReflection,
     DeviceType,
+    PipelineCompilationMode,
     Device,
     NativeHandle,
     get_cuda_current_context_native_handles,
@@ -27,6 +28,7 @@ def create_device(
     enable_print: bool = False,
     enable_hot_reload: bool = True,
     enable_compilation_reports: bool = False,
+    pipeline_compilation_mode: PipelineCompilationMode = PipelineCompilationMode.serial,
     existing_device_handles: Optional[Sequence[NativeHandle]] = None,
     bindless_options: Optional[BindlessDesc] = None,
 ):
@@ -61,6 +63,7 @@ def create_device(
         enable_print=enable_print,
         enable_hot_reload=enable_hot_reload,
         enable_compilation_reports=enable_compilation_reports,
+        pipeline_compilation_mode=pipeline_compilation_mode,
         existing_device_handles=existing_device_handles,
         bindless_options=bindless_options,
     )
@@ -82,6 +85,7 @@ def create_torch_device(
     enable_print: bool = False,
     enable_hot_reload: bool = True,
     enable_compilation_reports: bool = False,
+    pipeline_compilation_mode: PipelineCompilationMode = PipelineCompilationMode.serial,
 ):
     """
     Helper to create a device configured properly for PyTorch integration. If device type is CUDA,
@@ -120,6 +124,7 @@ def create_torch_device(
         enable_print=enable_print,
         enable_hot_reload=enable_hot_reload,
         enable_compilation_reports=enable_compilation_reports,
+        pipeline_compilation_mode=pipeline_compilation_mode,
         existing_device_handles=handles,
     )
 

--- a/slangpy/tests/device/test_device.py
+++ b/slangpy/tests/device/test_device.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import slangpy as spy
 from slangpy.testing import helpers
+from slangpy.testing.helpers import test_id  # type: ignore (pytest fixture)
 
 from typing import Optional
 
@@ -21,6 +22,7 @@ def test_create_device(device_type: spy.DeviceType):
     assert device.desc.type == device_type
     assert device.desc.enable_debug_layers == True
     assert device.desc.enable_rhi_validation == True
+    assert device.desc.pipeline_compilation_mode == spy.PipelineCompilationMode.serial
 
     assert device.info.type == device_type
     assert device.info.adapter_name != ""
@@ -31,6 +33,53 @@ def test_create_device(device_type: spy.DeviceType):
         spy.DeviceType.cuda: "CUDA",
     }
     assert device.info.api_name == API_NAMES[device_type]
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_parallel_pipeline_compilation(test_id: str, device_type: spy.DeviceType):
+    device = spy.create_device(
+        type=device_type,
+        pipeline_compilation_mode=spy.PipelineCompilationMode.parallel,
+    )
+    try:
+        assert device.desc.pipeline_compilation_mode == spy.PipelineCompilationMode.parallel
+
+        module = device.load_module_from_source(
+            module_name=f"parallel_pipeline_compilation_{test_id}",
+            source="""
+                [shader("compute")]
+                [numthreads(1, 1, 1)]
+                void add(RWStructuredBuffer<float> buffer) { buffer[0] += 1.0; }
+
+                [shader("compute")]
+                [numthreads(1, 1, 1)]
+                void multiply(RWStructuredBuffer<float> buffer) { buffer[0] *= 2.0; }
+            """,
+        )
+        pipelines = [
+            device.create_compute_pipeline(
+                device.link_program([module], [module.entry_point(entry_point)]),
+                defer_target_compilation=True,
+            )
+            for entry_point in ["add", "multiply"]
+        ]
+        buffer = device.create_buffer(
+            data=np.array([1.0], dtype=np.float32),
+            usage=spy.BufferUsage.unordered_access | spy.BufferUsage.shader_resource,
+        )
+
+        command_encoder = device.create_command_encoder()
+        for pipeline in pipelines:
+            with command_encoder.begin_compute_pass() as compute_pass:
+                shader_object = compute_pass.bind_pipeline(pipeline)
+                spy.ShaderCursor(shader_object).find_entry_point(0)["buffer"] = buffer
+                compute_pass.dispatch(thread_count=[1, 1, 1])
+
+        device.submit_command_buffer(command_encoder.finish())
+        device.wait()
+        assert buffer.to_numpy().view(np.float32)[0] == 4.0
+    finally:
+        device.close()
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -279,6 +279,7 @@ Device::Device(const DeviceDesc& desc)
         .enableAftermath = m_desc.enable_aftermath,
         .debugCallback = m_debug_logger.get(),
         .enableCompilationReports = m_desc.enable_compilation_reports,
+        .pipelineCompilationMode = static_cast<rhi::PipelineCompilationMode>(m_desc.pipeline_compilation_mode),
         .enableCUDALaunchFromGfx = m_desc.enable_cuda_launch_from_gfx,
         .enableRayTracing = m_desc.enable_ray_tracing,
         .bindless = bindless_desc,
@@ -1364,6 +1365,7 @@ std::string Device::to_string() const
         "  enable_print = {},\n"
         "  enable_hot_reload = {},\n"
         "  enable_compilation_reports = {},\n"
+        "  pipeline_compilation_mode = {},\n"
         "  supported_shader_model = {},\n"
         "  module_cache_path = \"{}\",\n"
         "  shader_cache_path = \"{}\"\n"
@@ -1379,6 +1381,7 @@ std::string Device::to_string() const
         m_desc.enable_print,
         m_desc.enable_hot_reload,
         m_desc.enable_compilation_reports,
+        m_desc.pipeline_compilation_mode,
         m_supported_shader_model,
         m_module_cache_path,
         m_shader_cache_path

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -90,6 +90,20 @@ SGL_ENUM_INFO(
 );
 SGL_ENUM_REGISTER(DeviceType);
 
+enum class PipelineCompilationMode : uint32_t {
+    serial = static_cast<uint32_t>(rhi::PipelineCompilationMode::Serial),
+    parallel = static_cast<uint32_t>(rhi::PipelineCompilationMode::Parallel),
+};
+
+SGL_ENUM_INFO(
+    PipelineCompilationMode,
+    {
+        {PipelineCompilationMode::serial, "serial"},
+        {PipelineCompilationMode::parallel, "parallel"},
+    }
+);
+SGL_ENUM_REGISTER(PipelineCompilationMode);
+
 struct BindlessDesc {
     uint32_t buffer_count{1024};
     uint32_t texture_count{1024};
@@ -145,6 +159,9 @@ struct DeviceDesc {
 
     /// Enable compilation reports.
     bool enable_compilation_reports{false};
+
+    /// Control resolution of deferred pipelines encountered while finishing a command encoder.
+    PipelineCompilationMode pipeline_compilation_mode{PipelineCompilationMode::serial};
 
     /// Adapter LUID to select adapter on which the device will be created.
     std::optional<AdapterLUID> adapter_luid;

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -65,6 +65,7 @@ SGL_DICT_TO_DESC_FIELD(enable_ray_tracing, bool)
 SGL_DICT_TO_DESC_FIELD(enable_print, bool)
 SGL_DICT_TO_DESC_FIELD(enable_hot_reload, bool)
 SGL_DICT_TO_DESC_FIELD(enable_compilation_reports, bool)
+SGL_DICT_TO_DESC_FIELD(pipeline_compilation_mode, PipelineCompilationMode)
 SGL_DICT_TO_DESC_FIELD(adapter_luid, AdapterLUID)
 SGL_DICT_TO_DESC_FIELD(compiler_options, SlangCompilerOptions)
 SGL_DICT_TO_DESC_FIELD(module_cache_path, std::filesystem::path)
@@ -318,6 +319,7 @@ SGL_PY_EXPORT(device_device)
 
 
     nb::sgl_enum<DeviceType>(m, "DeviceType");
+    nb::sgl_enum<PipelineCompilationMode>(m, "PipelineCompilationMode");
 
     nb::class_<DeviceDesc>(m, "DeviceDesc", D(DeviceDesc))
         .def(nb::init<>())
@@ -356,6 +358,11 @@ SGL_PY_EXPORT(device_device)
             "enable_compilation_reports",
             &DeviceDesc::enable_compilation_reports,
             D(DeviceDesc, enable_compilation_reports)
+        )
+        .def_rw(
+            "pipeline_compilation_mode",
+            &DeviceDesc::pipeline_compilation_mode,
+            D(DeviceDesc, pipeline_compilation_mode)
         )
         .def_rw("adapter_luid", &DeviceDesc::adapter_luid, D(DeviceDesc, adapter_luid))
         .def_rw("compiler_options", &DeviceDesc::compiler_options, D(DeviceDesc, compiler_options))
@@ -517,6 +524,7 @@ SGL_PY_EXPORT(device_device)
            bool enable_print,
            bool enable_hot_reload,
            bool enable_compilation_reports,
+           PipelineCompilationMode pipeline_compilation_mode,
            std::optional<AdapterLUID> adapter_luid,
            std::optional<SlangCompilerOptions> compiler_options,
            std::optional<std::filesystem::path> module_cache_path,
@@ -544,6 +552,7 @@ SGL_PY_EXPORT(device_device)
                  .enable_print = enable_print,
                  .enable_hot_reload = enable_hot_reload,
                  .enable_compilation_reports = enable_compilation_reports,
+                 .pipeline_compilation_mode = pipeline_compilation_mode,
                  .adapter_luid = adapter_luid,
                  .compiler_options = compiler_options.value_or(SlangCompilerOptions{}),
                  .bindless_options = bindless_options.value_or(BindlessDesc{}),
@@ -569,6 +578,7 @@ SGL_PY_EXPORT(device_device)
         "enable_print"_a = DeviceDesc().enable_print,
         "enable_hot_reload"_a = DeviceDesc().enable_hot_reload,
         "enable_compilation_reports"_a = DeviceDesc().enable_compilation_reports,
+        "pipeline_compilation_mode"_a = DeviceDesc().pipeline_compilation_mode,
         "adapter_luid"_a.none() = nb::none(),
         "compiler_options"_a.none() = nb::none(),
         "module_cache_path"_a.none() = nb::none(),

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -2875,6 +2875,10 @@ static const char *__doc_sgl_DeviceDesc_module_cache_path =
 R"doc(Path to the module cache directory (optional). If a relative path is
 used, the cache is stored in the application data directory.)doc";
 
+static const char *__doc_sgl_DeviceDesc_pipeline_compilation_mode =
+R"doc(Control resolution of deferred pipelines encountered while finishing a
+command encoder.)doc";
+
 static const char *__doc_sgl_DeviceDesc_rhi_validation_log_level =
 R"doc(RHI validation layer log level (only applicable if RHI validation is
 enabled).)doc";
@@ -5394,7 +5398,12 @@ static const char *__doc_sgl_Logger_2 = R"doc()doc";
 
 static const char *__doc_sgl_LoggerOutput = R"doc()doc";
 
-static const char *__doc_sgl_LoggerOutput_2 = R"doc(Abstract base class for logger outputs.)doc";
+static const char *__doc_sgl_LoggerOutput_2 =
+R"doc(Abstract base class for logger outputs.
+
+Implementations must be thread-safe. A LoggerOutput can be shared by
+multiple loggers, and write() may be called concurrently from multiple
+threads.)doc";
 
 static const char *__doc_sgl_LoggerOutput_class_name = R"doc()doc";
 
@@ -6255,6 +6264,14 @@ static const char *__doc_sgl_Pipeline = R"doc()doc";
 
 static const char *__doc_sgl_Pipeline_2 = R"doc(Pipeline base class.)doc";
 
+static const char *__doc_sgl_PipelineCompilationMode = R"doc()doc";
+
+static const char *__doc_sgl_PipelineCompilationMode_info = R"doc()doc";
+
+static const char *__doc_sgl_PipelineCompilationMode_parallel = R"doc()doc";
+
+static const char *__doc_sgl_PipelineCompilationMode_serial = R"doc()doc";
+
 static const char *__doc_sgl_Pipeline_Pipeline = R"doc()doc";
 
 static const char *__doc_sgl_Pipeline_class_name = R"doc()doc";
@@ -7043,8 +7060,8 @@ R"doc(Poll submitted GPU timestamp queries and queue resolved measurements
 for the collector.
 
 The poll does not deliberately wait for profiled submissions or
-unresolved queries. On CUDA, refreshing timestamp calibration synchronizes
-queued GPU work.)doc";
+unresolved queries. On CUDA, refreshing timestamp calibration
+synchronizes queued GPU work.)doc";
 
 static const char *__doc_sgl_Profiler_to_string = R"doc()doc";
 
@@ -8225,9 +8242,9 @@ static const char *__doc_sgl_SlangCompilerOptions_disable_warnings = R"doc(Speci
 
 static const char *__doc_sgl_SlangCompilerOptions_downstream_args =
 R"doc(Specifies a list of additional arguments to be passed to the
-downstream compiler. Only forwarded to downstream compilers that accept
-pass-through arguments: DXC (D3D12) and NVRTC (CUDA). Ignored for other
-backends.)doc";
+downstream compiler. Only forwarded to downstream compilers that
+accept pass-through arguments: DXC (D3D12) and NVRTC (CUDA). Ignored
+for other backends.)doc";
 
 static const char *__doc_sgl_SlangCompilerOptions_dump_intermediates = R"doc(When set will dump the intermediate source output.)doc";
 
@@ -8380,9 +8397,9 @@ code.)doc";
 
 static const char *__doc_sgl_SlangLinkOptions_downstream_args =
 R"doc(Specifies a list of additional arguments to be passed to the
-downstream compiler. Only forwarded to downstream compilers that accept
-pass-through arguments: DXC (D3D12) and NVRTC (CUDA). Ignored for other
-backends.)doc";
+downstream compiler. Only forwarded to downstream compilers that
+accept pass-through arguments: DXC (D3D12) and NVRTC (CUDA). Ignored
+for other backends.)doc";
 
 static const char *__doc_sgl_SlangLinkOptions_dump_intermediates = R"doc(When set will dump the intermediate source output.)doc";
 
@@ -8993,6 +9010,21 @@ Returns:
     New texture object.)doc";
 
 static const char *__doc_sgl_TextureLoader_load_texture_2 =
+R"doc(Load a texture from an image stream.
+
+The stream must be readable and seekable. All image formats supported
+by the file-path overload, including DDS, are supported.
+
+Parameter ``stream``:
+    Image data stream.
+
+Parameter ``options``:
+    Texture loading options.
+
+Returns:
+    New texture object.)doc";
+
+static const char *__doc_sgl_TextureLoader_load_texture_3 =
 R"doc(Load a texture from an image file.
 
 Parameter ``path``:
@@ -10775,6 +10807,8 @@ static const char *__doc_sgl_find_enum_info_adl_81 = R"doc()doc";
 static const char *__doc_sgl_find_enum_info_adl_82 = R"doc()doc";
 
 static const char *__doc_sgl_find_enum_info_adl_83 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_84 = R"doc()doc";
 
 static const char *__doc_sgl_flags_to_string_list = R"doc(Convert an flags enum value to a list of strings.)doc";
 


### PR DESCRIPTION
## Summary

Update the `slang-rhi` submodule from `8ffe21c` to `8f1e51b`, bringing in the latest changes from `main`.

The upstream changes introduce optional parallel compilation of deferred pipelines, along with improvements to surface validation, persistent-cache concurrency, native resource handling, and shader/pipeline compilation.

## Changes

- Update `external/slang-rhi` to `8f1e51b`.
- Add `PipelineCompilationMode` with `serial` and `parallel` options.
- Expose `pipeline_compilation_mode` through:
  - SGL `DeviceDesc`
  - Python `DeviceDesc`
  - `Device(...)`
  - `slangpy.create_device(...)`
  - `slangpy.create_torch_device(...)`
- Forward the selected mode to `rhi::DeviceDesc`.
- Include the mode in `Device::to_string()`.
- Add Python coverage for descriptor conversion and deferred parallel pipeline compilation.

The remaining upstream API and behavior changes do not require SGL or SlangPy wrapper changes. Existing cache and debug logging implementations already satisfy the new concurrency requirements.