### PR TITLE
Fix logger deadlock with Python-backed outputs

### DIFF
--- a/src/sgl/core/logger.cpp
+++ b/src/sgl/core/logger.cpp
@@ -179,6 +179,7 @@ std::string DebugConsoleLoggerOutput::to_string() const
 Logger::Logger(LogLevel log_level, const std::string_view name, bool use_default_outputs)
     : m_level(log_level)
     , m_name(name)
+    , m_outputs(std::make_shared<OutputSet>())
 {
     if (use_default_outputs) {
         add_output(make_ref<ConsoleLoggerOutput>());
@@ -208,29 +209,88 @@ ref<LoggerOutput> Logger::add_debug_console_output()
     return output;
 }
 
+// LoggerOutput uses intrusive reference counting. For outputs implemented in Python, copying or destroying a
+// ref<LoggerOutput> acquires the GIL. To avoid a lock-order inversion between the GIL and m_mutex, the mutex only
+// protects native shared_ptr handles to immutable output sets. Output sets themselves are copied and destroyed after
+// releasing the mutex.
+Logger::OutputSnapshot Logger::output_snapshot() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_outputs;
+}
+
+void Logger::publish_outputs(OutputSnapshot outputs)
+{
+    OutputSnapshot previous_outputs;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_outputs == outputs)
+            return;
+
+        // Move the previous snapshot into a local so its output references are released after unlocking.
+        previous_outputs = std::move(m_outputs);
+        m_outputs = std::move(outputs);
+    }
+}
+
+template<typename Mutator>
+void Logger::mutate_outputs(Mutator&& mutator)
+{
+    while (true) {
+        OutputSnapshot outputs = output_snapshot();
+
+        // Copying and modifying the set can retain or release Python-backed outputs, so do both without m_mutex.
+        auto next_outputs = std::make_shared<OutputSet>(*outputs);
+        if (!mutator(*next_outputs))
+            return;
+
+        OutputSnapshot previous_outputs;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+
+            // Another writer published while the set was being copied. Retry against its snapshot to avoid losing
+            // updates or resurrecting outputs replaced by remove_all_outputs() or use_same_outputs().
+            if (m_outputs != outputs)
+                continue;
+
+            // Keep the replaced snapshot alive until after m_mutex is released.
+            previous_outputs = std::move(m_outputs);
+            m_outputs = std::move(next_outputs);
+        }
+        return;
+    }
+}
+
 void Logger::use_same_outputs(const Logger& other)
 {
-    remove_all_outputs();
-    for (auto& output : other.m_outputs)
-        add_output(output);
+    if (&other == this)
+        return;
+    publish_outputs(other.output_snapshot());
 }
 
 void Logger::add_output(ref<LoggerOutput> output)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_outputs.insert(output);
+    mutate_outputs(
+        [&](OutputSet& outputs)
+        {
+            return outputs.insert(output).second;
+        }
+    );
 }
 
 void Logger::remove_output(ref<LoggerOutput> output)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_outputs.erase(output);
+    mutate_outputs(
+        [&](OutputSet& outputs)
+        {
+            return outputs.erase(output) != 0;
+        }
+    );
 }
 
 void Logger::remove_all_outputs()
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_outputs.clear();
+    publish_outputs(std::make_shared<OutputSet>());
 }
 
 std::string Logger::name() const
@@ -247,36 +307,35 @@ void Logger::set_name(std::string_view name)
 
 LogLevel Logger::level() const
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    return m_level;
+    return m_level.load(std::memory_order_relaxed);
 }
 
 void Logger::set_level(LogLevel level)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_level = level;
+    m_level.store(level, std::memory_order_relaxed);
 }
 
 void Logger::log(LogLevel level, const std::string_view msg, LogFrequency frequency)
 {
-    std::set<ref<LoggerOutput>> outputs;
+    if (!should_log(level))
+        return;
+
+    OutputSnapshot outputs;
     std::string name;
 
     {
         std::lock_guard<std::mutex> lock(m_mutex);
 
-        if (level != LogLevel::none && level < m_level)
-            return;
-
         if (frequency == LogFrequency::once && is_duplicate(msg))
             return;
 
-        // Outputs may re-enter the logger or call into another runtime such as Python.
+        // Retaining the outer shared_ptr does not touch the intrusive references stored in the immutable set.
         outputs = m_outputs;
         name = m_name;
     }
 
-    for (const auto& output : outputs)
+    // Outputs may re-enter the logger or call into another runtime such as Python.
+    for (const auto& output : *outputs)
         output->write(level, name, msg);
 }
 

--- a/src/sgl/core/logger.h
+++ b/src/sgl/core/logger.h
@@ -6,10 +6,12 @@
 #include "sgl/core/object.h"
 #include "sgl/core/format.h"
 
-#include <mutex>
-#include <string_view>
-#include <set>
+#include <atomic>
 #include <filesystem>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string_view>
 
 namespace sgl {
 
@@ -102,24 +104,26 @@ public:
 /// - name_once(msg)
 /// - name_once(fmt, ...)
 /// The once variants only log the message once per program run.
-#define SGL_LOG_FUNC_FAMILY(name, level, log_func)                                                                     \
+#define SGL_LOG_FUNC_FAMILY(name, level)                                                                               \
     inline void name(const std::string_view msg)                                                                       \
     {                                                                                                                  \
-        log_func(level, msg, LogFrequency::always);                                                                    \
+        log(level, msg, LogFrequency::always);                                                                         \
     }                                                                                                                  \
     template<typename... Args>                                                                                         \
     inline void name(fmt::format_string<Args...> fmt, Args&&... args)                                                  \
     {                                                                                                                  \
-        log_func(level, fmt::format(fmt, std::forward<Args>(args)...), LogFrequency::always);                          \
+        if (should_log(level))                                                                                         \
+            log(level, fmt::format(fmt, std::forward<Args>(args)...), LogFrequency::always);                           \
     }                                                                                                                  \
     inline void name##_once(const std::string_view msg)                                                                \
     {                                                                                                                  \
-        log_func(level, msg, LogFrequency::once);                                                                      \
+        log(level, msg, LogFrequency::once);                                                                           \
     }                                                                                                                  \
     template<typename... Args>                                                                                         \
     inline void name##_once(fmt::format_string<Args...> fmt, Args&&... args)                                           \
     {                                                                                                                  \
-        log_func(level, fmt::format(fmt, std::forward<Args>(args)...), LogFrequency::once);                            \
+        if (should_log(level))                                                                                         \
+            log(level, fmt::format(fmt, std::forward<Args>(args)...), LogFrequency::once);                             \
     }
 
 
@@ -182,11 +186,11 @@ public:
     void log(LogLevel level, const std::string_view msg, LogFrequency frequency = LogFrequency::always);
 
     // Define logging functions.
-    SGL_LOG_FUNC_FAMILY(debug, LogLevel::debug, log)
-    SGL_LOG_FUNC_FAMILY(info, LogLevel::info, log)
-    SGL_LOG_FUNC_FAMILY(warn, LogLevel::warn, log)
-    SGL_LOG_FUNC_FAMILY(error, LogLevel::error, log)
-    SGL_LOG_FUNC_FAMILY(fatal, LogLevel::fatal, log)
+    SGL_LOG_FUNC_FAMILY(debug, LogLevel::debug)
+    SGL_LOG_FUNC_FAMILY(info, LogLevel::info)
+    SGL_LOG_FUNC_FAMILY(warn, LogLevel::warn)
+    SGL_LOG_FUNC_FAMILY(error, LogLevel::error)
+    SGL_LOG_FUNC_FAMILY(fatal, LogLevel::fatal)
 
     /// Returns the global logger instance.
     static Logger& get();
@@ -195,27 +199,70 @@ public:
     static void static_shutdown();
 
 private:
+    using OutputSet = std::set<ref<LoggerOutput>>;
+    using OutputSnapshot = std::shared_ptr<const OutputSet>;
+
+    /// Returns the current immutable output set.
+    OutputSnapshot output_snapshot() const;
+
+    /// Publishes an immutable output set and retires the previous set after unlocking.
+    void publish_outputs(OutputSnapshot outputs);
+
+    /// Applies a copy-on-write mutation without copying or destroying output references while locked.
+    /// The mutator returns true if the copied set changed and may be called again after a publication race.
+    template<typename Mutator>
+    void mutate_outputs(Mutator&& mutator);
+
+    /// Returns true if a message at the given level should be logged.
+    bool should_log(LogLevel level) const
+    {
+        return level == LogLevel::none || level >= m_level.load(std::memory_order_relaxed);
+    }
+
     /// Checks if the given message has already been logged.
     bool is_duplicate(const std::string_view msg);
 
-    LogLevel m_level{LogLevel::info};
+    std::atomic<LogLevel> m_level{LogLevel::info};
     std::string m_name;
 
-    // Access to the output registry is protected by m_mutex. log() takes a snapshot and calls
-    // LoggerOutput::write() after releasing the mutex, so output implementations must be thread-safe.
-    std::set<ref<LoggerOutput>> m_outputs;
+    // Published output sets are immutable. log() retains one shared snapshot while holding m_mutex,
+    // then calls LoggerOutput::write() after releasing the mutex. An output removed concurrently may
+    // therefore receive a call already in progress. Output implementations must be thread-safe.
+    OutputSnapshot m_outputs;
     std::set<std::string, std::less<>> m_messages;
 
     mutable std::mutex m_mutex;
 };
 
-// Define global logging functions.
-SGL_LOG_FUNC_FAMILY(log_debug, LogLevel::debug, Logger::get().log)
-SGL_LOG_FUNC_FAMILY(log_info, LogLevel::info, Logger::get().log)
-SGL_LOG_FUNC_FAMILY(log_warn, LogLevel::warn, Logger::get().log)
-SGL_LOG_FUNC_FAMILY(log_error, LogLevel::error, Logger::get().log)
-SGL_LOG_FUNC_FAMILY(log_fatal, LogLevel::fatal, Logger::get().log)
+// Define global logging functions that forward to the global logger. Formatted messages are
+// filtered by the Logger methods before formatting.
+#define SGL_GLOBAL_LOG_FUNC_FAMILY(name)                                                                               \
+    inline void log_##name(const std::string_view msg)                                                                 \
+    {                                                                                                                  \
+        Logger::get().name(msg);                                                                                       \
+    }                                                                                                                  \
+    template<typename... Args>                                                                                         \
+    inline void log_##name(fmt::format_string<Args...> fmt, Args&&... args)                                            \
+    {                                                                                                                  \
+        Logger::get().name(fmt, std::forward<Args>(args)...);                                                          \
+    }                                                                                                                  \
+    inline void log_##name##_once(const std::string_view msg)                                                          \
+    {                                                                                                                  \
+        Logger::get().name##_once(msg);                                                                                \
+    }                                                                                                                  \
+    template<typename... Args>                                                                                         \
+    inline void log_##name##_once(fmt::format_string<Args...> fmt, Args&&... args)                                     \
+    {                                                                                                                  \
+        Logger::get().name##_once(fmt, std::forward<Args>(args)...);                                                   \
+    }
 
+SGL_GLOBAL_LOG_FUNC_FAMILY(debug)
+SGL_GLOBAL_LOG_FUNC_FAMILY(info)
+SGL_GLOBAL_LOG_FUNC_FAMILY(warn)
+SGL_GLOBAL_LOG_FUNC_FAMILY(error)
+SGL_GLOBAL_LOG_FUNC_FAMILY(fatal)
+
+#undef SGL_GLOBAL_LOG_FUNC_FAMILY
 #undef SGL_LOG_FUNC_FAMILY
 
 } // namespace sgl

--- a/tests/sgl/core/test_logger.cpp
+++ b/tests/sgl/core/test_logger.cpp
@@ -262,4 +262,21 @@ TEST_CASE("filtered formatted messages avoid formatting")
     CHECK_EQ(output->m_write_count, 1);
 }
 
+TEST_CASE("filtered formatted once messages avoid formatting")
+{
+    auto logger = Logger::create(LogLevel::info, "test", false);
+    auto output = make_ref<CountingLoggerOutput>();
+    logger->add_output(output);
+    bool formatted = false;
+
+    logger->debug_once("{}", FormatProbe{&formatted});
+    CHECK_FALSE(formatted);
+    CHECK_EQ(output->m_write_count, 0);
+
+    logger->set_level(LogLevel::debug);
+    logger->debug_once("{}", FormatProbe{&formatted});
+    CHECK(formatted);
+    CHECK_EQ(output->m_write_count, 1);
+}
+
 TEST_SUITE_END();

--- a/tests/sgl/core/test_logger.cpp
+++ b/tests/sgl/core/test_logger.cpp
@@ -3,7 +3,29 @@
 #include "testing.h"
 #include "sgl/core/logger.h"
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
 using namespace sgl;
+
+struct FormatProbe {
+    bool* formatted;
+};
+
+template<>
+struct fmt::formatter<FormatProbe> : fmt::formatter<std::string_view> {
+    template<typename FormatContext>
+    auto format(const FormatProbe& value, FormatContext& ctx) const
+    {
+        *value.formatted = true;
+        return fmt::formatter<std::string_view>::format("probe", ctx);
+    }
+};
 
 TEST_SUITE_BEGIN("logger");
 
@@ -32,6 +54,61 @@ public:
     size_t m_write_count{0};
 };
 
+class CountingLoggerOutput : public LoggerOutput {
+    SGL_OBJECT(CountingLoggerOutput)
+public:
+    void write(LogLevel, const std::string_view, const std::string_view) override { m_write_count++; }
+
+    std::atomic<size_t> m_write_count{0};
+};
+
+class RefCountLoggerOutput : public LoggerOutput {
+    SGL_OBJECT(RefCountLoggerOutput)
+public:
+    void write(LogLevel, const std::string_view, const std::string_view) override
+    {
+        m_ref_count_during_write = ref_count();
+    }
+
+    uint64_t m_ref_count_during_write{0};
+};
+
+struct BlockingLoggerOutputState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool entered{false};
+    bool release{false};
+    std::atomic<bool> destroyed{false};
+};
+
+class BlockingLoggerOutput : public LoggerOutput {
+    SGL_OBJECT(BlockingLoggerOutput)
+public:
+    explicit BlockingLoggerOutput(std::shared_ptr<BlockingLoggerOutputState> state)
+        : m_state(std::move(state))
+    {
+    }
+
+    ~BlockingLoggerOutput() { m_state->destroyed = true; }
+
+    void write(LogLevel, const std::string_view, const std::string_view) override
+    {
+        std::unique_lock lock(m_state->mutex);
+        m_state->entered = true;
+        m_state->condition.notify_all();
+        m_state->condition.wait(
+            lock,
+            [&]()
+            {
+                return m_state->release;
+            }
+        );
+    }
+
+private:
+    std::shared_ptr<BlockingLoggerOutputState> m_state;
+};
+
 TEST_CASE("output callback can re-enter logger")
 {
     auto logger = Logger::create(LogLevel::info, "test", false);
@@ -45,6 +122,144 @@ TEST_CASE("output callback can re-enter logger")
     CHECK_EQ(output->m_module, "test");
     CHECK_EQ(output->m_msg, "message");
     CHECK_EQ(output->m_logger_name, "test");
+}
+
+TEST_CASE("logging retains the output set snapshot")
+{
+    auto logger = Logger::create(LogLevel::info, "test", false);
+    auto output = make_ref<RefCountLoggerOutput>();
+    logger->add_output(output);
+    const uint64_t ref_count_before_log = output->ref_count();
+
+    logger->warn("message");
+
+    CHECK_EQ(output->m_ref_count_during_write, ref_count_before_log);
+}
+
+TEST_CASE("output snapshot keeps a removed output alive during a callback")
+{
+    auto logger = Logger::create(LogLevel::info, "test", false);
+    auto state = std::make_shared<BlockingLoggerOutputState>();
+    auto output = make_ref<BlockingLoggerOutput>(state);
+    logger->add_output(output);
+
+    std::thread worker(
+        [logger]()
+        {
+            logger->warn("message");
+        }
+    );
+
+    {
+        std::unique_lock lock(state->mutex);
+        REQUIRE(state->condition.wait_for(
+            lock,
+            std::chrono::seconds(5),
+            [&]()
+            {
+                return state->entered;
+            }
+        ));
+    }
+
+    logger->remove_output(output);
+    output.reset();
+    CHECK_FALSE(state->destroyed);
+
+    {
+        std::lock_guard lock(state->mutex);
+        state->release = true;
+    }
+    state->condition.notify_all();
+    worker.join();
+
+    CHECK(state->destroyed);
+}
+
+TEST_CASE("use_same_outputs copies an immutable snapshot")
+{
+    auto source = Logger::create(LogLevel::info, "source", false);
+    auto target = Logger::create(LogLevel::info, "target", false);
+    auto first = make_ref<CountingLoggerOutput>();
+    auto second = make_ref<CountingLoggerOutput>();
+    source->add_output(first);
+
+    target->use_same_outputs(*source);
+    target->use_same_outputs(*target);
+    source->add_output(second);
+
+    target->warn("target");
+    CHECK_EQ(first->m_write_count, 1);
+    CHECK_EQ(second->m_write_count, 0);
+
+    source->warn("source");
+    CHECK_EQ(first->m_write_count, 2);
+    CHECK_EQ(second->m_write_count, 1);
+
+    target->remove_all_outputs();
+    target->warn("removed");
+    CHECK_EQ(first->m_write_count, 2);
+    CHECK_EQ(second->m_write_count, 1);
+}
+
+TEST_CASE("concurrent output mutations preserve all updates")
+{
+    auto logger = Logger::create(LogLevel::info, "test", false);
+    constexpr size_t output_count = 16;
+    std::vector<ref<CountingLoggerOutput>> outputs;
+    std::vector<std::thread> workers;
+
+    outputs.reserve(output_count);
+    workers.reserve(output_count);
+    for (size_t i = 0; i < output_count; ++i)
+        outputs.push_back(make_ref<CountingLoggerOutput>());
+
+    for (const auto& output : outputs)
+        workers.emplace_back(
+            [logger, output]()
+            {
+                logger->add_output(output);
+            }
+        );
+    for (auto& worker : workers)
+        worker.join();
+
+    logger->warn("added");
+    for (const auto& output : outputs)
+        CHECK_EQ(output->m_write_count, 1);
+
+    workers.clear();
+    for (size_t i = 0; i < output_count; i += 2)
+        workers.emplace_back(
+            [logger, output = outputs[i]]()
+            {
+                logger->remove_output(output);
+            }
+        );
+    for (auto& worker : workers)
+        worker.join();
+
+    logger->warn("removed");
+    for (size_t i = 0; i < output_count; ++i)
+        CHECK_EQ(outputs[i]->m_write_count, i % 2 == 0 ? 1 : 2);
+}
+
+TEST_CASE("filtered formatted messages avoid formatting")
+{
+    auto logger = Logger::create(LogLevel::info, "test", false);
+    auto output = make_ref<CountingLoggerOutput>();
+    logger->add_output(output);
+    bool formatted = false;
+
+    logger->debug("{}", FormatProbe{&formatted});
+    CHECK_FALSE(formatted);
+    CHECK_EQ(output->m_write_count, 0);
+
+    logger->set_level(LogLevel::debug);
+    CHECK_EQ(logger->level(), LogLevel::debug);
+    logger->debug("{}", FormatProbe{&formatted});
+    CHECK(formatted);
+    CHECK_EQ(output->m_write_count, 1);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Store logger outputs in immutable shared snapshots so logging only retains a native shared_ptr while holding the logger mutex. This prevents intrusive reference operations for Python-backed outputs from acquiring the GIL under the mutex.

Update output registration through copy-on-write snapshots constructed and destroyed outside the mutex. Retry publication after concurrent changes to avoid lost updates and prevent cleared or replaced outputs from being resurrected.

Make the log level atomic so filtered messages avoid mutex acquisition, and skip formatting for filtered formatted messages. Also make use_same_outputs() synchronized and safe for self-assignment.

Add coverage for callback re-entry, snapshot reference counts, removal during active callbacks, concurrent output mutations, snapshot sharing, and lazy formatting.