### PR TITLE
Add pipeline compilation policy

### DIFF
--- a/docs/generated/api.rst
+++ b/docs/generated/api.rst
@@ -3560,6 +3560,9 @@ Device
     
     .. py:property:: program
         :type: slangpy.ShaderProgram
+
+    .. py:property:: compilation_policy
+        :type: slangpy.PipelineCompilationPolicy
     
     .. py:property:: label
         :type: str
@@ -4301,17 +4304,17 @@ Device
     .. py:method:: create_shader_object(self, cursor: slangpy.ReflectionCursor) -> slangpy.ShaderObject
         :no-index:
     
-    .. py:method:: create_compute_pipeline(self, program: slangpy.ShaderProgram, defer_target_compilation: bool = False, label: str | None = None) -> slangpy.ComputePipeline
+    .. py:method:: create_compute_pipeline(self, program: slangpy.ShaderProgram, compilation_policy: slangpy.PipelineCompilationPolicy = PipelineCompilationPolicy.default, label: str | None = None) -> slangpy.ComputePipeline
     
     .. py:method:: create_compute_pipeline(self, desc: slangpy.ComputePipelineDesc) -> slangpy.ComputePipeline
         :no-index:
     
-    .. py:method:: create_render_pipeline(self, program: slangpy.ShaderProgram, input_layout: slangpy.InputLayout | None, primitive_topology: slangpy.PrimitiveTopology = PrimitiveTopology.triangle_list, targets: collections.abc.Sequence[slangpy.ColorTargetDesc] = [], depth_stencil: slangpy.DepthStencilDesc | None = None, rasterizer: slangpy.RasterizerDesc | None = None, multisample: slangpy.MultisampleDesc | None = None, defer_target_compilation: bool = False, label: str | None = None) -> slangpy.RenderPipeline
+    .. py:method:: create_render_pipeline(self, program: slangpy.ShaderProgram, input_layout: slangpy.InputLayout | None, primitive_topology: slangpy.PrimitiveTopology = PrimitiveTopology.triangle_list, targets: collections.abc.Sequence[slangpy.ColorTargetDesc] = [], depth_stencil: slangpy.DepthStencilDesc | None = None, rasterizer: slangpy.RasterizerDesc | None = None, multisample: slangpy.MultisampleDesc | None = None, compilation_policy: slangpy.PipelineCompilationPolicy = PipelineCompilationPolicy.default, label: str | None = None) -> slangpy.RenderPipeline
     
     .. py:method:: create_render_pipeline(self, desc: slangpy.RenderPipelineDesc) -> slangpy.RenderPipeline
         :no-index:
     
-    .. py:method:: create_ray_tracing_pipeline(self, program: slangpy.ShaderProgram, hit_groups: collections.abc.Sequence[slangpy.HitGroupDesc], max_recursion: int = 0, max_ray_payload_size: int = 0, max_attribute_size: int = 8, flags: slangpy.RayTracingPipelineFlags = 0, defer_target_compilation: bool = False, label: str | None = None) -> slangpy.RayTracingPipeline
+    .. py:method:: create_ray_tracing_pipeline(self, program: slangpy.ShaderProgram, hit_groups: collections.abc.Sequence[slangpy.HitGroupDesc], max_recursion: int = 0, max_ray_payload_size: int = 0, max_attribute_size: int = 8, flags: slangpy.RayTracingPipelineFlags = 0, compilation_policy: slangpy.PipelineCompilationPolicy = PipelineCompilationPolicy.default, label: str | None = None) -> slangpy.RayTracingPipeline
     
     .. py:method:: create_ray_tracing_pipeline(self, desc: slangpy.RayTracingPipelineDesc) -> slangpy.RayTracingPipeline
         :no-index:
@@ -6232,6 +6235,26 @@ Device
 
 ----
 
+.. py:class:: slangpy.PipelineCompilationPolicy
+
+    Base class: :py:class:`enum.Enum`
+
+    .. py:attribute:: slangpy.PipelineCompilationPolicy.default
+        :type: PipelineCompilationPolicy
+        :value: PipelineCompilationPolicy.default
+
+    .. py:attribute:: slangpy.PipelineCompilationPolicy.immediate
+        :type: PipelineCompilationPolicy
+        :value: PipelineCompilationPolicy.immediate
+
+    .. py:attribute:: slangpy.PipelineCompilationPolicy.deferred
+        :type: PipelineCompilationPolicy
+        :value: PipelineCompilationPolicy.deferred
+
+
+
+----
+
 .. py:class:: slangpy.Pipeline
 
     Base class: :py:class:`slangpy.DeviceChild`
@@ -6526,6 +6549,9 @@ Device
     
     .. py:property:: flags
         :type: slangpy.RayTracingPipelineFlags
+
+    .. py:property:: compilation_policy
+        :type: slangpy.PipelineCompilationPolicy
     
     .. py:property:: label
         :type: str
@@ -6746,6 +6772,9 @@ Device
     
     .. py:property:: multisample
         :type: slangpy.MultisampleDesc
+
+    .. py:property:: compilation_policy
+        :type: slangpy.PipelineCompilationPolicy
     
     .. py:property:: label
         :type: str

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -21,6 +21,7 @@ from slangpy import (
     SlangLinkOptions,
     NativeHandle,
     DeviceType,
+    PipelineCompilationPolicy,
     TypeConformance,
     is_torch_bridge_using_fallback,
     get_torch_bridge_fallback_reason,
@@ -510,8 +511,8 @@ class CallData(NativeCallData):
             opts = SlangLinkOptions()
             opts.dump_intermediates = _DUMP_SLANG_INTERMEDIATES
             opts.dump_intermediates_prefix = sanitized
-            defer_target_compilation = bool(
-                build_info.options.get("defer_target_compilation", True)
+            compilation_policy = build_info.options.get(
+                "pipeline_compilation_policy", PipelineCompilationPolicy.default
             )
             if build_info.pipeline_type == PipelineType.compute:
                 # Create compute pipeline
@@ -523,7 +524,7 @@ class CallData(NativeCallData):
                 )
                 self.pipeline = device.create_compute_pipeline(
                     program,
-                    defer_target_compilation=defer_target_compilation,
+                    compilation_policy=compilation_policy,
                     label=f"{build_info.module.name}_{build_info.name}_compute_call",
                 )
                 build_info.module.pipeline_cache[hash] = self.pipeline
@@ -571,7 +572,7 @@ class CallData(NativeCallData):
                     max_ray_payload_size=build_info.ray_tracing_max_ray_payload_size,
                     max_attribute_size=build_info.ray_tracing_max_attribute_size,
                     flags=build_info.ray_tracing_flags,
-                    defer_target_compilation=defer_target_compilation,
+                    compilation_policy=compilation_policy,
                     label=f"{build_info.module.name}_{build_info.name}_rt_call",
                 )
                 build_info.module.pipeline_cache[hash] = self.pipeline

--- a/slangpy/core/calldata.py
+++ b/slangpy/core/calldata.py
@@ -512,7 +512,7 @@ class CallData(NativeCallData):
             opts.dump_intermediates = _DUMP_SLANG_INTERMEDIATES
             opts.dump_intermediates_prefix = sanitized
             compilation_policy = build_info.options.get(
-                "pipeline_compilation_policy", PipelineCompilationPolicy.default
+                "pipeline_compilation_policy", PipelineCompilationPolicy.deferred
             )
             if build_info.pipeline_type == PipelineType.compute:
                 # Create compute pipeline

--- a/slangpy/core/dispatchdata.py
+++ b/slangpy/core/dispatchdata.py
@@ -201,7 +201,7 @@ void {reflection.name}_entrypoint({params}) {{
                     opts,
                 )
                 compilation_policy = build_info.options.get(
-                    "pipeline_compilation_policy", PipelineCompilationPolicy.default
+                    "pipeline_compilation_policy", PipelineCompilationPolicy.deferred
                 )
                 self.compute_pipeline = device.create_compute_pipeline(
                     program,

--- a/slangpy/core/dispatchdata.py
+++ b/slangpy/core/dispatchdata.py
@@ -15,6 +15,7 @@ from slangpy import (
     SlangLinkOptions,
     uint3,
     DeviceType,
+    PipelineCompilationPolicy,
 )
 from slangpy.core.native import NativeCallRuntimeOptions
 from slangpy.bindings.marshall import BindContext
@@ -199,12 +200,12 @@ void {reflection.name}_entrypoint({params}) {{
                     [ep],
                     opts,
                 )
-                defer_target_compilation = bool(
-                    build_info.options.get("defer_target_compilation", True)
+                compilation_policy = build_info.options.get(
+                    "pipeline_compilation_policy", PipelineCompilationPolicy.default
                 )
                 self.compute_pipeline = device.create_compute_pipeline(
                     program,
-                    defer_target_compilation=defer_target_compilation,
+                    compilation_policy=compilation_policy,
                     label=f"{build_info.module.name}_{build_info.name}_dispatch",
                 )
                 self.device = device

--- a/slangpy/tests/device/test_compilation_reports.py
+++ b/slangpy/tests/device/test_compilation_reports.py
@@ -58,7 +58,10 @@ def test_compilation_reports(test_id: str, device_type: spy.DeviceType):
             """,
         )
         program = device.link_program([module], [module.entry_point("compute_main")])
-        pipeline = device.create_compute_pipeline(program, defer_target_compilation=False)
+        pipeline = device.create_compute_pipeline(
+            program,
+            compilation_policy=spy.PipelineCompilationPolicy.immediate,
+        )
 
         assert pipeline is not None
 

--- a/slangpy/tests/device/test_device.py
+++ b/slangpy/tests/device/test_device.py
@@ -59,7 +59,6 @@ def test_parallel_pipeline_compilation(test_id: str, device_type: spy.DeviceType
         pipelines = [
             device.create_compute_pipeline(
                 device.link_program([module], [module.entry_point(entry_point)]),
-                defer_target_compilation=True,
             )
             for entry_point in ["add", "multiply"]
         ]

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -160,7 +160,7 @@ struct DeviceDesc {
     /// Enable compilation reports.
     bool enable_compilation_reports{false};
 
-    /// Control resolution of deferred pipelines encountered while finishing a command encoder.
+    /// Control the default pipeline compilation policy and resolution of deferred pipelines.
     PipelineCompilationMode pipeline_compilation_mode{PipelineCompilationMode::serial};
 
     /// Adapter LUID to select adapter on which the device will be created.

--- a/src/sgl/device/pipeline.cpp
+++ b/src/sgl/device/pipeline.cpp
@@ -52,7 +52,7 @@ void ComputePipeline::recreate()
 {
     rhi::ComputePipelineDesc rhi_desc{
         .program = m_desc.program->rhi_shader_program(),
-        .deferTargetCompilation = m_desc.defer_target_compilation,
+        .compilationPolicy = static_cast<rhi::PipelineCompilationPolicy>(m_desc.compilation_policy),
         .label = m_desc.label.empty() ? nullptr : m_desc.label.c_str(),
     };
     SLANG_RHI_CALL(
@@ -169,7 +169,7 @@ void RenderPipeline::recreate()
             .alphaToCoverageEnable = desc.multisample.alpha_to_coverage_enable,
             .alphaToOneEnable = desc.multisample.alpha_to_one_enable,
         },
-        .deferTargetCompilation = m_desc.defer_target_compilation,
+        .compilationPolicy = static_cast<rhi::PipelineCompilationPolicy>(m_desc.compilation_policy),
         .label = m_desc.label.empty() ? nullptr : m_desc.label.c_str(),
     };
 
@@ -236,7 +236,7 @@ void RayTracingPipeline::recreate()
         .maxRayPayloadSize = desc.max_ray_payload_size,
         .maxAttributeSizeInBytes = desc.max_attribute_size,
         .flags = static_cast<rhi::RayTracingPipelineFlags>(desc.flags),
-        .deferTargetCompilation = m_desc.defer_target_compilation,
+        .compilationPolicy = static_cast<rhi::PipelineCompilationPolicy>(m_desc.compilation_policy),
         .label = m_desc.label.empty() ? nullptr : m_desc.label.c_str(),
     };
     SLANG_RHI_CALL(

--- a/src/sgl/device/pipeline.h
+++ b/src/sgl/device/pipeline.h
@@ -20,6 +20,22 @@
 
 namespace sgl {
 
+enum class PipelineCompilationPolicy : uint32_t {
+    default_ = static_cast<uint32_t>(rhi::PipelineCompilationPolicy::Default),
+    immediate = static_cast<uint32_t>(rhi::PipelineCompilationPolicy::Immediate),
+    deferred = static_cast<uint32_t>(rhi::PipelineCompilationPolicy::Deferred),
+};
+
+SGL_ENUM_INFO(
+    PipelineCompilationPolicy,
+    {
+        {PipelineCompilationPolicy::default_, "default"},
+        {PipelineCompilationPolicy::immediate, "immediate"},
+        {PipelineCompilationPolicy::deferred, "deferred"},
+    }
+);
+SGL_ENUM_REGISTER(PipelineCompilationPolicy);
+
 
 /// Pipeline base class.
 class SGL_API Pipeline : public DeviceChild {
@@ -43,7 +59,7 @@ private:
 
 struct ComputePipelineDesc {
     ref<ShaderProgram> program;
-    bool defer_target_compilation{false};
+    PipelineCompilationPolicy compilation_policy{PipelineCompilationPolicy::default_};
     std::string label;
 };
 
@@ -84,7 +100,7 @@ struct RenderPipelineDesc {
     DepthStencilDesc depth_stencil;
     RasterizerDesc rasterizer;
     MultisampleDesc multisample;
-    bool defer_target_compilation{false};
+    PipelineCompilationPolicy compilation_policy{PipelineCompilationPolicy::default_};
     std::string label;
 };
 
@@ -131,7 +147,7 @@ struct RayTracingPipelineDesc {
     uint32_t max_ray_payload_size{0};
     uint32_t max_attribute_size{8};
     RayTracingPipelineFlags flags{RayTracingPipelineFlags::none};
-    bool defer_target_compilation{false};
+    PipelineCompilationPolicy compilation_policy{PipelineCompilationPolicy::default_};
     std::string label;
 };
 

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -1127,16 +1127,19 @@ SGL_PY_EXPORT(device_device)
 
     device.def(
         "create_compute_pipeline",
-        [](Device* self, ref<ShaderProgram> program, bool defer_target_compilation, std::optional<std::string> label)
+        [](Device* self,
+           ref<ShaderProgram> program,
+           PipelineCompilationPolicy compilation_policy,
+           std::optional<std::string> label)
         {
             return self->create_compute_pipeline({
                 .program = std::move(program),
-                .defer_target_compilation = defer_target_compilation,
+                .compilation_policy = compilation_policy,
                 .label = label.value_or(""),
             });
         },
         "program"_a,
-        "defer_target_compilation"_a = ComputePipelineDesc().defer_target_compilation,
+        "compilation_policy"_a = ComputePipelineDesc().compilation_policy,
         "label"_a.none() = nb::none(),
         D(Device, create_compute_pipeline)
     );
@@ -1153,7 +1156,7 @@ SGL_PY_EXPORT(device_device)
            std::optional<DepthStencilDesc> depth_stencil,
            std::optional<RasterizerDesc> rasterizer,
            std::optional<MultisampleDesc> multisample,
-           bool defer_target_compilation,
+           PipelineCompilationPolicy compilation_policy,
            std::optional<std::string> label)
         {
             return self->create_render_pipeline(
@@ -1164,7 +1167,7 @@ SGL_PY_EXPORT(device_device)
                  .depth_stencil = depth_stencil.value_or(DepthStencilDesc{}),
                  .rasterizer = rasterizer.value_or(RasterizerDesc{}),
                  .multisample = multisample.value_or(MultisampleDesc{}),
-                 .defer_target_compilation = defer_target_compilation,
+                 .compilation_policy = compilation_policy,
                  .label = label.value_or("")}
             );
         },
@@ -1175,7 +1178,7 @@ SGL_PY_EXPORT(device_device)
         "depth_stencil"_a.none() = nb::none(),
         "rasterizer"_a.none() = nb::none(),
         "multisample"_a.none() = nb::none(),
-        "defer_target_compilation"_a = RenderPipelineDesc().defer_target_compilation,
+        "compilation_policy"_a = RenderPipelineDesc().compilation_policy,
         "label"_a.none() = nb::none(),
         D(Device, create_render_pipeline)
     );
@@ -1190,7 +1193,7 @@ SGL_PY_EXPORT(device_device)
            uint32_t max_ray_payload_size,
            uint32_t max_attribute_size,
            RayTracingPipelineFlags flags,
-           bool defer_target_compilation,
+           PipelineCompilationPolicy compilation_policy,
            std::optional<std::string> label)
         {
             return self->create_ray_tracing_pipeline({
@@ -1200,7 +1203,7 @@ SGL_PY_EXPORT(device_device)
                 .max_ray_payload_size = max_ray_payload_size,
                 .max_attribute_size = max_attribute_size,
                 .flags = flags,
-                .defer_target_compilation = defer_target_compilation,
+                .compilation_policy = compilation_policy,
                 .label = label.value_or(""),
             });
         },
@@ -1210,7 +1213,7 @@ SGL_PY_EXPORT(device_device)
         "max_ray_payload_size"_a = RayTracingPipelineDesc().max_ray_payload_size,
         "max_attribute_size"_a = RayTracingPipelineDesc().max_attribute_size,
         "flags"_a = RayTracingPipelineDesc().flags,
-        "defer_target_compilation"_a = RayTracingPipelineDesc().defer_target_compilation,
+        "compilation_policy"_a = RayTracingPipelineDesc().compilation_policy,
         "label"_a.none() = nb::none(),
         D(Device, create_ray_tracing_pipeline)
     );
@@ -1741,16 +1744,16 @@ SGL_PY_EXPORT(device_device)
 
     m.def(
         "create_compute_pipeline",
-        [](ref<ShaderProgram> program, bool defer_target_compilation, std::optional<std::string> label)
+        [](ref<ShaderProgram> program, PipelineCompilationPolicy compilation_policy, std::optional<std::string> label)
         {
             return create_compute_pipeline({
                 .program = std::move(program),
-                .defer_target_compilation = defer_target_compilation,
+                .compilation_policy = compilation_policy,
                 .label = label.value_or(""),
             });
         },
         "program"_a,
-        "defer_target_compilation"_a = ComputePipelineDesc().defer_target_compilation,
+        "compilation_policy"_a = ComputePipelineDesc().compilation_policy,
         "label"_a.none() = nb::none(),
         D(create_compute_pipeline)
     );
@@ -1770,7 +1773,7 @@ SGL_PY_EXPORT(device_device)
            std::optional<DepthStencilDesc> depth_stencil,
            std::optional<RasterizerDesc> rasterizer,
            std::optional<MultisampleDesc> multisample,
-           bool defer_target_compilation,
+           PipelineCompilationPolicy compilation_policy,
            std::optional<std::string> label)
         {
             return create_render_pipeline(
@@ -1781,7 +1784,7 @@ SGL_PY_EXPORT(device_device)
                  .depth_stencil = depth_stencil.value_or(DepthStencilDesc{}),
                  .rasterizer = rasterizer.value_or(RasterizerDesc{}),
                  .multisample = multisample.value_or(MultisampleDesc{}),
-                 .defer_target_compilation = defer_target_compilation,
+                 .compilation_policy = compilation_policy,
                  .label = label.value_or("")}
             );
         },
@@ -1792,7 +1795,7 @@ SGL_PY_EXPORT(device_device)
         "depth_stencil"_a.none() = nb::none(),
         "rasterizer"_a.none() = nb::none(),
         "multisample"_a.none() = nb::none(),
-        "defer_target_compilation"_a = RenderPipelineDesc().defer_target_compilation,
+        "compilation_policy"_a = RenderPipelineDesc().compilation_policy,
         "label"_a.none() = nb::none(),
         D(create_render_pipeline)
     );
@@ -1811,7 +1814,7 @@ SGL_PY_EXPORT(device_device)
            uint32_t max_ray_payload_size,
            uint32_t max_attribute_size,
            RayTracingPipelineFlags flags,
-           bool defer_target_compilation,
+           PipelineCompilationPolicy compilation_policy,
            std::optional<std::string> label)
         {
             return create_ray_tracing_pipeline({
@@ -1821,7 +1824,7 @@ SGL_PY_EXPORT(device_device)
                 .max_ray_payload_size = max_ray_payload_size,
                 .max_attribute_size = max_attribute_size,
                 .flags = flags,
-                .defer_target_compilation = defer_target_compilation,
+                .compilation_policy = compilation_policy,
                 .label = label.value_or(""),
             });
         },
@@ -1831,7 +1834,7 @@ SGL_PY_EXPORT(device_device)
         "max_ray_payload_size"_a = RayTracingPipelineDesc().max_ray_payload_size,
         "max_attribute_size"_a = RayTracingPipelineDesc().max_attribute_size,
         "flags"_a = RayTracingPipelineDesc().flags,
-        "defer_target_compilation"_a = RayTracingPipelineDesc().defer_target_compilation,
+        "compilation_policy"_a = RayTracingPipelineDesc().compilation_policy,
         "label"_a.none() = nb::none(),
         D(create_ray_tracing_pipeline)
     );

--- a/src/slangpy_ext/device/pipeline.cpp
+++ b/src/slangpy_ext/device/pipeline.cpp
@@ -9,6 +9,7 @@
 namespace sgl {
 SGL_DICT_TO_DESC_BEGIN(ComputePipelineDesc)
 SGL_DICT_TO_DESC_FIELD(program, ref<ShaderProgram>)
+SGL_DICT_TO_DESC_FIELD(compilation_policy, PipelineCompilationPolicy)
 SGL_DICT_TO_DESC_FIELD(label, std::string)
 SGL_DICT_TO_DESC_END()
 
@@ -20,6 +21,7 @@ SGL_DICT_TO_DESC_FIELD(targets, std::vector<ColorTargetDesc>)
 SGL_DICT_TO_DESC_FIELD(depth_stencil, DepthStencilDesc)
 SGL_DICT_TO_DESC_FIELD(rasterizer, RasterizerDesc)
 SGL_DICT_TO_DESC_FIELD(multisample, MultisampleDesc)
+SGL_DICT_TO_DESC_FIELD(compilation_policy, PipelineCompilationPolicy)
 SGL_DICT_TO_DESC_FIELD(label, std::string)
 SGL_DICT_TO_DESC_END()
 
@@ -37,6 +39,7 @@ SGL_DICT_TO_DESC_FIELD(max_recursion, uint32_t)
 SGL_DICT_TO_DESC_FIELD(max_ray_payload_size, uint32_t)
 SGL_DICT_TO_DESC_FIELD(max_attribute_size, uint32_t)
 SGL_DICT_TO_DESC_FIELD(flags, RayTracingPipelineFlags)
+SGL_DICT_TO_DESC_FIELD(compilation_policy, PipelineCompilationPolicy)
 SGL_DICT_TO_DESC_FIELD(label, std::string)
 SGL_DICT_TO_DESC_END()
 } // namespace sgl
@@ -44,6 +47,8 @@ SGL_DICT_TO_DESC_END()
 SGL_PY_EXPORT(device_pipeline)
 {
     using namespace sgl;
+
+    nb::sgl_enum<PipelineCompilationPolicy>(m, "PipelineCompilationPolicy");
 
     nb::class_<Pipeline, DeviceChild>(m, "Pipeline", D(Pipeline));
 
@@ -57,6 +62,7 @@ SGL_PY_EXPORT(device_pipeline)
             }
         )
         .def_rw("program", &ComputePipelineDesc::program, D(ComputePipelineDesc, program))
+        .def_rw("compilation_policy", &ComputePipelineDesc::compilation_policy)
         .def_rw("label", &ComputePipelineDesc::label, D(ComputePipelineDesc, label));
     nb::implicitly_convertible<nb::dict, ComputePipelineDesc>();
 
@@ -84,6 +90,7 @@ SGL_PY_EXPORT(device_pipeline)
         .def_rw("depth_stencil", &RenderPipelineDesc::depth_stencil, D(RenderPipelineDesc, depth_stencil))
         .def_rw("rasterizer", &RenderPipelineDesc::rasterizer, D(RenderPipelineDesc, rasterizer))
         .def_rw("multisample", &RenderPipelineDesc::multisample, D(RenderPipelineDesc, multisample))
+        .def_rw("compilation_policy", &RenderPipelineDesc::compilation_policy)
         .def_rw("label", &RenderPipelineDesc::label, D(RenderPipelineDesc, label));
 
     nb::class_<RenderPipeline, Pipeline>(m, "RenderPipeline", D(RenderPipeline)) //
@@ -147,6 +154,7 @@ SGL_PY_EXPORT(device_pipeline)
             D(RayTracingPipelineDesc, max_attribute_size)
         )
         .def_rw("flags", &RayTracingPipelineDesc::flags, D(RayTracingPipelineDesc, flags))
+        .def_rw("compilation_policy", &RayTracingPipelineDesc::compilation_policy)
         .def_rw("label", &RayTracingPipelineDesc::label, D(RayTracingPipelineDesc, label));
     nb::implicitly_convertible<nb::dict, RayTracingPipelineDesc>();
 

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -2007,7 +2007,7 @@ static const char *__doc_sgl_ComputePipelineDesc = R"doc()doc";
 
 static const char *__doc_sgl_ComputePipelineDesc_2 = R"doc()doc";
 
-static const char *__doc_sgl_ComputePipelineDesc_defer_target_compilation = R"doc()doc";
+static const char *__doc_sgl_ComputePipelineDesc_compilation_policy = R"doc()doc";
 
 static const char *__doc_sgl_ComputePipelineDesc_label = R"doc()doc";
 
@@ -2880,8 +2880,8 @@ R"doc(Path to the module cache directory (optional). If a relative path is
 used, the cache is stored in the application data directory.)doc";
 
 static const char *__doc_sgl_DeviceDesc_pipeline_compilation_mode =
-R"doc(Control resolution of deferred pipelines encountered while finishing a
-command encoder.)doc";
+R"doc(Control the default pipeline compilation policy and resolution of
+deferred pipelines.)doc";
 
 static const char *__doc_sgl_DeviceDesc_rhi_validation_log_level =
 R"doc(RHI validation layer log level (only applicable if RHI validation is
@@ -6300,6 +6300,16 @@ static const char *__doc_sgl_PipelineCompilationMode_parallel = R"doc()doc";
 
 static const char *__doc_sgl_PipelineCompilationMode_serial = R"doc()doc";
 
+static const char *__doc_sgl_PipelineCompilationPolicy = R"doc()doc";
+
+static const char *__doc_sgl_PipelineCompilationPolicy_default = R"doc()doc";
+
+static const char *__doc_sgl_PipelineCompilationPolicy_deferred = R"doc()doc";
+
+static const char *__doc_sgl_PipelineCompilationPolicy_immediate = R"doc()doc";
+
+static const char *__doc_sgl_PipelineCompilationPolicy_info = R"doc()doc";
+
 static const char *__doc_sgl_Pipeline_Pipeline = R"doc()doc";
 
 static const char *__doc_sgl_Pipeline_class_name = R"doc()doc";
@@ -7313,7 +7323,7 @@ static const char *__doc_sgl_RayTracingPipelineDesc = R"doc()doc";
 
 static const char *__doc_sgl_RayTracingPipelineDesc_2 = R"doc()doc";
 
-static const char *__doc_sgl_RayTracingPipelineDesc_defer_target_compilation = R"doc()doc";
+static const char *__doc_sgl_RayTracingPipelineDesc_compilation_policy = R"doc()doc";
 
 static const char *__doc_sgl_RayTracingPipelineDesc_flags = R"doc()doc";
 
@@ -7473,7 +7483,7 @@ static const char *__doc_sgl_RenderPipelineDesc = R"doc()doc";
 
 static const char *__doc_sgl_RenderPipelineDesc_2 = R"doc()doc";
 
-static const char *__doc_sgl_RenderPipelineDesc_defer_target_compilation = R"doc()doc";
+static const char *__doc_sgl_RenderPipelineDesc_compilation_policy = R"doc()doc";
 
 static const char *__doc_sgl_RenderPipelineDesc_depth_stencil = R"doc()doc";
 
@@ -10837,6 +10847,8 @@ static const char *__doc_sgl_find_enum_info_adl_82 = R"doc()doc";
 static const char *__doc_sgl_find_enum_info_adl_83 = R"doc()doc";
 
 static const char *__doc_sgl_find_enum_info_adl_84 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_85 = R"doc()doc";
 
 static const char *__doc_sgl_flags_to_string_list = R"doc(Convert an flags enum value to a list of strings.)doc";
 


### PR DESCRIPTION
Expose PipelineCompilationPolicy with default, immediate, and deferred modes across SGL and SlangPy. Replace the legacy
defer_target_compilation flag on pipeline descriptors and creation APIs.

The default policy now follows the device pipeline compilation mode, so selecting parallel compilation automatically defers pipeline compilation. Propagate the policy through functional-call pipeline creation and update tests, bindings, and generated API documentation.

Update slang-rhi to the revision providing the corresponding policy API.