### PR TITLE
Fix sanitizer-detected memory and offset issues

### DIFF
--- a/src/sgl/core/bitmap.cpp
+++ b/src/sgl/core/bitmap.cpp
@@ -63,6 +63,9 @@ derivative works thereof, in binary and source code form.
 
 #include "sgl/stl/bit.h"
 
+#define STBI_MALLOC(size) std::malloc(size)
+#define STBI_REALLOC(data, size) std::realloc(data, size)
+#define STBI_FREE(data) std::free(data)
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
@@ -110,6 +113,7 @@ SGL_DIAGNOSTIC_POP
 #endif
 
 #include <algorithm>
+#include <new>
 #include <numeric>
 #include <map>
 #include <mutex>
@@ -164,8 +168,7 @@ Bitmap::Bitmap(
     , m_component_type(component_type)
     , m_width(width)
     , m_height(height)
-    , m_data(reinterpret_cast<uint8_t*>(data))
-    , m_owns_data(false)
+    , m_data(static_cast<uint8_t*>(data))
 {
     SGL_CHECK(
         pixel_format != PixelFormat::multi_channel || channel_count > 0,
@@ -180,10 +183,8 @@ Bitmap::Bitmap(
 
     rebuild_pixel_struct(channel_count, channel_names);
 
-    if (!m_data) {
-        m_data = std::make_unique<uint8_t[]>(buffer_size());
-        m_owns_data = true;
-    }
+    if (!m_data)
+        allocate_data(buffer_size());
 }
 
 Bitmap::Bitmap(const Bitmap& other)
@@ -194,9 +195,9 @@ Bitmap::Bitmap(const Bitmap& other)
     , m_width(other.m_width)
     , m_height(other.m_height)
     , m_srgb_gamma(other.m_srgb_gamma)
-    , m_data(new uint8_t[other.buffer_size()])
 {
-    std::memcpy(m_data.get(), other.m_data.get(), other.buffer_size());
+    allocate_data(other.buffer_size());
+    std::memcpy(m_data, other.m_data, other.buffer_size());
 }
 
 Bitmap::Bitmap(Bitmap&& other)
@@ -206,7 +207,8 @@ Bitmap::Bitmap(Bitmap&& other)
     , m_width(std::exchange(other.m_width, 0))
     , m_height(std::exchange(other.m_height, 0))
     , m_srgb_gamma(std::exchange(other.m_srgb_gamma, false))
-    , m_data(std::move(other.m_data))
+    , m_owned_data(std::move(other.m_owned_data))
+    , m_data(std::exchange(other.m_data, nullptr))
 {
 }
 
@@ -219,12 +221,6 @@ Bitmap::Bitmap(const std::filesystem::path& path, FileFormat format)
 {
     FileStream stream(path, FileStream::Mode::read);
     read(&stream, format);
-}
-
-Bitmap::~Bitmap()
-{
-    if (!m_owns_data)
-        m_data.release();
 }
 
 std::vector<ref<Bitmap>> Bitmap::read_multiple(std::span<std::filesystem::path> paths, FileFormat format)
@@ -351,7 +347,7 @@ void Bitmap::set_srgb_gamma(bool srgb_gamma)
 
 void Bitmap::clear()
 {
-    std::memset(m_data.get(), 0, buffer_size());
+    std::memset(m_data, 0, buffer_size());
 }
 
 void Bitmap::vflip()
@@ -530,7 +526,7 @@ bool Bitmap::operator==(const Bitmap& other) const
 {
     return m_pixel_format == other.m_pixel_format && m_component_type == other.m_component_type
         && *m_pixel_struct == *other.m_pixel_struct && m_width == other.m_width && m_height == other.m_height
-        && m_srgb_gamma == other.m_srgb_gamma && std::memcmp(m_data.get(), other.m_data.get(), buffer_size()) == 0;
+        && m_srgb_gamma == other.m_srgb_gamma && std::memcmp(m_data, other.m_data, buffer_size()) == 0;
 }
 
 std::string Bitmap::to_string() const
@@ -607,6 +603,16 @@ void Bitmap::static_init()
 }
 
 void Bitmap::static_shutdown() { }
+
+void Bitmap::allocate_data(size_t size)
+{
+    auto* data = static_cast<uint8_t*>(std::malloc(std::max<size_t>(size, 1)));
+    if (!data)
+        throw std::bad_alloc();
+
+    m_owned_data.reset(data);
+    m_data = data;
+}
 
 void Bitmap::rebuild_pixel_struct(uint32_t channel_count, const std::vector<std::string>& channel_names)
 {
@@ -820,11 +826,11 @@ void Bitmap::read_stb(Stream* stream, const char* format, bool is_srgb, bool is_
     if (!data)
         SGL_THROW(fmt::format("Failed to read {} file!", format));
 
+    m_owned_data.reset(static_cast<uint8_t*>(data));
+    m_data = m_owned_data.get();
+
     SGL_ASSERT_EQ(m_width, static_cast<uint32_t>(w));
     SGL_ASSERT_EQ(m_height, static_cast<uint32_t>(h));
-
-    m_data = std::unique_ptr<uint8_t[]>(reinterpret_cast<uint8_t*>(data));
-    m_owns_data = true;
 }
 
 // ----------------------------------------------------------------------------
@@ -990,8 +996,7 @@ void Bitmap::read_png(Stream* stream)
     );
 
     size_t size = buffer_size();
-    m_data = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
-    m_owns_data = true;
+    allocate_data(size);
 
     size_t row_bytes = png_get_rowbytes(png_ptr, info_ptr);
     SGL_ASSERT(row_bytes == size / m_height);
@@ -1312,8 +1317,7 @@ void Bitmap::read_jpg(Stream* stream)
 
     size_t row_stride = static_cast<size_t>(cinfo.output_width) * static_cast<size_t>(cinfo.output_components);
 
-    m_data = std::unique_ptr<uint8_t[]>(new uint8_t[buffer_size()]);
-    m_owns_data = true;
+    allocate_data(buffer_size());
 
     JSAMPARRAY scanlines = reinterpret_cast<JSAMPARRAY>(alloca(sizeof(JSAMPROW) * m_height));
     for (size_t i = 0; i < m_height; ++i)
@@ -1385,7 +1389,7 @@ void Bitmap::write_jpg(Stream* stream, int quality) const
 
     // Write scanline by scanline
     for (size_t i = 0; i < m_height; ++i) {
-        const uint8_t* source = m_data.get() + i * m_width * cinfo.input_components;
+        const uint8_t* source = m_data + i * m_width * cinfo.input_components;
         jpeg_write_scanlines(&cinfo, const_cast<JSAMPARRAY>(&source), 1);
     }
 
@@ -1726,15 +1730,14 @@ void Bitmap::read_exr(Stream* stream)
     size_t pixel_count = this->pixel_count();
     size_t row_stride = pixel_stride * m_width;
 
-    m_data = std::unique_ptr<uint8_t[]>(new uint8_t[row_stride * m_height]);
-    m_owns_data = true;
+    allocate_data(row_stride * m_height);
 
 #if 0
     using ResampleBuffer = std::pair<std::string, ref<Bitmap>>;
     std::vector<ResampleBuffer> resample_buffers;
 #endif
 
-    uint8_t* ptr = m_data.get() - (data_window.min.x + data_window.min.y * m_width) * pixel_stride;
+    uint8_t* ptr = m_data - (data_window.min.x + data_window.min.y * m_width) * pixel_stride;
 
     // Tell OpenEXR where the image data should be put.
     Imf::FrameBuffer framebuffer;
@@ -1854,13 +1857,13 @@ void Bitmap::read_exr(Stream* stream)
 
         switch (m_component_type) {
         case ComponentType::float16:
-            convert(reinterpret_cast<math::float16_t*>(m_data.get()));
+            convert(reinterpret_cast<math::float16_t*>(m_data));
             break;
         case ComponentType::float32:
-            convert(reinterpret_cast<float*>(m_data.get()));
+            convert(reinterpret_cast<float*>(m_data));
             break;
         case ComponentType::uint32:
-            convert(reinterpret_cast<uint32_t*>(m_data.get()));
+            convert(reinterpret_cast<uint32_t*>(m_data));
             break;
         default:
             SGL_THROW("Internal error!");
@@ -1935,13 +1938,13 @@ void Bitmap::read_exr(Stream* stream)
 
         switch (m_component_format) {
         case DataStruct::Type::Float16:
-            convert((dr::half*)m_data.get());
+            convert((dr::half*)m_data);
             break;
         case DataStruct::Type::Float32:
-            convert((float*)m_data.get());
+            convert((float*)m_data);
             break;
         case DataStruct::Type::UInt32:
-            convert((uint32_t*)m_data.get());
+            convert((uint32_t*)m_data);
             break;
         default:
             Throw("Internal error!");
@@ -2267,8 +2270,7 @@ void Bitmap::read_exr(Stream* stream)
     size_t pixel_count = this->pixel_count();
     size_t row_stride = pixel_stride * m_width;
 
-    m_data = std::unique_ptr<uint8_t[]>(new uint8_t[row_stride * m_height]);
-    m_owns_data = true;
+    allocate_data(row_stride * m_height);
 
     for (const auto& field : *m_pixel_struct) {
         int channel_index = find_channel_index(field.name);
@@ -2633,11 +2635,10 @@ void Bitmap::read_dds(Stream* stream)
 
         uint32_t bpp = static_cast<uint32_t>(bytes_per_pixel());
         size_t buf_size = buffer_size();
-        m_data = std::make_unique<uint8_t[]>(buf_size);
-        m_owns_data = true;
+        allocate_data(buf_size);
 
         BCMutableImage dst{
-            .data = m_data.get(),
+            .data = m_data,
             .width = m_width,
             .height = m_height,
             .row_pitch = m_width * bpp,
@@ -2718,8 +2719,7 @@ void Bitmap::read_dds(Stream* stream)
         rebuild_pixel_struct();
 
         size_t buf_size = buffer_size();
-        m_data = std::make_unique<uint8_t[]>(buf_size);
-        m_owns_data = true;
+        allocate_data(buf_size);
 
         // Copy mip level 0 data. Only tightly packed rows are supported.
         uint32_t row_pitch, slice_pitch;
@@ -2727,7 +2727,7 @@ void Bitmap::read_dds(Stream* stream)
         uint32_t dst_row_pitch = static_cast<uint32_t>(m_width * bytes_per_pixel());
         const uint8_t* src = dds.get_subresource_data(0, 0);
         SGL_CHECK(row_pitch == dst_row_pitch, "Bitmap::read_dds: unsupported row pitch for format {}.", format);
-        std::memcpy(m_data.get(), src, buf_size);
+        std::memcpy(m_data, src, buf_size);
     }
 }
 

--- a/src/sgl/core/bitmap.h
+++ b/src/sgl/core/bitmap.h
@@ -53,6 +53,7 @@ derivative works thereof, in binary and source code form.
 #include "sgl/core/data_struct.h"
 #include "sgl/core/rfilter.h"
 
+#include <cstdlib>
 #include <filesystem>
 #include <future>
 #include <memory>
@@ -147,9 +148,6 @@ public:
     /// Move constructor.
     Bitmap(Bitmap&& other);
 
-    /// Destructor.
-    ~Bitmap();
-
     /// Load a list of bitmaps from multiple paths. Uses multi-threading to load bitmaps in parallel.
     static std::vector<ref<Bitmap>>
     read_multiple(std::span<std::filesystem::path> paths, FileFormat format = FileFormat::auto_);
@@ -200,22 +198,22 @@ public:
     size_t buffer_size() const { return pixel_count() * bytes_per_pixel(); }
 
     /// The raw image data.
-    void* data() { return m_data.get(); }
-    const void* data() const { return m_data.get(); }
+    void* data() { return m_data; }
+    const void* data() const { return m_data; }
 
     /// The raw image data as uint8_t.
-    uint8_t* uint8_data() { return m_data.get(); }
-    const uint8_t* uint8_data() const { return m_data.get(); }
+    uint8_t* uint8_data() { return m_data; }
+    const uint8_t* uint8_data() const { return m_data; }
 
     template<typename T>
     T* data_as()
     {
-        return reinterpret_cast<T*>(m_data.get());
+        return reinterpret_cast<T*>(m_data);
     }
     template<typename T>
     const T* data_as() const
     {
-        return reinterpret_cast<const T*>(m_data.get());
+        return reinterpret_cast<const T*>(m_data);
     }
 
     /// True if bitmap is empty.
@@ -298,6 +296,8 @@ public:
     static void static_shutdown();
 
 private:
+    void allocate_data(size_t size);
+
     void rebuild_pixel_struct(uint32_t channel_count = 0, const std::vector<std::string>& channel_names = {});
 
     void read(Stream* stream, FileFormat format);
@@ -336,8 +336,9 @@ private:
     uint32_t m_width;
     uint32_t m_height;
     bool m_srgb_gamma;
-    std::unique_ptr<uint8_t[]> m_data;
-    bool m_owns_data;
+    using OwnedData = std::unique_ptr<uint8_t, decltype(&std::free)>;
+    OwnedData m_owned_data{nullptr, &std::free};
+    uint8_t* m_data{nullptr};
 };
 
 SGL_ENUM_REGISTER(Bitmap::FileFormat);

--- a/src/sgl/core/dds_file.cpp
+++ b/src/sgl/core/dds_file.cpp
@@ -825,26 +825,20 @@ using namespace detail;
 
 DDSFile::DDSFile(Stream* stream)
 {
-    m_size = stream->size();
-    if (m_size < MIN_HEADER_SIZE)
+    const size_t size = stream->size();
+    if (size < MIN_HEADER_SIZE)
         SGL_THROW("DDS file is too small");
 
-    m_data = new uint8_t[m_size];
-    stream->read(m_data, m_size);
+    m_data.resize(size);
+    stream->read(m_data.data(), m_data.size());
 
-    if (!decode_header(m_data, m_size))
+    if (!decode_header(m_data.data(), m_data.size()))
         SGL_THROW("DDS file has invalid header");
 }
 
 DDSFile::DDSFile(const std::filesystem::path& path)
     : DDSFile(ref(new FileStream(path, FileStream::Mode::read)))
 {
-}
-
-DDSFile::~DDSFile()
-{
-    if (m_data)
-        delete[] m_data;
 }
 
 const uint8_t* DDSFile::get_subresource_data(uint32_t mip, uint32_t slice) const

--- a/src/sgl/core/dds_file.h
+++ b/src/sgl/core/dds_file.h
@@ -7,6 +7,7 @@
 #include "sgl/core/stream.h"
 
 #include <filesystem>
+#include <vector>
 
 namespace sgl {
 
@@ -38,13 +39,11 @@ public:
     explicit DDSFile(Stream* stream);
     explicit DDSFile(const std::filesystem::path& path);
 
-    ~DDSFile();
+    const uint8_t* data() const { return m_data.data(); }
+    size_t size() const { return m_data.size(); }
 
-    const uint8_t* data() const { return m_data; }
-    size_t size() const { return m_size; }
-
-    const uint8_t* resource_data() const { return m_data + m_header_size; }
-    size_t resource_size() const { return m_size - m_header_size; }
+    const uint8_t* resource_data() const { return m_data.data() + m_header_size; }
+    size_t resource_size() const { return m_data.size() - m_header_size; }
 
     uint32_t dxgi_format() const { return m_dxgi_format; }
     TextureType type() const { return m_type; }
@@ -111,8 +110,7 @@ private:
     bool get_subresource_offset(uint32_t mip, uint32_t slice, size_t* offset) const;
     bool get_required_resource_size(size_t* size) const;
 
-    uint8_t* m_data{nullptr};
-    size_t m_size{0};
+    std::vector<uint8_t> m_data;
 
     uint32_t m_dxgi_format;
     TextureType m_type;

--- a/src/sgl/core/platform_windows.cpp
+++ b/src/sgl/core/platform_windows.cpp
@@ -21,6 +21,7 @@
 #include <winioctl.h>
 #include <DbgHelp.h>
 
+#include <cstddef>
 #include <mutex>
 
 #define WINDOWS_CALL(a)                                                                                                \
@@ -298,7 +299,7 @@ bool create_junction(const std::filesystem::path& link, const std::filesystem::p
     // Set the total size of the data buffer.
 
     // Use DeviceIoControl to set the reparse point data on the file handle.
-    size_t header_size = FIELD_OFFSET(REPARSE_DATA_BUFFER, MountPointReparseBuffer);
+    size_t header_size = offsetof(REPARSE_DATA_BUFFER, MountPointReparseBuffer);
     bool success = DeviceIoControl(
         handle,
         FSCTL_SET_REPARSE_POINT,
@@ -339,7 +340,7 @@ bool delete_junction(const std::filesystem::path& link)
         handle,
         FSCTL_DELETE_REPARSE_POINT,
         &rgdb,
-        REPARSE_GUID_DATA_BUFFER_HEADER_SIZE,
+        static_cast<DWORD>(offsetof(REPARSE_GUID_DATA_BUFFER, GenericReparseBuffer)),
         NULL,
         0,
         NULL,


### PR DESCRIPTION
Use malloc-backed ownership for Bitmap data so stb allocations can be adopted without copying while external buffers remain non-owning. Pin stb to matching malloc, realloc, and free functions.

Store DDS file contents in a vector to ensure partially constructed objects release their buffers when loading or validation fails.

Replace Windows FIELD_OFFSET-based reparse buffer sizes with offsetof to avoid null-pointer undefined behavior under UBSan.