### PR TITLE
nanothread adapter for slang-rhi task pool

### DIFF
--- a/src/sgl/core/thread.cpp
+++ b/src/sgl/core/thread.cpp
@@ -4,13 +4,152 @@
 
 #include "sgl/core/error.h"
 
+#include <slang-rhi.h>
+
+#include <mutex>
 #include <vector>
 
 namespace sgl::thread {
 
-void static_init() { }
+namespace {
 
-void static_shutdown() { }
+    /// Adapter that executes slang-rhi tasks on a nanothread pool.
+    class NanothreadTaskPool : public rhi::ITaskPool {
+    public:
+        explicit NanothreadTaskPool(Pool* pool = nullptr)
+            : m_pool(pool)
+        {
+        }
+
+        SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(const SlangUUID& uuid, void** out_object) override
+        {
+            if (uuid == ISlangUnknown::getTypeGuid() || uuid == rhi::ITaskPool::getTypeGuid()) {
+                *out_object = static_cast<rhi::ITaskPool*>(this);
+                return SLANG_OK;
+            }
+            *out_object = nullptr;
+            return SLANG_E_NO_INTERFACE;
+        }
+
+        // This adapter has process lifetime and is not reference counted.
+        SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 2; }
+        SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 2; }
+
+        SLANG_NO_THROW TaskHandle SLANG_MCALL
+        submitTask(void (*func)(void*), void* payload, void (*payload_deleter)(void*), TaskGroupHandle group) override
+        {
+            SGL_ASSERT(func);
+
+            TaskGroup* task_group = static_cast<TaskGroup*>(group);
+            SGL_ASSERT(!task_group || task_group->owner == this);
+
+            TaskPayload* task_payload = new TaskPayload{func, payload, payload_deleter};
+            Task* task = task_submit(m_pool, 1, execute_task, task_payload, 0, delete_task_payload, 1);
+            SGL_ASSERT(task);
+
+            if (task_group) {
+                // The group owns a reference independently of the handle returned to the caller.
+                task_retain(task);
+                std::lock_guard lock(task_group->mutex);
+                task_group->tasks.push_back(task);
+            }
+
+            return task;
+        }
+
+        SLANG_NO_THROW void SLANG_MCALL releaseTask(TaskHandle task) override
+        {
+            SGL_ASSERT(task);
+            task_release(static_cast<Task*>(task));
+        }
+
+        SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTask(TaskHandle task) override
+        {
+            SGL_ASSERT(task);
+            task_wait_and_release(static_cast<Task*>(task));
+        }
+
+        SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() override { return new TaskGroup{this}; }
+
+        SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTaskGroup(TaskGroupHandle group) override
+        {
+            SGL_ASSERT(group);
+            TaskGroup* task_group = static_cast<TaskGroup*>(group);
+            SGL_ASSERT(task_group->owner == this);
+
+            // A task in one batch may submit more tasks to the same group. Waiting for every
+            // task in the batch guarantees that all such submissions are visible before the
+            // group can be observed as empty.
+            std::vector<Task*> tasks;
+            while (true) {
+                {
+                    std::lock_guard lock(task_group->mutex);
+                    if (task_group->tasks.empty())
+                        break;
+                    tasks.swap(task_group->tasks);
+                }
+
+                for (Task* task : tasks)
+                    task_wait_and_release(task);
+                tasks.clear();
+            }
+
+            delete task_group;
+        }
+
+    private:
+        struct TaskGroup {
+            NanothreadTaskPool* owner;
+            std::mutex mutex;
+            std::vector<Task*> tasks;
+        };
+
+        struct TaskPayload {
+            void (*func)(void*);
+            void* payload;
+            void (*payload_deleter)(void*);
+        };
+
+        static void execute_task(uint32_t, void* payload)
+        {
+            TaskPayload* task_payload = static_cast<TaskPayload*>(payload);
+            task_payload->func(task_payload->payload);
+        }
+
+        static void delete_task_payload(void* payload)
+        {
+            TaskPayload* task_payload = static_cast<TaskPayload*>(payload);
+            if (task_payload->payload_deleter)
+                task_payload->payload_deleter(task_payload->payload);
+            delete task_payload;
+        }
+
+        Pool* m_pool;
+    };
+
+    NanothreadTaskPool s_rhi_task_pool;
+
+} // namespace
+
+void static_init()
+{
+    SGL_CHECK(SLANG_SUCCEEDED(rhi::getRHI()->setTaskPool(&s_rhi_task_pool)), "Failed to set slang-rhi task pool.");
+}
+
+void static_shutdown()
+{
+    SGL_CHECK(SLANG_SUCCEEDED(rhi::getRHI()->setTaskPool(nullptr)), "Failed to reset slang-rhi task pool.");
+}
+
+rhi::ITaskPool* rhi_task_pool()
+{
+    return &s_rhi_task_pool;
+}
+
+uint32_t current_thread_id()
+{
+    return pool_thread_id();
+}
 
 TaskGroup& global_task_group()
 {

--- a/src/sgl/core/thread.h
+++ b/src/sgl/core/thread.h
@@ -11,10 +11,20 @@
 #include <mutex>
 #include <vector>
 
+namespace rhi {
+class ITaskPool;
+}
+
 namespace sgl::thread {
 
 SGL_API void static_init();
 SGL_API void static_shutdown();
+
+/// Get the nanothread-backed task pool installed in slang-rhi.
+SGL_API rhi::ITaskPool* rhi_task_pool();
+
+/// Return the nanothread worker ID for the current thread, or zero for a non-worker thread.
+SGL_API uint32_t current_thread_id();
 
 // Import nanothread symbols into sgl::thread namespace.
 using ::Task;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ if(SGL_BUILD_TESTS)
         sgl/core/test_static_vector.cpp
         sgl/core/test_stream.cpp
         sgl/core/test_string.cpp
+        sgl/core/test_thread.cpp
         sgl/device/test_cursors.cpp
         sgl/device/test_device.cpp
         sgl/device/test_hot_reload.cpp

--- a/tests/sgl/core/test_thread.cpp
+++ b/tests/sgl/core/test_thread.cpp
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "testing.h"
+#include "sgl/core/thread.h"
+
+#include <slang-rhi.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+using namespace sgl;
+
+namespace {
+
+struct RecursiveTaskPayload {
+    rhi::ITaskPool* pool;
+    rhi::ITaskPool::TaskGroupHandle group;
+    std::atomic<uint32_t>* execute_count;
+    std::atomic<uint32_t>* delete_count;
+    uint32_t depth;
+};
+
+void delete_recursive_task_payload(void* data)
+{
+    auto* payload = static_cast<RecursiveTaskPayload*>(data);
+    payload->delete_count->fetch_add(1);
+    delete payload;
+}
+
+void execute_recursive_task(void* data)
+{
+    auto* payload = static_cast<RecursiveTaskPayload*>(data);
+    payload->execute_count->fetch_add(1);
+    if (payload->depth == 0)
+        return;
+
+    for (uint32_t i = 0; i < 2; ++i) {
+        auto* child = new RecursiveTaskPayload{
+            payload->pool,
+            payload->group,
+            payload->execute_count,
+            payload->delete_count,
+            payload->depth - 1,
+        };
+        auto task
+            = payload->pool->submitTask(execute_recursive_task, child, delete_recursive_task_payload, payload->group);
+        payload->pool->releaseTask(task);
+    }
+}
+
+} // namespace
+
+TEST_SUITE_BEGIN("thread");
+
+TEST_CASE("rhi task pool executes tasks and deletes payloads")
+{
+    struct Payload {
+        std::atomic<uint32_t>* execute_count;
+        std::atomic<uint32_t>* delete_count;
+    };
+
+    std::atomic<uint32_t> execute_count{0};
+    std::atomic<uint32_t> delete_count{0};
+    auto* payload = new Payload{&execute_count, &delete_count};
+
+    rhi::ITaskPool* pool = thread::rhi_task_pool();
+    auto task = pool->submitTask(
+        [](void* data)
+        {
+            static_cast<Payload*>(data)->execute_count->fetch_add(1);
+        },
+        payload,
+        [](void* data)
+        {
+            auto* payload = static_cast<Payload*>(data);
+            payload->delete_count->fetch_add(1);
+            delete payload;
+        }
+    );
+    pool->waitAndReleaseTask(task);
+
+    CHECK(execute_count.load() == 1);
+    CHECK(delete_count.load() == 1);
+}
+
+TEST_CASE("rhi task groups include tasks spawned by callbacks")
+{
+    std::atomic<uint32_t> execute_count{0};
+    std::atomic<uint32_t> delete_count{0};
+    rhi::ITaskPool* pool = thread::rhi_task_pool();
+    auto group = pool->createTaskGroup();
+    auto* root = new RecursiveTaskPayload{pool, group, &execute_count, &delete_count, 2};
+    auto task = pool->submitTask(execute_recursive_task, root, delete_recursive_task_payload, group);
+    pool->releaseTask(task);
+    pool->waitAndReleaseTaskGroup(group);
+
+    CHECK(execute_count.load() == 7);
+    CHECK(delete_count.load() == 7);
+}
+
+TEST_CASE("rhi task pool shares nanothread workers")
+{
+    struct Payload {
+        std::mutex mutex;
+        std::condition_variable condition;
+        bool done{false};
+        uint32_t worker_id{0};
+    } payload;
+
+    rhi::ITaskPool* pool = thread::rhi_task_pool();
+    auto task = pool->submitTask(
+        [](void* data)
+        {
+            auto* payload = static_cast<Payload*>(data);
+            {
+                std::lock_guard lock(payload->mutex);
+                payload->worker_id = thread::current_thread_id();
+                payload->done = true;
+            }
+            payload->condition.notify_one();
+        },
+        &payload,
+        nullptr
+    );
+
+    bool completed_on_worker = false;
+    {
+        std::unique_lock lock(payload.mutex);
+        completed_on_worker = payload.condition.wait_for(
+            lock,
+            std::chrono::seconds(10),
+            [&]
+            {
+                return payload.done;
+            }
+        );
+    }
+    pool->waitAndReleaseTask(task);
+
+    CHECK(completed_on_worker);
+    CHECK(payload.worker_id != 0);
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
## Summary

- Update `slang-rhi` to `46a66b47` (`Simplify and harden the task pool API`).
- Add an `rhi::ITaskPool` adapter backed by SGL’s default nanothread pool.
- Install the adapter during SGL initialization and reset it during shutdown.
- Share worker threads between SGL and slang-rhi instead of maintaining separate pools.
- Support task-handle ownership, payload cleanup, and dynamically growing task groups.
- Add focused tests for execution, cleanup, recursive task groups, and shared-worker usage.
- Retain vulkan module.

## Implementation details

Grouped tasks retain an additional nanothread task reference owned by the group. Group waits drain tasks in batches until no tasks remain, ensuring work submitted recursively from callbacks is included.

An exported worker-ID helper allows tests to query the nanothread instance linked into `sgl.dll`.
