### PR TITLE
Sanitizers

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,171 @@
+name: sanitizers
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  asan-ubsan:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows, platform: x86_64, compiler: clang, preset: windows-clang, config: RelWithDebInfo, runs-on: { labels: [Windows, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: linux, platform: x86_64, compiler: clang, preset: linux-clang, config: RelWithDebInfo, runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: macos, platform: aarch64, compiler: clang, preset: macos-arm64-clang, config: RelWithDebInfo, runs-on: macos-latest }
+
+    runs-on: ${{ matrix.runs-on }}
+
+    env:
+      CI_OS: ${{ matrix.os }}
+      CI_PLATFORM: ${{ matrix.platform }}
+      CI_COMPILER: ${{ matrix.compiler }}
+      CI_CONFIG: ${{ matrix.config }}
+      CI_PYTHON: "3.10"
+      CI_CMAKE_ARGS: "-DSGL_ENABLE_ASAN=ON -DSGL_ENABLE_UBSAN=ON"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Cleanup submodules
+        run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
+
+      - name: Setup MSVC
+        if: runner.os == 'Windows'
+        uses: step-security/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+
+      - name: Setup CMake/Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Setup Python (no cache)
+        if: runner.environment == 'self-hosted'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Setup Python (pip cache)
+        if: runner.environment == 'github-hosted'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Setup Python environment
+        run: |
+          python -m pip install -r requirements-dev.txt
+          python -m pip install pytest-github-actions-annotate-failures
+
+      # LLVM 22 contains the Windows ASan exception-handling fix from
+      # llvm/llvm-project#159618. The Clang bundled with Visual Studio is too
+      # old and produces false access violations for ordinary catch blocks.
+      - name: Setup LLVM 22 for Windows ASan
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $llvmVersion = "22.1.6"
+          $llvmRoot = Join-Path $env:RUNNER_TEMP "llvm-$llvmVersion"
+          $llvmInstaller = Join-Path $env:RUNNER_TEMP "LLVM-$llvmVersion-win64.exe"
+          $llvmUrl = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvmVersion/LLVM-$llvmVersion-win64.exe"
+
+          Invoke-WebRequest -Uri $llvmUrl -OutFile $llvmInstaller
+          $process = Start-Process -FilePath $llvmInstaller -ArgumentList "/S", "/D=$llvmRoot" -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "LLVM installer failed with exit code $($process.ExitCode)"
+          }
+
+          $llvmBin = Join-Path $llvmRoot "bin"
+          $clang = Join-Path $llvmBin "clang.exe"
+          $clangxx = Join-Path $llvmBin "clang++.exe"
+          if (!(Test-Path -LiteralPath $clang) -or !(Test-Path -LiteralPath $clangxx)) {
+            throw "LLVM installation did not produce the expected Clang executables in $llvmBin"
+          }
+
+          $llvmBin >> $env:GITHUB_PATH
+          "CC=$clang" >> $env:GITHUB_ENV
+          "CXX=$clangxx" >> $env:GITHUB_ENV
+
+      - name: Setup repository
+        run: python tools/ci.py setup
+
+      - name: Set vcpkg cache directory
+        if: runner.environment == 'github-hosted'
+        run: |
+          echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg-cache" >> $GITHUB_ENV
+          mkdir -p ${{ github.workspace }}/vcpkg-cache
+
+      - name: Setup vcpkg caching
+        if: runner.environment == 'github-hosted'
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: vcpkg-sanitizers-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'external/vcpkg-triplets/**') }}
+
+      - name: Configure
+        run: python tools/ci.py configure
+
+      - name: Build
+        run: python tools/ci.py build
+
+      - name: Setup Sanitizer Options
+        id: sanitizer_options
+        run: python tools/setup-sanitizer-env.py --os ${{ matrix.os }} --sanitizers address,undefined --binary-dir build/${{ matrix.preset }}/${{ matrix.config }}
+
+      - name: Unit Tests (C++)
+        env:
+          # Native test executables link the sanitizer runtimes themselves.
+          # Preloading another copy can create incompatible runtime instances.
+          LD_PRELOAD: ""
+          DYLD_INSERT_LIBRARIES: ""
+        run: python tools/ci.py unit-test-cpp
+
+      - name: Verify Windows ASan runtime
+        if: matrix.os == 'windows'
+        run: |
+          build/${{ matrix.preset }}/${{ matrix.config }}/slangpy_sanitizer_python.exe -c "import ctypes, slangpy; assert ctypes.windll.kernel32.GetModuleHandleW('clang_rt.asan_dynamic-x86_64.dll'), 'ASan runtime was not loaded'"
+
+      - name: Unit Tests (Python)
+        if: matrix.os == 'linux'
+        run: python tools/ci.py unit-test-python --disable-torch
+
+      - name: Unit Tests (Python, Windows ASan host)
+        if: matrix.os == 'windows'
+        env:
+          # ASan commits shadow pages through handled access violations on
+          # Windows. Pytest's faulthandler otherwise prints each first-chance
+          # exception even though execution continues normally.
+          PYTEST_ADDOPTS: "-p no:faulthandler"
+        run: build/${{ matrix.preset }}/${{ matrix.config }}/slangpy_sanitizer_python.exe tools/ci.py unit-test-python --disable-torch
+
+      - name: Unit Tests (Python, macOS sanitizer host)
+        if: matrix.os == 'macos'
+        env:
+          # The host links ASan and UBSan before initializing stock CPython.
+          DYLD_INSERT_LIBRARIES: ""
+        run: build/${{ matrix.preset }}/${{ matrix.config }}/slangpy_sanitizer_python tools/ci.py unit-test-python --disable-torch
+
+      - name: Check LeakSanitizer Reports
+        if: ${{ always() && matrix.os == 'linux' && steps.sanitizer_options.outcome == 'success' }}
+        run: python tools/filter-lsan-reports.py
+
+      - name: Upload Sanitizer Reports
+        if: ${{ always() && matrix.os == 'linux' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: sanitizer-reports-${{ matrix.os }}-${{ matrix.platform }}
+          path: build/${{ matrix.preset }}/${{ matrix.config }}/sanitizer-logs/
+          if-no-files-found: ignore

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -160,10 +160,15 @@ jobs:
 
       - name: Check LeakSanitizer Reports
         if: ${{ always() && matrix.os == 'linux' && steps.sanitizer_options.outcome == 'success' }}
+        env:
+          # This tooling is not instrumented; do not preload the runtimes.
+          LD_PRELOAD: ""
         run: python tools/filter-lsan-reports.py
 
       - name: Upload Sanitizer Reports
         if: ${{ always() && matrix.os == 'linux' }}
+        env:
+          LD_PRELOAD: ""
         uses: actions/upload-artifact@v7
         with:
           name: sanitizer-reports-${{ matrix.os }}-${{ matrix.platform }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,11 @@ option(SGL_ENABLE_PCH "Enable precompiled headers" OFF)
 # Enable/disable code coverage.
 option(SGL_ENABLE_COVERAGE "Enable code coverage (gcov)" OFF)
 
-# Enable/disable address sanitizer.
-option(SGL_ENABLE_ASAN "Enable address sanitizer" OFF)
+# Enable/disable sanitizers.
+option(SGL_ENABLE_ASAN "Enable AddressSanitizer (Clang only)" OFF)
+option(SGL_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer (Clang only)" OFF)
+
+include(sanitizers)
 
 # Enable/disable header validation.
 # If enabled, additional targets are generated to validate that headers are self sufficient.
@@ -120,7 +123,11 @@ message(STATUS "Architecture: ${SGL_ARCHITECTURE}")
 # -----------------------------------------------------------------------------
 
 if(SGL_BUILD_PYTHON)
-    find_package(Python 3.9 COMPONENTS Interpreter Development.Module REQUIRED)
+    if((SGL_WINDOWS OR SGL_MACOS) AND SGL_ENABLE_ASAN)
+        find_package(Python 3.9 COMPONENTS Interpreter Development.Module Development.Embed REQUIRED)
+    else()
+        find_package(Python 3.9 COMPONENTS Interpreter Development.Module REQUIRED)
+    endif()
 endif()
 
 # -----------------------------------------------------------------------------
@@ -188,6 +195,7 @@ git_version_setup()
 
 macro(sgl_add_example target)
     add_executable(${target})
+    sgl_enable_sanitizers(${target})
     target_link_libraries(${target} PRIVATE sgl)
     target_compile_definitions(${target} PRIVATE SGL_EXAMPLE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
     set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${SGL_RUNTIME_OUTPUT_DIRECTORY})
@@ -413,6 +421,18 @@ endif()
 
 if(SGL_BUILD_TESTS)
     add_subdirectory(tests)
+endif()
+
+# Windows and macOS cannot reliably load ASan into an existing Python process.
+# This small host links the sanitizer runtime before initializing stock CPython,
+# so the Python interpreter itself does not need to be rebuilt with ASan.
+if((SGL_WINDOWS OR SGL_MACOS) AND SGL_ENABLE_ASAN AND SGL_BUILD_PYTHON)
+    add_executable(slangpy_sanitizer_python tools/sanitizer_python.cpp)
+    sgl_enable_sanitizers(slangpy_sanitizer_python)
+    target_link_libraries(slangpy_sanitizer_python PRIVATE Python::Python)
+    set_target_properties(slangpy_sanitizer_python PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${SGL_RUNTIME_OUTPUT_DIRECTORY}
+    )
 endif()
 
 # -----------------------------------------------------------------------------

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,0 +1,112 @@
+# Configure sanitizer instrumentation for SlangPy-owned native targets.
+
+if(NOT SGL_ENABLE_ASAN AND NOT SGL_ENABLE_UBSAN)
+    function(sgl_enable_sanitizers target)
+    endfunction()
+    return()
+endif()
+
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "SlangPy sanitizers are only supported with Clang")
+endif()
+
+set(SGL_SANITIZERS)
+if(SGL_ENABLE_ASAN)
+    list(APPEND SGL_SANITIZERS address)
+endif()
+if(SGL_ENABLE_UBSAN)
+    list(APPEND SGL_SANITIZERS undefined)
+endif()
+list(JOIN SGL_SANITIZERS "," SGL_SANITIZER_FLAGS)
+
+add_library(sgl_sanitizers INTERFACE)
+target_compile_options(sgl_sanitizers INTERFACE
+    -fsanitize=${SGL_SANITIZER_FLAGS}
+    -fno-omit-frame-pointer
+)
+target_link_options(sgl_sanitizers INTERFACE
+    -fsanitize=${SGL_SANITIZER_FLAGS}
+)
+
+if(SGL_ENABLE_UBSAN)
+    target_compile_options(sgl_sanitizers INTERFACE
+        -fno-sanitize-recover=undefined
+        -fsanitize-ignorelist=${CMAKE_SOURCE_DIR}/tools/ubsan-ignorelist.txt
+    )
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        # Clang's Windows vptr runtime is built against the static release CRT,
+        # while SlangPy and its vcpkg dependencies use the dynamic CRT. Keep the
+        # remaining UBSan checks without introducing an incompatible runtime.
+        # Clang autolinks both UBSan libraries for the umbrella `undefined`
+        # group even after vptr is disabled. Ignore only the incompatible C++
+        # runtime default library and explicitly retain the core runtime.
+        target_compile_options(sgl_sanitizers INTERFACE
+            -fno-sanitize=vptr
+        )
+        target_link_options(sgl_sanitizers INTERFACE
+            -fno-sanitize=vptr
+        )
+
+        if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "x64")
+            set(SGL_UBSAN_RUNTIME_ARCH "x86_64")
+        elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64")
+            set(SGL_UBSAN_RUNTIME_ARCH "aarch64")
+        else()
+            message(FATAL_ERROR
+                "Unsupported Windows architecture for UBSan: ${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}"
+            )
+        endif()
+        set(SGL_UBSAN_RUNTIME_NAME
+            "clang_rt.ubsan_standalone-${SGL_UBSAN_RUNTIME_ARCH}.lib"
+        )
+        target_link_options(sgl_sanitizers INTERFACE
+            -Xlinker /NODEFAULTLIB:clang_rt.ubsan_standalone_cxx-${SGL_UBSAN_RUNTIME_ARCH}.lib
+        )
+        execute_process(
+            COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=${SGL_UBSAN_RUNTIME_NAME}
+            OUTPUT_VARIABLE SGL_UBSAN_RUNTIME
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(NOT EXISTS "${SGL_UBSAN_RUNTIME}")
+            message(FATAL_ERROR "Could not locate the Windows UBSan runtime: ${SGL_UBSAN_RUNTIME_NAME}")
+        endif()
+        target_link_libraries(sgl_sanitizers INTERFACE "${SGL_UBSAN_RUNTIME}")
+    endif()
+endif()
+
+if(SGL_ENABLE_ASAN AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 22)
+        message(FATAL_ERROR
+            "Windows ASan requires Clang 22 or newer because older releases "
+            "mis-instrument C++ exception catch parameters"
+        )
+    endif()
+
+    # The debug CRT conflicts with ASan. SlangPy's vcpkg triplet uses the
+    # dynamic release CRT, so keep all targets on that compatible runtime.
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
+    # Current Clang releases use the dynamic ASan runtime for Windows executables
+    # and DLLs, including DLLs loaded by an unsanitized host. Prebuilt vcpkg
+    # libraries have MSVC STL annotations disabled, so all linked objects must
+    # use the same setting to satisfy the linker's /failifmismatch checks.
+    target_compile_definitions(sgl_sanitizers INTERFACE
+        _DISABLE_STRING_ANNOTATION
+        _DISABLE_VECTOR_ANNOTATION
+    )
+
+    # Windows exception unwinding is still incompatible with ASan's general
+    # stack-object instrumentation (google/sanitizers#749). Disabling stack
+    # instrumentation retains heap and global checks and allows exceptions to
+    # cross between the extension, the stock CPython DLL, and the test host.
+    target_compile_options(sgl_sanitizers INTERFACE
+        -mllvm -asan-stack=0
+    )
+endif()
+
+function(sgl_enable_sanitizers target)
+    target_link_libraries(${target} PRIVATE sgl_sanitizers)
+endfunction()
+
+message(STATUS "SlangPy sanitizers: ${SGL_SANITIZER_FLAGS}")

--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -246,10 +246,87 @@ The following table lists the available configuration options:
       - Enable precompiled headers
     * - ``SGL_ENABLE_ASAN``
       - ``OFF``
-      - Enable address sanitizer
+      - Enable AddressSanitizer (Clang only)
+    * - ``SGL_ENABLE_UBSAN``
+      - ``OFF``
+      - Enable UndefinedBehaviorSanitizer (Clang only)
     * - ``SGL_ENABLE_HEADER_VALIDATION``
       - ``OFF``
       - Enable header validation
+
+
+Sanitizer builds
+----------------
+
+SlangPy supports AddressSanitizer (ASan) and UndefinedBehaviorSanitizer
+(UBSan) with Clang. Enabling these options instruments the native SlangPy
+libraries, the Python extension, C++ tests, examples, and the embedded
+``slang-rhi`` library. Prebuilt dependencies such as Slang, Python, and GPU
+drivers are not instrumented.
+
+Configure and build a sanitizer-enabled ``RelWithDebInfo`` build with the
+platform's Clang preset. For example, on Linux use::
+
+    cmake --preset linux-clang --fresh -DSGL_ENABLE_ASAN=ON -DSGL_ENABLE_UBSAN=ON
+    cmake --build --preset linux-clang-relwithdebinfo
+
+On Windows, use Clang 22 or newer and a ``RelWithDebInfo`` build. Clang 22
+includes the fix for incorrect ASan instrumentation of C++ exception catch
+parameters on Windows. Configure both sanitizers with::
+
+    cmake --preset windows-clang --fresh -DSGL_ENABLE_ASAN=ON -DSGL_ENABLE_UBSAN=ON
+    cmake --build --preset windows-clang-relwithdebinfo
+
+``RelWithDebInfo`` is required on Windows because LLVM's UBSan C++ runtime uses
+the release iterator ABI. It retains symbols while avoiding an ABI mismatch
+with the Debug C++ runtime. The ``vptr`` check is disabled on Windows because
+Clang ships its support library with a static-CRT ABI that is incompatible with
+SlangPy's dynamic-CRT dependencies; SlangPy explicitly links the compatible
+core runtime and the remaining UBSan checks are enabled.
+
+On Apple Silicon, use ``macos-arm64-clang`` and
+``macos-arm64-clang-relwithdebinfo`` with both sanitizer options.
+
+On Linux, the native extension is loaded by an ordinary Python executable, so
+test processes must preload the Clang sanitizer runtimes. The helper below
+prints the required environment assignments for local use and writes them
+directly to the GitHub Actions environment when ``GITHUB_ENV`` is present::
+
+    python tools/setup-sanitizer-env.py \
+        --os linux \
+        --sanitizers address,undefined \
+        --binary-dir build/linux-clang/RelWithDebInfo
+
+On Linux, apply the printed environment assignments and run the C++ and Python
+tests normally. Pass the generated leak reports through
+``tools/filter-lsan-reports.py``. The filter fails for leaks originating in
+SlangPy or ``slang-rhi`` and ignores reports whose allocation site is external
+code such as Python or a GPU driver.
+
+On Windows and macOS, loading the sanitizer runtimes only when the SlangPy
+extension is imported is too late for CPython's existing allocations. ASan
+builds on these platforms therefore also produce ``slangpy_sanitizer_python``
+(``.exe`` on Windows). This small executable links the runtimes before it
+initializes stock CPython; CPython itself does not need to be rebuilt. Use it in
+place of the ordinary Python executable when running tests. On Windows, the
+environment helper also copies the matching runtime DLL beside the build output
+and adds its directory to ``PATH``. For example::
+
+    build\windows-clang\RelWithDebInfo\slangpy_sanitizer_python.exe \
+        tools\ci.py unit-test-python --disable-torch
+
+On macOS, use the corresponding host without the ``.exe`` suffix::
+
+    build/macos-arm64-clang/RelWithDebInfo/slangpy_sanitizer_python \
+        tools/ci.py unit-test-python --disable-torch
+
+Only instrumented SlangPy and ``slang-rhi`` code receives complete ASan
+coverage; prebuilt Python and GPU driver code does not. Sanitizer tests make
+installed ``torch`` and ``slangpy_torch`` packages unavailable because they
+load separately built native libraries into the instrumented process. Tests
+that require them are skipped in the same way as in an environment where the
+packages are not installed.
+
 
 
 

--- a/docs/src/developer_guide/compiling.rst
+++ b/docs/src/developer_guide/compiling.rst
@@ -312,8 +312,7 @@ place of the ordinary Python executable when running tests. On Windows, the
 environment helper also copies the matching runtime DLL beside the build output
 and adds its directory to ``PATH``. For example::
 
-    build\windows-clang\RelWithDebInfo\slangpy_sanitizer_python.exe \
-        tools\ci.py unit-test-python --disable-torch
+    build\windows-clang\RelWithDebInfo\slangpy_sanitizer_python.exe tools\ci.py unit-test-python --disable-torch
 
 On macOS, use the corresponding host without the ``.exe`` suffix::
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -247,6 +247,24 @@ set(SLANG_RHI_BUILD_EXAMPLES OFF)
 set(SLANG_RHI_FETCH_SLANG OFF)
 set(SLANG_RHI_ENABLE_D3D11 OFF)
 set(SLANG_RHI_ENABLE_WGPU OFF)
+# A sanitizer-enabled SlangPy build instruments all project-owned native code,
+# including the statically linked slang-rhi implementation.
+set(SLANG_RHI_ENABLE_ASAN ${SGL_ENABLE_ASAN} CACHE BOOL "Enable AddressSanitizer in slang-rhi" FORCE)
+set(SLANG_RHI_ENABLE_UBSAN ${SGL_ENABLE_UBSAN} CACHE BOOL "Enable UndefinedBehaviorSanitizer in slang-rhi" FORCE)
+# ThreadSanitizer support is available in slang-rhi, but SlangPy does not yet
+# expose or test a compatible top-level configuration.
+set(SLANG_RHI_ENABLE_TSAN OFF CACHE BOOL "Enable ThreadSanitizer in slang-rhi" FORCE)
+if(SGL_ENABLE_UBSAN AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Match the Windows UBSan scope used by SlangPy-owned targets. The vptr
+    # support library has a static-CRT ABI incompatible with our dependencies;
+    # the final owned target explicitly links only the core UBSan runtime.
+    add_compile_options(-fno-sanitize=vptr)
+endif()
+if(SGL_ENABLE_ASAN AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Keep MSVC STL annotation settings consistent with uninstrumented vcpkg
+    # libraries linked into sgl. slang-rhi remains otherwise ASan-instrumented.
+    add_compile_definitions(_DISABLE_STRING_ANNOTATION _DISABLE_VECTOR_ANNOTATION)
+endif()
 # TODO: We should rename SLANG_RHI_BUILD_FROM_SLANG_REPO to something more generic.
 # We want slang-rhi to support using a `slang` target that is provided from the outside.
 set(SLANG_RHI_BUILD_FROM_SLANG_REPO ON)
@@ -259,6 +277,17 @@ if(SGL_LOCAL_RHI)
 else()
     add_subdirectory(slang-rhi)
     set(SGL_RHI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/slang-rhi)
+endif()
+
+if(SGL_ENABLE_ASAN AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Standalone slang-rhi uses the static release CRT for ASan. SlangPy's
+    # x64-windows-static-md-fix vcpkg triplet instead links static libraries
+    # built with the dynamic release CRT, so embedded RHI targets must match it.
+    foreach(target slang-rhi slang-rhi-d3d12ma slang-rhi-vma slang-rhi-resources)
+        if(TARGET ${target})
+            set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+        endif()
+    endforeach()
 endif()
 
 # Copy shared slang-rhi-device.h header to shaders directory (wrapped in sgl/device/rhi.slang)

--- a/slangpy/tests/conftest.py
+++ b/slangpy/tests/conftest.py
@@ -1,3 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import os
+import sys
+
+
+if os.environ.get("SLANGPY_TEST_DISABLE_TORCH"):
+    # Make installed Torch packages behave as if they were unavailable. This
+    # runs before the SlangPy pytest plugin imports the native extension, so the
+    # bridge and individual tests consistently observe the same environment.
+    for package in ("torch", "slangpy_torch"):
+        if sys.modules.get(package) is not None:
+            raise RuntimeError(f"{package} was imported before it could be disabled")
+        sys.modules[package] = None
+
+
 pytest_plugins = "slangpy.testing.plugin"

--- a/src/sgl/CMakeLists.txt
+++ b/src/sgl/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_library(sgl SHARED)
+sgl_enable_sanitizers(sgl)
 
 option(SGL_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
@@ -299,31 +300,6 @@ if(SGL_ENABLE_COVERAGE)
     else()
         message(WARNING "gcov not found! Code coverage will not be available.")
     endif()
-endif()
-
-if(SGL_ENABLE_ASAN)
-    target_compile_options(sgl
-        PUBLIC
-            $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:
-                /fsanitize=address
-            >
-            $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-                -fsanitize=address
-            >
-    )
-    target_link_options(sgl
-        PUBLIC
-            $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-                -fsanitize=address
-            >
-    )
-    target_compile_definitions(sgl
-        PUBLIC
-            $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:
-                _DISABLE_VECTOR_ANNOTATION
-                _DISABLE_STRING_ANNOTATION
-            >
-    )
 endif()
 
 if(SGL_ENABLE_BUILD_METRICS)

--- a/src/slangpy_ext/CMakeLists.txt
+++ b/src/slangpy_ext/CMakeLists.txt
@@ -72,6 +72,8 @@ nanobind_add_module(slangpy_ext NB_STATIC LTO
     utils/torch_bridge.cpp
 )
 
+sgl_enable_sanitizers(slangpy_ext)
+
 if(SGL_ENABLE_PCH)
     target_precompile_headers(slangpy_ext
         PRIVATE
@@ -128,42 +130,46 @@ function(postprocess_stub stub_file args)
     )
 endfunction()
 
-# Generate main stub file.
-nanobind_add_stub(
-    slangpy_stub
-    MODULE slangpy
-    PYTHON_PATH ${SLANGPY_PACKAGE_DIR}/..
-    OUTPUT ${SLANGPY_PACKAGE_DIR}/__init__.pyi
-    DEPENDS slangpy_ext ${SLANGPY_PACKAGE_DIR}/__init__.py
-    INCLUDE_PRIVATE # allow us to have functions/variables that start with _
-    PATTERN_FILE ${CMAKE_CURRENT_LIST_DIR}/slangpy_stub_patterns.nb
-)
-
-# Post-process the main stub file.
-postprocess_stub(${SLANGPY_PACKAGE_DIR}/__init__.pyi "")
-
-# Install the main stub file.
-install(FILES ${SLANGPY_PACKAGE_DIR}/__init__.pyi DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-# Generate submodule stub files.
-foreach(submodule IN ITEMS platform thread math ui tev crashpad renderdoc slangpy native_refl native_func)
-    string(REPLACE "." "/" submodule_path ${submodule})
+# Stub generation imports the extension into an unsanitized Python host. The
+# required sanitizer runtime preload is not portable across the Clang runtime
+# layouts used by our CI platforms, so retain the checked-in stubs instead.
+if(NOT SGL_ENABLE_ASAN AND NOT SGL_ENABLE_UBSAN)
+    # Generate main stub file.
     nanobind_add_stub(
-        slangpy_${submodule}_stub
-        MODULE slangpy.${submodule}
+        slangpy_stub
+        MODULE slangpy
         PYTHON_PATH ${SLANGPY_PACKAGE_DIR}/..
-        OUTPUT ${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.pyi
-        DEPENDS slangpy_ext ${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.py
+        OUTPUT ${SLANGPY_PACKAGE_DIR}/__init__.pyi
+        DEPENDS slangpy_ext ${SLANGPY_PACKAGE_DIR}/__init__.py
         INCLUDE_PRIVATE # allow us to have functions/variables that start with _
+        PATTERN_FILE ${CMAKE_CURRENT_LIST_DIR}/slangpy_stub_patterns.nb
     )
 
-    # Post-process the submodule stub file.
-    postprocess_stub(${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.pyi "--submodule")
+    # Post-process the main stub file.
+    postprocess_stub(${SLANGPY_PACKAGE_DIR}/__init__.pyi "")
 
-    # Install the submodule stub file.
-    install(FILES ${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.pyi DESTINATION ${CMAKE_INSTALL_BINDIR}/${submodule_path})
+    # Install the main stub file.
+    install(FILES ${SLANGPY_PACKAGE_DIR}/__init__.pyi DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-endforeach()
+    # Generate submodule stub files.
+    foreach(submodule IN ITEMS platform thread math ui tev crashpad renderdoc slangpy native_refl native_func)
+        string(REPLACE "." "/" submodule_path ${submodule})
+        nanobind_add_stub(
+            slangpy_${submodule}_stub
+            MODULE slangpy.${submodule}
+            PYTHON_PATH ${SLANGPY_PACKAGE_DIR}/..
+            OUTPUT ${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.pyi
+            DEPENDS slangpy_ext ${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.py
+            INCLUDE_PRIVATE # allow us to have functions/variables that start with _
+        )
+
+        # Post-process the submodule stub file.
+        postprocess_stub(${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.pyi "--submodule")
+
+        # Install the submodule stub file.
+        install(FILES ${SLANGPY_PACKAGE_DIR}/${submodule_path}/__init__.pyi DESTINATION ${CMAKE_INSTALL_BINDIR}/${submodule_path})
+    endforeach()
+endif()
 
 set(MKDOC_ARGS "")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@
 if(SGL_BUILD_TESTS)
 
     add_executable(sgl_tests)
+    sgl_enable_sanitizers(sgl_tests)
     target_sources(sgl_tests PRIVATE
         sgl/sgl_tests.cpp
         sgl/testing.cpp

--- a/tools/asan-suppressions.txt
+++ b/tools/asan-suppressions.txt
@@ -1,0 +1,23 @@
+# AddressSanitizer suppressions for SlangPy sanitizer test runs.
+# These suppress known issues in third-party GPU libraries outside SlangPy and slang-rhi.
+# Reference: https://clang.llvm.org/docs/AddressSanitizer.html#suppressing-reports-in-external-libraries
+
+# NVIDIA CUDA driver
+interceptor_via_lib:libcuda.so
+interceptor_via_lib:libnvidia
+
+# NVIDIA Runtime Compiler
+interceptor_via_lib:libnvrtc
+
+# NVIDIA OptiX ray tracing engine
+interceptor_via_lib:libnvoptix
+
+# Vulkan loader and drivers
+interceptor_via_lib:libvulkan
+
+# OpenGL/GLX/EGL (used by some drivers)
+interceptor_via_lib:libGLX
+interceptor_via_lib:libEGL
+
+# Dawn WebGPU
+interceptor_via_lib:libdawn

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -217,7 +217,7 @@ def benchmark_python(args: Any):
                     cmd += ["--benchmark-mongodb-database-name", args.mongodb_database_name]
 
             try:
-                run_command(cmd, env=env)
+                run_command(cmd, shell=False, env=env)
             except Exception as e:
                 print(f"Benchmarks failed for device type {device_type}: {e}")
                 if args.device_type:  # If specific device requested, fail hard

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -20,7 +20,7 @@ PYTEST_BASE_TEMP_DIR = PROJECT_DIR / ".temp" / "pytest"
 def pytest_command(test_path: str, *args: str) -> list[str]:
     # Pytest clears --basetemp on startup, so keep it in a dedicated repo-local directory.
     PYTEST_BASE_TEMP_DIR.parent.mkdir(exist_ok=True)
-    return ["pytest", test_path, *args, f"--basetemp={PYTEST_BASE_TEMP_DIR}"]
+    return [sys.executable, "-m", "pytest", test_path, *args, f"--basetemp={PYTEST_BASE_TEMP_DIR}"]
 
 
 def get_os():
@@ -109,9 +109,12 @@ def run_command(
     return out
 
 
-def get_python_env():
+def get_python_env(preset: Optional[str] = None) -> dict[str, str]:
     env = dict(os.environ)
     env["PYTHONPATH"] = str(PROJECT_DIR)
+    if preset:
+        slang_bin_dir = PROJECT_DIR / "build" / preset / "_deps" / "slang-src" / "bin"
+        env["PATH"] = os.pathsep.join((str(slang_bin_dir), env.get("PATH", "")))
     return env
 
 
@@ -149,20 +152,22 @@ def typing_check_python(args: Any):
 
 
 def unit_test_python(args: Any):
-    env = get_python_env()
+    env = get_python_env(args.preset)
+    if args.disable_torch:
+        env["SLANGPY_TEST_DISABLE_TORCH"] = "1"
     os.makedirs("reports", exist_ok=True)
     cmd = pytest_command("slangpy/tests", "-vra")
     if args.parallel:
         cmd += ["-n", "auto", "--maxprocesses=4"]
-    run_command(cmd, env=env)
+    run_command(cmd, shell=False, env=env)
 
 
 def test_examples(args: Any):
-    env = get_python_env()
+    env = get_python_env(args.preset)
     cmd = pytest_command("samples/tests", "-vra")
     if args.parallel:
         cmd += ["-n", "auto", "--maxprocesses=4"]
-    run_command(cmd, env=env)
+    run_command(cmd, shell=False, env=env)
 
 
 def benchmark_python(args: Any):
@@ -296,6 +301,11 @@ def main():
     parser_test_python = commands.add_parser("unit-test-python", help="run unit tests (python)")
     parser_test_python.add_argument(
         "-p", "--parallel", action="store_true", help="run tests in parallel"
+    )
+    parser_test_python.add_argument(
+        "--disable-torch",
+        action="store_true",
+        help="make torch and slangpy_torch unavailable to the test process",
     )
 
     parser_test_examples = commands.add_parser("test-examples", help="run examples tests")

--- a/tools/filter-lsan-reports.py
+++ b/tools/filter-lsan-reports.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#!/usr/bin/env python3
-
 import argparse
 import os
 import pathlib

--- a/tools/filter-lsan-reports.py
+++ b/tools/filter-lsan-reports.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+from typing import List, Optional, Tuple
+
+
+LEAK_HEADER_RE = re.compile(r"^(Direct|Indirect) leak of .+ allocated from:$")
+FRAME_RE = re.compile(r"^\s*#(?P<index>\d+)\s+")
+PROJECT_SOURCE_DIRS = (
+    "src/sgl/",
+    "src/slangpy_ext/",
+    "src/slangpy_torch/",
+    "tests/",
+    "external/slang-rhi/src/",
+    "external/slang-rhi/include/",
+)
+PROJECT_SYMBOL_RE = re.compile(r"\b(?:sgl|rhi|slangpy)::|\bslangpy_ext\b")
+PROJECT_BINARY_MARKERS = (
+    "sgl_tests+",
+    "sgl_tests.exe+",
+    "slangpy_ext.pyd+",
+    "slangpy_ext.cpython-",
+    "libsgl.so+",
+    "libsgl.dylib+",
+    "sgl.dll+",
+)
+
+
+def normalize_path_text(value: str) -> str:
+    return value.replace("\\", "/").lower()
+
+
+def frame_index(line: str) -> Optional[int]:
+    match = FRAME_RE.match(line)
+    return int(match.group("index")) if match else None
+
+
+def is_allocator_interceptor_frame(line: str) -> bool:
+    index = frame_index(line)
+    if index is None:
+        return False
+
+    lower = line.lower()
+    allocator_markers = (
+        "__interceptor_",
+        "asan_malloc",
+        "lsan_interceptors",
+        "sanitizer_common",
+        " in operator new",
+        " in operator new[]",
+    )
+    c_allocator = re.search(r"\bin (?:malloc|calloc|realloc)(?:\s|\(|$)", lower)
+    return c_allocator is not None or any(marker in lower for marker in allocator_markers)
+
+
+def is_project_source_frame(line: str, repo_root: str) -> bool:
+    normalized = normalize_path_text(line)
+    repo = normalize_path_text(repo_root).rstrip("/") + "/"
+    repo_index = normalized.find(repo)
+    if repo_index < 0:
+        return False
+
+    relative = normalized[repo_index + len(repo) :]
+    return relative.startswith(PROJECT_SOURCE_DIRS)
+
+
+def is_project_binary_frame(line: str) -> bool:
+    normalized = normalize_path_text(line)
+    return any(marker in normalized for marker in PROJECT_BINARY_MARKERS)
+
+
+def is_project_leak(block: List[str], repo_root: str) -> bool:
+    """Attribute a leak using its first non-allocator frame.
+
+    Looking at every frame makes calls into GPU drivers appear to be project
+    leaks merely because SlangPy initiated the external API call. The allocation
+    site is the first meaningful frame after allocator interceptors.
+    """
+    for line in block:
+        if frame_index(line) is None:
+            continue
+        if is_allocator_interceptor_frame(line):
+            continue
+        return (
+            is_project_source_frame(line, repo_root)
+            or is_project_binary_frame(line)
+            or PROJECT_SYMBOL_RE.search(line) is not None
+        )
+    return False
+
+
+def extract_leak_blocks(text: str) -> List[List[str]]:
+    lines = text.splitlines()
+    blocks: List[List[str]] = []
+    index = 0
+
+    while index < len(lines):
+        if not LEAK_HEADER_RE.match(lines[index]):
+            index += 1
+            continue
+
+        block = [lines[index]]
+        index += 1
+        while index < len(lines):
+            line = lines[index]
+            if not line.strip():
+                break
+            if LEAK_HEADER_RE.match(line):
+                index -= 1
+                break
+            if (
+                line.startswith("SUMMARY:")
+                or line.startswith("----")
+                or line.startswith("Suppressions used:")
+            ):
+                break
+            block.append(line)
+            index += 1
+        blocks.append(block)
+        index += 1
+
+    return blocks
+
+
+def read_log(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify LeakSanitizer reports and surface other sanitizer failures."
+    )
+    parser.add_argument("--log-dir", type=pathlib.Path)
+    parser.add_argument("--repo-root", type=pathlib.Path)
+    args = parser.parse_args()
+
+    if args.log_dir:
+        log_dir = args.log_dir
+    elif os.environ.get("SANITIZER_LOG_DIR"):
+        log_dir = pathlib.Path(os.environ["SANITIZER_LOG_DIR"])
+    else:
+        print("No sanitizer log directory provided and SANITIZER_LOG_DIR is not set.")
+        return 1
+
+    repo_root_arg = args.repo_root or pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd()))
+    repo_root = str(repo_root_arg.resolve())
+    if not log_dir.exists():
+        print(f"No sanitizer log directory found: {log_dir}")
+        return 0
+
+    leak_blocks: List[Tuple[pathlib.Path, List[str]]] = []
+    project_root_blocks: List[Tuple[pathlib.Path, List[str]]] = []
+    external_root_count = 0
+    indirect_block_count = 0
+    unexpected_reports: List[Tuple[pathlib.Path, str]] = []
+
+    for log_path in sorted(path for path in log_dir.iterdir() if path.is_file()):
+        text = read_log(log_path)
+        if not text.strip():
+            continue
+        if "LeakSanitizer" not in text:
+            # LSAN_OPTIONS.log_path is a sanitizer-common setting, so ASan and
+            # UBSan diagnostics can land here too. Never silently discard them.
+            unexpected_reports.append((log_path, text))
+            continue
+        blocks = extract_leak_blocks(text)
+        if "ERROR: LeakSanitizer:" in text and not blocks:
+            # Treat format changes and truncated reports as failures. Silently
+            # accepting a report we could not classify would hide regressions.
+            unexpected_reports.append((log_path, text))
+            continue
+        for block in blocks:
+            leak_blocks.append((log_path, block))
+            if block[0].startswith("Indirect leak"):
+                # An indirect allocation is owned by a direct leak root. Its
+                # allocation stack alone cannot identify which root retained it.
+                indirect_block_count += 1
+            elif is_project_leak(block, repo_root):
+                project_root_blocks.append((log_path, block))
+            else:
+                external_root_count += 1
+
+    failed = False
+
+    if unexpected_reports:
+        failed = True
+        print(f"::error::Found {len(unexpected_reports)} non-LSan sanitizer report(s).")
+        for log_path, text in unexpected_reports:
+            print(f"\n{log_path}:")
+            print(text.rstrip())
+
+    if project_root_blocks:
+        failed = True
+        print(
+            f"::error::LeakSanitizer found {len(project_root_blocks)} direct leak root(s) "
+            "attributed to SlangPy or slang-rhi."
+        )
+        for log_path, block in project_root_blocks:
+            print(f"\n{log_path}:")
+            print("\n".join(block))
+
+    if external_root_count:
+        print(
+            f"Ignored {external_root_count} direct LeakSanitizer leak root(s) "
+            "attributed to external code."
+        )
+    if indirect_block_count:
+        print(
+            f"Ignored {indirect_block_count} indirect LeakSanitizer leak block(s); "
+            "their ownership is determined by the direct leak root."
+        )
+    if not leak_blocks:
+        print("No LeakSanitizer leak reports found.")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sanitizer_python.cpp
+++ b/tools/sanitizer_python.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <Python.h>
+
+#if defined(_WIN32)
+int wmain(int argc, wchar_t* argv[])
+{
+    return Py_Main(argc, argv);
+}
+#else
+int main(int argc, char* argv[])
+{
+    return Py_BytesMain(argc, argv);
+}
+#endif

--- a/tools/setup-sanitizer-env.py
+++ b/tools/setup-sanitizer-env.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#!/usr/bin/env python3
-
 import argparse
 import os
 import pathlib
 import shutil
 import subprocess
 import sys
+import sysconfig
 from typing import Optional
 
 
@@ -179,6 +178,11 @@ def main() -> int:
         deploy_windows_asan_runtime(binary_dir)
         # The sanitizer host lives outside the Python installation, so CPython
         # cannot reliably derive the standard-library paths from argv[0].
+        if sys.prefix != sys.base_prefix:
+            python_paths = [sysconfig.get_path("purelib")]
+            if existing_pythonpath := os.environ.get("PYTHONPATH"):
+                python_paths.append(existing_pythonpath)
+            append_github_env("PYTHONPATH", os.pathsep.join(python_paths))
         append_github_env("PYTHONHOME", sys.base_prefix)
 
     if "address" in sanitizers:

--- a/tools/setup-sanitizer-env.py
+++ b/tools/setup-sanitizer-env.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+from typing import Optional
+
+
+def sanitizer_path(path: pathlib.Path) -> str:
+    return str(path).replace("\\", "/")
+
+
+def append_github_env(name: str, value: str) -> None:
+    env_file = os.environ.get("GITHUB_ENV")
+    if not env_file:
+        print(f"{name}={value}")
+        return
+    with open(env_file, "a", encoding="utf-8") as file:
+        file.write(f"{name}={value}\n")
+
+
+def prepend_github_path(path: pathlib.Path) -> None:
+    github_path = os.environ.get("GITHUB_PATH")
+    if not github_path:
+        print(f"PATH={path}{os.pathsep}{os.environ.get('PATH', '')}")
+        return
+    with open(github_path, "a", encoding="utf-8") as file:
+        file.write(f"{path}\n")
+
+
+def find_symbolizer() -> Optional[str]:
+    clang = shutil.which("clang++")
+    if clang:
+        result = subprocess.run(
+            [clang, "--print-prog-name=llvm-symbolizer"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        symbolizer = shutil.which(result.stdout.strip())
+        if symbolizer:
+            return symbolizer
+
+    return (
+        shutil.which("llvm-symbolizer")
+        or shutil.which("llvm-symbolizer-20")
+        or shutil.which("llvm-symbolizer-19")
+        or shutil.which("llvm-symbolizer-18")
+        or shutil.which("llvm-symbolizer-17")
+    )
+
+
+def query_clang_runtime(runtime_name: str) -> Optional[pathlib.Path]:
+    clang = shutil.which("clang++")
+    if not clang:
+        raise RuntimeError(f"Could not find clang++ while locating {runtime_name}.")
+
+    result = subprocess.run(
+        [clang, f"--print-file-name={runtime_name}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    runtime_path = pathlib.Path(result.stdout.strip())
+    return runtime_path.resolve() if runtime_path.is_file() else None
+
+
+def find_clang_runtime(runtime_names: tuple[str, ...]) -> pathlib.Path:
+    for runtime_name in runtime_names:
+        runtime_path = query_clang_runtime(runtime_name)
+        if runtime_path:
+            return runtime_path
+    raise RuntimeError(
+        "Could not locate a Clang sanitizer runtime matching: " + ", ".join(runtime_names)
+    )
+
+
+def deploy_windows_asan_runtime(binary_dir: pathlib.Path) -> None:
+    machine = os.environ.get("PROCESSOR_ARCHITECTURE", "AMD64").lower()
+    architecture = "aarch64" if machine in ("arm64", "aarch64") else "x86_64"
+    runtime = find_clang_runtime((f"clang_rt.asan_dynamic-{architecture}.dll",))
+    binary_dir.mkdir(parents=True, exist_ok=True)
+    destination = binary_dir / runtime.name
+    shutil.copy2(runtime, destination)
+    prepend_github_path(runtime.parent)
+    print(f"Copied Windows ASan runtime to {destination}")
+
+
+def configure_linux_preload(sanitizers: set[str]) -> None:
+    asan_runtime_names = (
+        "libclang_rt.asan.so",
+        "libclang_rt.asan-x86_64.so",
+        "libclang_rt.asan-aarch64.so",
+    )
+    ubsan_runtime_names = (
+        "libclang_rt.ubsan.so",
+        "libclang_rt.ubsan_standalone-x86_64.so",
+        "libclang_rt.ubsan_standalone-aarch64.so",
+    )
+
+    runtime_paths: list[str] = []
+    if "address" in sanitizers:
+        # ASan must be the first runtime loaded into the unsanitized Python process.
+        runtime_paths.append(str(find_clang_runtime(asan_runtime_names)))
+    if "undefined" in sanitizers:
+        # UBSan is often incorporated into ASan or linked as a module dependency.
+        # Preload its standalone runtime when Clang exposes one.
+        for runtime_name in ubsan_runtime_names:
+            runtime_path = query_clang_runtime(runtime_name)
+            if runtime_path:
+                runtime_paths.append(str(runtime_path))
+                break
+    existing_preload = os.environ.get("LD_PRELOAD")
+    if existing_preload:
+        runtime_paths.append(existing_preload)
+    append_github_env("LD_PRELOAD", os.pathsep.join(runtime_paths))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Configure sanitizer environment variables for SlangPy tests."
+    )
+    parser.add_argument("--binary-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--os", required=True, choices=("windows", "linux", "macos"))
+    parser.add_argument("--sanitizers", default="address,undefined")
+    args = parser.parse_args()
+
+    sanitizers = set(args.sanitizers.split(","))
+    unsupported_sanitizers = sanitizers - {"address", "undefined"}
+    if unsupported_sanitizers:
+        parser.error("Unsupported sanitizers: " + ", ".join(sorted(unsupported_sanitizers)))
+
+    workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
+    binary_dir = args.binary_dir.resolve()
+    asan_suppressions = workspace / "tools" / "asan-suppressions.txt"
+
+    symbolizer = find_symbolizer()
+    if symbolizer:
+        append_github_env("ASAN_SYMBOLIZER_PATH", symbolizer)
+
+    asan_options = [
+        "halt_on_error=1",
+        "symbolize=1",
+        "fast_unwind_on_malloc=0",
+    ]
+
+    # The Windows ASan runtime rejects interceptor_via_lib suppressions. The
+    # suppression file contains only Unix library names, so do not pass it there.
+    if args.os != "windows" and "address" in sanitizers:
+        asan_options.append(f"suppressions={sanitizer_path(asan_suppressions)}")
+    if args.os == "linux":
+        configure_linux_preload(sanitizers)
+
+    if args.os == "linux" and "address" in sanitizers:
+        sanitizer_log_dir = binary_dir / "sanitizer-logs"
+        sanitizer_log_dir.mkdir(parents=True, exist_ok=True)
+        xdg_runtime_dir = binary_dir / "xdg-runtime"
+        xdg_runtime_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        xdg_runtime_dir.chmod(0o700)
+        asan_options = [
+            "detect_leaks=1",
+            "protect_shadow_gap=0",
+            "abort_on_error=1",
+            *asan_options,
+        ]
+        append_github_env(
+            "LSAN_OPTIONS",
+            f"exitcode=0:log_path={sanitizer_path(sanitizer_log_dir / 'lsan.log')}",
+        )
+        append_github_env("SANITIZER_LOG_DIR", str(sanitizer_log_dir))
+        append_github_env("XDG_RUNTIME_DIR", str(xdg_runtime_dir))
+
+    if args.os == "windows" and "address" in sanitizers:
+        deploy_windows_asan_runtime(binary_dir)
+        # The sanitizer host lives outside the Python installation, so CPython
+        # cannot reliably derive the standard-library paths from argv[0].
+        append_github_env("PYTHONHOME", sys.base_prefix)
+
+    if "address" in sanitizers:
+        append_github_env("ASAN_OPTIONS", ":".join(asan_options))
+    if "undefined" in sanitizers:
+        append_github_env("UBSAN_OPTIONS", "print_stacktrace=1:halt_on_error=1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ubsan-ignorelist.txt
+++ b/tools/ubsan-ignorelist.txt
@@ -1,0 +1,4 @@
+# bcdec reads packed BC blocks from byte-aligned input. Restrict the exception
+# to its vendored implementation; SlangPy's codec wrapper remains checked.
+[alignment]
+src:*bcdec.h


### PR DESCRIPTION
Adds first-class AddressSanitizer and UndefinedBehaviorSanitizer support for SlangPy and its embedded `slang-rhi` build.

## Details

- Adds reusable CMake sanitizer configuration for SlangPy-owned native targets.
- Propagates ASan and UBSan settings to embedded `slang-rhi`; TSAN remains explicitly disabled.
- Adds nightly and manually triggered sanitizer testing on Windows, Linux, and macOS using `RelWithDebInfo`.
- Handles platform-specific sanitizer runtime requirements:
  - Clang 22 and a sanitizer-enabled Python host on Windows.
  - Runtime preloading and LeakSanitizer reporting on Linux.
  - A sanitizer-enabled Python host on macOS.
- Adds leak-report filtering that fails on leaks attributed to SlangPy or `slang-rhi` while ignoring external driver/runtime leak roots.
- Allows sanitizer tests to make Torch unavailable without requiring a separate Python environment.
- Adds sanitizer setup documentation, suppressions, and tests for leak-report classification.
