### PR TITLE
Make nanothread a private SGL dependency

### DIFF
--- a/src/sgl/CMakeLists.txt
+++ b/src/sgl/CMakeLists.txt
@@ -404,7 +404,6 @@ target_include_directories(sgl PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/${SGL_BUILD_TY
 target_link_libraries(sgl
     PUBLIC
         fmt::fmt
-        nanothread
         slang
         slang-rhi
         slang-rhi-vulkan-headers
@@ -412,6 +411,7 @@ target_link_libraries(sgl
         $<$<NOT:$<BOOL:${SGL_USE_DYNAMIC_CUDA}>>:CUDA::cuda_driver>
         sgl_data
     PRIVATE
+        nanothread
         git_version
         glfw
         tevclient

--- a/src/sgl/core/thread.cpp
+++ b/src/sgl/core/thread.cpp
@@ -3,7 +3,9 @@
 #include "thread.h"
 
 #include "sgl/core/error.h"
+#include "sgl/core/short_vector.h"
 
+#include <nanothread/nanothread.h>
 #include <slang-rhi.h>
 
 #include <mutex>
@@ -35,7 +37,7 @@ namespace {
         SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 2; }
         SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 2; }
 
-        SLANG_NO_THROW TaskHandle SLANG_MCALL
+        SLANG_NO_THROW rhi::ITaskPool::TaskHandle SLANG_MCALL
         submitTask(void (*func)(void*), void* payload, void (*payload_deleter)(void*), TaskGroupHandle group) override
         {
             SGL_ASSERT(func);
@@ -44,12 +46,12 @@ namespace {
             SGL_ASSERT(!task_group || task_group->owner == this);
 
             TaskPayload* task_payload = new TaskPayload{func, payload, payload_deleter};
-            Task* task = task_submit(m_pool, 1, execute_task, task_payload, 0, delete_task_payload, 1);
+            ::Task* task = ::task_submit(m_pool, 1, execute_task, task_payload, 0, delete_task_payload, 1);
             SGL_ASSERT(task);
 
             if (task_group) {
                 // The group owns a reference independently of the handle returned to the caller.
-                task_retain(task);
+                ::task_retain(task);
                 std::lock_guard lock(task_group->mutex);
                 task_group->tasks.push_back(task);
             }
@@ -57,16 +59,16 @@ namespace {
             return task;
         }
 
-        SLANG_NO_THROW void SLANG_MCALL releaseTask(TaskHandle task) override
+        SLANG_NO_THROW void SLANG_MCALL releaseTask(rhi::ITaskPool::TaskHandle task) override
         {
             SGL_ASSERT(task);
-            task_release(static_cast<Task*>(task));
+            ::task_release(static_cast<::Task*>(task));
         }
 
-        SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTask(TaskHandle task) override
+        SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTask(rhi::ITaskPool::TaskHandle task) override
         {
             SGL_ASSERT(task);
-            task_wait_and_release(static_cast<Task*>(task));
+            ::task_wait_and_release(static_cast<::Task*>(task));
         }
 
         SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() override { return new TaskGroup{this}; }
@@ -80,7 +82,7 @@ namespace {
             // A task in one batch may submit more tasks to the same group. Waiting for every
             // task in the batch guarantees that all such submissions are visible before the
             // group can be observed as empty.
-            std::vector<Task*> tasks;
+            std::vector<::Task*> tasks;
             while (true) {
                 {
                     std::lock_guard lock(task_group->mutex);
@@ -89,8 +91,8 @@ namespace {
                     tasks.swap(task_group->tasks);
                 }
 
-                for (Task* task : tasks)
-                    task_wait_and_release(task);
+                for (::Task* task : tasks)
+                    ::task_wait_and_release(task);
                 tasks.clear();
             }
 
@@ -101,7 +103,7 @@ namespace {
         struct TaskGroup {
             NanothreadTaskPool* owner;
             std::mutex mutex;
-            std::vector<Task*> tasks;
+            std::vector<::Task*> tasks;
         };
 
         struct TaskPayload {
@@ -129,7 +131,85 @@ namespace {
 
     NanothreadTaskPool s_rhi_task_pool;
 
+    ::Task* unwrap_task(TaskHandle task)
+    {
+        return reinterpret_cast<::Task*>(task);
+    }
+
+    TaskHandle wrap_task(::Task* task)
+    {
+        return reinterpret_cast<TaskHandle>(task);
+    }
+
 } // namespace
+
+TaskHandle task_submit_dep(
+    const TaskHandle* parents,
+    uint32_t parent_count,
+    uint32_t size,
+    TaskFunc func,
+    void* payload,
+    uint32_t payload_size,
+    TaskPayloadDeleter payload_deleter,
+    bool always_async,
+    bool profile
+)
+{
+    short_vector<const ::Task*, 16> unwrapped_parents;
+    unwrapped_parents.reserve(parent_count);
+    for (uint32_t i = 0; i < parent_count; ++i)
+        unwrapped_parents.push_back(unwrap_task(parents[i]));
+
+    return wrap_task(
+        ::task_submit_dep(
+            nullptr,
+            unwrapped_parents.data(),
+            parent_count,
+            size,
+            func,
+            payload,
+            payload_size,
+            payload_deleter,
+            always_async ? 1 : 0,
+            profile ? 1 : 0
+        )
+    );
+}
+
+void task_retain(TaskHandle task)
+{
+    ::task_retain(unwrap_task(task));
+}
+
+void task_release(TaskHandle task)
+{
+    ::task_release(unwrap_task(task));
+}
+
+void task_wait(TaskHandle task)
+{
+    ::task_wait(unwrap_task(task));
+}
+
+void task_wait_and_release(TaskHandle task)
+{
+    ::task_wait_and_release(unwrap_task(task));
+}
+
+bool task_query(TaskHandle task)
+{
+    return ::task_query(unwrap_task(task));
+}
+
+double task_time(TaskHandle task)
+{
+    return ::task_time(unwrap_task(task));
+}
+
+double task_time_rel(TaskHandle task_1, TaskHandle task_2)
+{
+    return ::task_time_rel(unwrap_task(task_1), unwrap_task(task_2));
+}
 
 void static_init()
 {
@@ -144,11 +224,6 @@ void static_shutdown()
 rhi::ITaskPool* rhi_task_pool()
 {
     return &s_rhi_task_pool;
-}
-
-uint32_t current_thread_id()
-{
-    return pool_thread_id();
 }
 
 TaskGroup& global_task_group()

--- a/src/sgl/core/thread.h
+++ b/src/sgl/core/thread.h
@@ -5,8 +5,8 @@
 #include "sgl/core/macros.h"
 #include "sgl/core/error.h"
 
-#include <nanothread/nanothread.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <type_traits>
 #include <mutex>
 #include <vector>
@@ -17,31 +17,74 @@ class ITaskPool;
 
 namespace sgl::thread {
 
+// This API is a thin wrapper around nanothread. Nanothread is linked privately into SGL so all
+// clients route task operations through the single nanothread instance owned by SGL. Exposing
+// nanothread as a public static dependency would give every linked module its own default pool.
+
 SGL_API void static_init();
 SGL_API void static_shutdown();
 
-/// Get the nanothread-backed task pool installed in slang-rhi.
+/// Get the SGL task pool installed in slang-rhi.
 SGL_API rhi::ITaskPool* rhi_task_pool();
 
-/// Return the nanothread worker ID for the current thread, or zero for a non-worker thread.
-SGL_API uint32_t current_thread_id();
+/// Opaque task type.
+struct Task;
 
-// Import nanothread symbols into sgl::thread namespace.
-using ::Task;
-using ::task_submit_dep;
-using ::task_release;
-using ::task_wait;
-using ::task_wait_and_release;
-using ::task_query;
-using ::task_time;
-using ::task_time_rel;
-using ::task_retain;
-
-/// Task handle type.
+/// Opaque task handle type.
 using TaskHandle = Task*;
 
+/// Task callback type.
+using TaskFunc = void (*)(uint32_t index, void* payload);
+
+/// Task payload deleter type.
+using TaskPayloadDeleter = void (*)(void* payload);
+
+/// Submit a task with optional dependencies to the SGL thread pool.
+/// \param parents Parent tasks to wait for before executing.
+/// \param parent_count Number of parent tasks.
+/// \param size Number of work units to execute.
+/// \param func Function called once for each work unit.
+/// \param payload Payload passed to the function.
+/// \param payload_size Size of the payload copied into the task when no deleter is provided.
+/// \param payload_deleter Optional function that releases the payload after execution.
+/// \param always_async Whether to disable synchronous execution of small tasks.
+/// \param profile Whether to collect timing information for this task.
+/// \return The submitted task, or nullptr if it completed synchronously.
+SGL_API TaskHandle task_submit_dep(
+    const TaskHandle* parents,
+    uint32_t parent_count,
+    uint32_t size = 1,
+    TaskFunc func = nullptr,
+    void* payload = nullptr,
+    uint32_t payload_size = 0,
+    TaskPayloadDeleter payload_deleter = nullptr,
+    bool always_async = false,
+    bool profile = false
+);
+
+/// Increase the reference count of a task.
+SGL_API void task_retain(TaskHandle task);
+
+/// Release a task handle.
+SGL_API void task_release(TaskHandle task);
+
+/// Wait for a task to complete.
+SGL_API void task_wait(TaskHandle task);
+
+/// Wait for a task to complete and release its handle.
+SGL_API void task_wait_and_release(TaskHandle task);
+
+/// Return whether a task has completed.
+SGL_API bool task_query(TaskHandle task);
+
+/// Return the execution time of a profiled task in milliseconds.
+SGL_API double task_time(TaskHandle task);
+
+/// Return the difference between the start times of two profiled tasks in milliseconds.
+SGL_API double task_time_rel(TaskHandle task_1, TaskHandle task_2);
+
 /// Run a function asynchronously in a new task.
-/// See nanothread documentation on `task_submit_dep` for details.
+/// See `task_submit_dep` for details.
 /// \param func Function to call.
 /// \param parents Parent tasks to wait for before executing.
 /// \param parent_count Number of parent tasks.
@@ -61,19 +104,9 @@ template<typename Func>
     };
 
     if constexpr (std::is_trivially_copyable_v<BaseFunc> && std::is_trivially_destructible_v<BaseFunc>) {
-        // Payload is trivially copyable/destructible. Let nanothread manage the payload memory.
+        // Payload is trivially copyable/destructible. Let the task implementation manage the payload memory.
         Payload payload{std::forward<Func>(func)};
-        return task_submit_dep(
-            nullptr, // default pool
-            parents,
-            (uint32_t)parent_count,
-            1,
-            callback,
-            &payload,
-            sizeof(Payload),
-            nullptr,
-            1
-        );
+        return task_submit_dep(parents, (uint32_t)parent_count, 1, callback, &payload, sizeof(Payload), nullptr, 1);
     } else {
         // Payload is non-trivially copyable/destructible. Manage payload manually.
         Payload* payload = new Payload{std::forward<Func>(func)};
@@ -81,22 +114,12 @@ template<typename Func>
         {
             delete (Payload*)payload;
         };
-        return task_submit_dep(
-            nullptr, // default pool
-            parents,
-            (uint32_t)parent_count,
-            1,
-            callback,
-            payload,
-            0,
-            deleter,
-            1
-        );
+        return task_submit_dep(parents, (uint32_t)parent_count, 1, callback, payload, 0, deleter, 1);
     }
 }
 
 /// Run a function asynchronously in a new task.
-/// See nanothread documentation on `task_submit_dep` for details.
+/// See `task_submit_dep` for details.
 /// \param func Function to call.
 /// \param parents Parent tasks to wait for before executing.
 /// \return The new task.
@@ -169,16 +192,12 @@ void parallel_for(const blocked_range<Int>& range, Func&& func)
         (*p->f)(blocked_range<Int>(begin, end));
     };
 
-    task_submit_and_wait(
-        nullptr, // default pool
-        range.blocks(),
-        callback,
-        &payload
-    );
+    TaskHandle task = task_submit_dep(nullptr, 0, range.blocks(), callback, &payload, 0, nullptr, false);
+    task_wait_and_release(task);
 }
 
 /// Run a parallel for-loop asynchronously in a new task.
-/// See nanothread documentation on `task_submit_dep` for details.
+/// See `task_submit_dep` for details.
 /// \param range Loop range.
 /// \param func Function to execute (taking a `blocked_range<Int>` as an argument).
 /// \param parents Parent tasks to wait for before executing.
@@ -210,7 +229,6 @@ parallel_for_async(const blocked_range<Int>& range, Func&& func, const TaskHandl
         Payload payload{std::forward<Func>(func), range.begin(), range.end(), range.block_size()};
 
         return task_submit_dep(
-            nullptr, // default pool
             parents,
             (uint32_t)parent_count,
             range.blocks(),
@@ -228,22 +246,12 @@ parallel_for_async(const blocked_range<Int>& range, Func&& func, const TaskHandl
             delete (Payload*)payload;
         };
 
-        return task_submit_dep(
-            nullptr, // default pool
-            parents,
-            (uint32_t)parent_count,
-            range.blocks(),
-            callback,
-            payload,
-            0,
-            deleter,
-            1
-        );
+        return task_submit_dep(parents, (uint32_t)parent_count, range.blocks(), callback, payload, 0, deleter, 1);
     }
 }
 
 /// Run a parallel for-loop asynchronously in a new task.
-/// See nanothread documentation on `task_submit_dep` for details.
+/// See `task_submit_dep` for details.
 /// \param range Loop range.
 /// \param func Function to execute (taking a `blocked_range<Int>` as an argument).
 /// \param parents Parent tasks to wait for before executing.

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -14130,6 +14130,8 @@ Parameter ``port``:
 Parameter ``max_retries``:
     Maximum number of retries.)doc";
 
+static const char *__doc_sgl_thread_Task = R"doc(Opaque task type.)doc";
+
 static const char *__doc_sgl_thread_TaskGroup = R"doc(Helper class for managing a group of tasks.)doc";
 
 static const char *__doc_sgl_thread_TaskGroup_TaskGroup = R"doc()doc";
@@ -14192,13 +14194,9 @@ static const char *__doc_sgl_thread_blocked_range_m_block_size = R"doc()doc";
 
 static const char *__doc_sgl_thread_blocked_range_m_end = R"doc()doc";
 
-static const char *__doc_sgl_thread_current_thread_id =
-R"doc(Return the nanothread worker ID for the current thread, or zero for a
-non-worker thread.)doc";
-
 static const char *__doc_sgl_thread_do_async =
-R"doc(Run a function asynchronously in a new task. See nanothread
-documentation on `task_submit_dep` for details.
+R"doc(Run a function asynchronously in a new task. See `task_submit_dep` for
+details.
 
 Parameter ``func``:
     Function to call.
@@ -14213,8 +14211,8 @@ Returns:
     The new task.)doc";
 
 static const char *__doc_sgl_thread_do_async_2 =
-R"doc(Run a function asynchronously in a new task. See nanothread
-documentation on `task_submit_dep` for details.
+R"doc(Run a function asynchronously in a new task. See `task_submit_dep` for
+details.
 
 Parameter ``func``:
     Function to call.
@@ -14241,8 +14239,8 @@ Parameter ``func``:
     argument).)doc";
 
 static const char *__doc_sgl_thread_parallel_for_async =
-R"doc(Run a parallel for-loop asynchronously in a new task. See nanothread
-documentation on `task_submit_dep` for details.
+R"doc(Run a parallel for-loop asynchronously in a new task. See
+`task_submit_dep` for details.
 
 Parameter ``range``:
     Loop range.
@@ -14261,8 +14259,8 @@ Returns:
     The new task.)doc";
 
 static const char *__doc_sgl_thread_parallel_for_async_2 =
-R"doc(Run a parallel for-loop asynchronously in a new task. See nanothread
-documentation on `task_submit_dep` for details.
+R"doc(Run a parallel for-loop asynchronously in a new task. See
+`task_submit_dep` for details.
 
 Parameter ``range``:
     Loop range.
@@ -14277,11 +14275,61 @@ Parameter ``parents``:
 Returns:
     The new task.)doc";
 
-static const char *__doc_sgl_thread_rhi_task_pool = R"doc(Get the nanothread-backed task pool installed in slang-rhi.)doc";
+static const char *__doc_sgl_thread_rhi_task_pool = R"doc(Get the SGL task pool installed in slang-rhi.)doc";
 
 static const char *__doc_sgl_thread_static_init = R"doc()doc";
 
 static const char *__doc_sgl_thread_static_shutdown = R"doc()doc";
+
+static const char *__doc_sgl_thread_task_query = R"doc(Return whether a task has completed.)doc";
+
+static const char *__doc_sgl_thread_task_release = R"doc(Release a task handle.)doc";
+
+static const char *__doc_sgl_thread_task_retain = R"doc(Increase the reference count of a task.)doc";
+
+static const char *__doc_sgl_thread_task_submit_dep =
+R"doc(Submit a task with optional dependencies to the SGL thread pool.
+
+Parameter ``parents``:
+    Parent tasks to wait for before executing.
+
+Parameter ``parent_count``:
+    Number of parent tasks.
+
+Parameter ``size``:
+    Number of work units to execute.
+
+Parameter ``func``:
+    Function called once for each work unit.
+
+Parameter ``payload``:
+    Payload passed to the function.
+
+Parameter ``payload_size``:
+    Size of the payload copied into the task when no deleter is
+    provided.
+
+Parameter ``payload_deleter``:
+    Optional function that releases the payload after execution.
+
+Parameter ``always_async``:
+    Whether to disable synchronous execution of small tasks.
+
+Parameter ``profile``:
+    Whether to collect timing information for this task.
+
+Returns:
+    The submitted task, or nullptr if it completed synchronously.)doc";
+
+static const char *__doc_sgl_thread_task_time = R"doc(Return the execution time of a profiled task in milliseconds.)doc";
+
+static const char *__doc_sgl_thread_task_time_rel =
+R"doc(Return the difference between the start times of two profiled tasks in
+milliseconds.)doc";
+
+static const char *__doc_sgl_thread_task_wait = R"doc(Wait for a task to complete.)doc";
+
+static const char *__doc_sgl_thread_task_wait_and_release = R"doc(Wait for a task to complete and release its handle.)doc";
 
 static const char *__doc_sgl_thread_wait_for_tasks = R"doc(Wait for all tasks in the global task group.)doc";
 

--- a/tests/sgl/core/test_thread.cpp
+++ b/tests/sgl/core/test_thread.cpp
@@ -6,9 +6,6 @@
 #include <slang-rhi.h>
 
 #include <atomic>
-#include <chrono>
-#include <condition_variable>
-#include <mutex>
 
 using namespace sgl;
 
@@ -54,6 +51,20 @@ void execute_recursive_task(void* data)
 
 TEST_SUITE_BEGIN("thread");
 
+TEST_CASE("public task API executes tasks")
+{
+    std::atomic<bool> executed{false};
+    thread::TaskHandle task = thread::do_async(
+        [&executed]
+        {
+            executed.store(true);
+        }
+    );
+    thread::task_wait_and_release(task);
+
+    CHECK(executed.load());
+}
+
 TEST_CASE("rhi task pool executes tasks and deletes payloads")
 {
     struct Payload {
@@ -98,49 +109,6 @@ TEST_CASE("rhi task groups include tasks spawned by callbacks")
 
     CHECK(execute_count.load() == 7);
     CHECK(delete_count.load() == 7);
-}
-
-TEST_CASE("rhi task pool shares nanothread workers")
-{
-    struct Payload {
-        std::mutex mutex;
-        std::condition_variable condition;
-        bool done{false};
-        uint32_t worker_id{0};
-    } payload;
-
-    rhi::ITaskPool* pool = thread::rhi_task_pool();
-    auto task = pool->submitTask(
-        [](void* data)
-        {
-            auto* payload = static_cast<Payload*>(data);
-            {
-                std::lock_guard lock(payload->mutex);
-                payload->worker_id = thread::current_thread_id();
-                payload->done = true;
-            }
-            payload->condition.notify_one();
-        },
-        &payload,
-        nullptr
-    );
-
-    bool completed_on_worker = false;
-    {
-        std::unique_lock lock(payload.mutex);
-        completed_on_worker = payload.condition.wait_for(
-            lock,
-            std::chrono::seconds(10),
-            [&]
-            {
-                return payload.done;
-            }
-        );
-    }
-    pool->waitAndReleaseTask(task);
-
-    CHECK(completed_on_worker);
-    CHECK(payload.worker_id != 0);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Route public task operations through exported SGL wrappers so downstream libraries no longer create separate nanothread default pools.

Hide nanothread task types behind opaque handles, use short_vector for dependency conversion, and share the same pool with slang-rhi. Remove the unused worker-ID API and limit tests to SGL integration behavior.