### PR TITLE
Fix thread safety issues

### DIFF
--- a/src/sgl/core/file_system_watcher.cpp
+++ b/src/sgl/core/file_system_watcher.cpp
@@ -213,8 +213,8 @@ void FileSystemWatcher::_notify_change(
         std::lock_guard<std::mutex> lock(m_queued_events_mutex);
 #endif
         m_queued_events.push_back(event);
+        m_last_event = now;
     }
-    m_last_event = now;
 }
 
 void FileSystemWatcher::update()

--- a/src/sgl/core/object.cpp
+++ b/src/sgl/core/object.cpp
@@ -52,7 +52,7 @@ void Object::inc_ref() const noexcept
 
 void Object::dec_ref(bool dealloc) const noexcept
 {
-    uintptr_t value = m_state.load(std::memory_order_relaxed);
+    uintptr_t value = m_state.load(std::memory_order_acquire);
 
     while (true) {
         if (value & 1) {
@@ -63,11 +63,11 @@ void Object::dec_ref(bool dealloc) const noexcept
                 if (dealloc) {
                     delete this;
                 } else {
-                    m_state.store(1, std::memory_order_relaxed);
+                    m_state.store(1, std::memory_order_release);
                 }
             } else {
                 if (!m_state
-                         .compare_exchange_weak(value, value - 2, std::memory_order_relaxed, std::memory_order_relaxed))
+                         .compare_exchange_weak(value, value - 2, std::memory_order_acq_rel, std::memory_order_acquire))
                     continue;
             }
         } else {

--- a/src/sgl/core/thread.cpp
+++ b/src/sgl/core/thread.cpp
@@ -8,6 +8,7 @@
 #include <nanothread/nanothread.h>
 #include <slang-rhi.h>
 
+#include <exception>
 #include <mutex>
 #include <vector>
 
@@ -115,7 +116,32 @@ namespace {
         static void execute_task(uint32_t, void* payload)
         {
             TaskPayload* task_payload = static_cast<TaskPayload*>(payload);
-            task_payload->func(task_payload->payload);
+            void (*func)(void*) = task_payload->func;
+            void* user_payload = task_payload->payload;
+            void (*user_payload_deleter)(void*) = task_payload->payload_deleter;
+
+            // Nanothread publishes task completion before running its payload deleter. Run the
+            // user deleter as part of the callback so waiters cannot outlive user payload cleanup.
+            task_payload->payload = nullptr;
+            task_payload->payload_deleter = nullptr;
+
+            std::exception_ptr exception;
+            try {
+                func(user_payload);
+            } catch (...) {
+                exception = std::current_exception();
+            }
+
+            try {
+                if (user_payload_deleter)
+                    user_payload_deleter(user_payload);
+            } catch (...) {
+                if (!exception)
+                    exception = std::current_exception();
+            }
+
+            if (exception)
+                std::rethrow_exception(exception);
         }
 
         static void delete_task_payload(void* payload)

--- a/tests/sgl/core/test_lmdb_cache.cpp
+++ b/tests/sgl/core/test_lmdb_cache.cpp
@@ -34,44 +34,54 @@ struct CacheEntry {
     uint64_t last_access{0};
 };
 
-static uint32_t rng()
-{
-    static constexpr uint32_t A = 1664525u;
-    static constexpr uint32_t C = 1013904223u;
-    static uint32_t state = 0xdeadbeef;
-    state = (A * state + C);
-    return state;
-}
+struct RNG {
+    explicit RNG(uint32_t seed = 0xdeadbeef)
+        : state(seed)
+    {
+    }
 
-static double rng_uniform()
-{
-    return static_cast<double>(rng()) / static_cast<double>(0xFFFFFFFFu);
-}
+    uint32_t next()
+    {
+        static constexpr uint32_t A = 1664525u;
+        static constexpr uint32_t C = 1013904223u;
+        state = A * state + C;
+        return state;
+    }
 
-template<typename T>
-static T rng_range(T range)
-{
-    return std::min(static_cast<T>(rng_uniform() * range), range - 1);
-}
+    double uniform() { return static_cast<double>(next()) / static_cast<double>(0xFFFFFFFFu); }
 
-Blob random_data(size_t size)
+    template<typename T>
+    T range(T size)
+    {
+        return std::min(static_cast<T>(uniform() * size), size - 1);
+    }
+
+    uint32_t state;
+};
+
+Blob random_data(RNG& rng, size_t size)
 {
     Blob data(size);
     uint8_t* ptr = data.data();
     for (size_t i = 0; i < size; ++i)
-        ptr[i] = static_cast<uint8_t>((rng() >> 24) & 0xff);
+        ptr[i] = static_cast<uint8_t>((rng.next() >> 24) & 0xff);
     return data;
 }
 
-std::vector<CacheEntry>
-generate_random_entries(size_t count, size_t key_size = 32, size_t min_value_size = 64, size_t max_value_size = 1024)
+std::vector<CacheEntry> generate_random_entries(
+    RNG& rng,
+    size_t count,
+    size_t key_size = 32,
+    size_t min_value_size = 64,
+    size_t max_value_size = 1024
+)
 {
     std::vector<CacheEntry> entries;
     entries.reserve(count);
     for (size_t i = 0; i < count; ++i) {
-        Blob key = random_data(key_size);
-        size_t value_size = min_value_size + rng_range(max_value_size - min_value_size);
-        Blob value = random_data(value_size);
+        Blob key = random_data(rng, key_size);
+        size_t value_size = min_value_size + rng.range(max_value_size - min_value_size);
+        Blob value = random_data(rng, value_size);
         entries.push_back({key, value});
     }
     return entries;
@@ -107,11 +117,12 @@ TEST_CASE("simple")
 {
     auto cache_dir = testing::get_case_temp_directory() / "cache";
     LMDBCache cache(cache_dir);
+    RNG rng;
 
-    Blob key1 = random_data(32);
-    Blob value1 = random_data(128);
-    Blob key2 = random_data(32);
-    Blob value2 = random_data(256);
+    Blob key1 = random_data(rng, 32);
+    Blob value1 = random_data(rng, 128);
+    Blob key2 = random_data(rng, 32);
+    Blob value2 = random_data(rng, 256);
 
     std::vector<uint8_t> temp_value;
 
@@ -149,7 +160,7 @@ TEST_CASE("simple")
     CHECK(temp_value == value2);
 
     // Overwrite key1 with a new value
-    Blob new_value1 = random_data(512);
+    Blob new_value1 = random_data(rng, 512);
     cache.set(key1, new_value1);
 
     // Check cache stats after overwriting key1
@@ -185,13 +196,14 @@ TEST_CASE("readonly_get_and_touch")
     auto cache_dir = testing::get_case_temp_directory() / "cache";
     LMDBCache::Options options{.max_size = 8ull * 1024 * 1024};
     LMDBCache cache(cache_dir, options);
+    RNG rng;
 
     Blob readonly_key{1};
     Blob touched_key{2};
     Blob trigger_key{255};
     Blob value(128 * 1024, 42);
     Blob trigger_value(128 * 1024, 43);
-    Blob missing_key = random_data(32);
+    Blob missing_key = random_data(rng, 32);
     std::vector<uint8_t> temp_value;
 
     cache.set(readonly_key, value);
@@ -217,8 +229,9 @@ TEST_CASE("readonly_get_and_touch")
 TEST_CASE("persistence")
 {
     auto cache_dir = testing::get_case_temp_directory() / "cache";
+    RNG rng;
 
-    std::vector<CacheEntry> entries = generate_random_entries(1000);
+    std::vector<CacheEntry> entries = generate_random_entries(rng, 1000);
 
     {
         LMDBCache cache(cache_dir);
@@ -368,7 +381,9 @@ struct StressTest {
         : options(options_)
         , cache(options.path, LMDBCache::Options{.max_size = options.cache_size})
     {
+        RNG rng;
         entries = generate_random_entries(
+            rng,
             options.candidate_count,
             options.key_size,
             options.min_value_size,
@@ -376,7 +391,7 @@ struct StressTest {
         );
     }
 
-    RunStats run(size_t iterations)
+    RunStats run(RNG& rng, size_t iterations)
     {
         RunStats stats = {};
         std::vector<uint8_t> temp_value;
@@ -387,9 +402,9 @@ struct StressTest {
                     print_usage(cache.usage());
                 }
             }
-            if (rng_uniform() < options.delete_ratio) {
+            if (rng.uniform() < options.delete_ratio) {
                 // delete entry
-                size_t entry_index = rng_range(entries.size());
+                size_t entry_index = rng.range(entries.size());
                 auto& entry = entries[entry_index];
                 Timer timer;
                 bool success = cache.del(entry.key);
@@ -401,9 +416,9 @@ struct StressTest {
                 }
             } else {
                 // access entry, write if not present
-                size_t entry_index = rng_uniform() < options.hot_ratio
-                    ? rng_range(options.hot_candidates)
-                    : (options.hot_candidates + rng_range(entries.size() - options.hot_candidates));
+                size_t entry_index = rng.uniform() < options.hot_ratio
+                    ? rng.range(options.hot_candidates)
+                    : (options.hot_candidates + rng.range(entries.size() - options.hot_candidates));
                 auto& entry = entries[entry_index];
                 // try to get the entry
                 Timer timer;
@@ -562,9 +577,10 @@ TEST_CASE("stress-single-threaded")
     StressTest::Options options;
     options.path = testing::get_case_temp_directory() / "cache";
     StressTest test(options);
+    RNG rng;
 
     size_t iterations = 100000;
-    StressTest::RunStats run_stats = test.run(iterations);
+    StressTest::RunStats run_stats = test.run(rng, iterations);
 
     test.verify(false);
 
@@ -590,7 +606,8 @@ TEST_CASE("stress-multi-threaded")
         threads.emplace_back(
             [&, i]()
             {
-                thread_run_stats[i] = test.run(iterations_per_thread);
+                RNG rng(0xdeadbeef + static_cast<uint32_t>(i) * 0x9e3779b9u);
+                thread_run_stats[i] = test.run(rng, iterations_per_thread);
             }
         );
     for (auto& thread : threads)

--- a/tests/sgl/core/test_object.cpp
+++ b/tests/sgl/core/test_object.cpp
@@ -3,6 +3,9 @@
 #include "testing.h"
 #include "sgl/core/object.h"
 
+#include <atomic>
+#include <thread>
+
 using namespace sgl;
 
 TEST_SUITE_BEGIN("object");
@@ -61,6 +64,43 @@ TEST_CASE("ref")
 
     r1 = nullptr;
     CHECK_EQ(DummyObject::get_count(), 0);
+}
+
+class OrderedDestructionObject : public Object {
+    SGL_OBJECT(OrderedDestructionObject)
+public:
+    explicit OrderedDestructionObject(std::atomic<uint32_t>* destroyed_value)
+        : destroyed_value(destroyed_value)
+    {
+    }
+
+    ~OrderedDestructionObject() { destroyed_value->store(value, std::memory_order_relaxed); }
+
+    uint32_t value{0};
+    std::atomic<uint32_t>* destroyed_value;
+};
+
+TEST_CASE("cross-thread final release observes prior object access")
+{
+    std::atomic<uint32_t> destroyed_value{0};
+    std::atomic<bool> release_worker{false};
+    ref<OrderedDestructionObject> object = make_ref<OrderedDestructionObject>(&destroyed_value);
+
+    std::thread worker(
+        [held_object = ref<OrderedDestructionObject>(object), &release_worker]() mutable
+        {
+            while (!release_worker.load(std::memory_order_relaxed))
+                std::this_thread::yield();
+            held_object = nullptr;
+        }
+    );
+
+    object->value = 42;
+    object = nullptr;
+    release_worker.store(true, std::memory_order_relaxed);
+    worker.join();
+
+    CHECK(destroyed_value.load(std::memory_order_relaxed) == 42);
 }
 
 class DummyBuffer;

--- a/tests/sgl/core/test_thread.cpp
+++ b/tests/sgl/core/test_thread.cpp
@@ -6,6 +6,10 @@
 #include <slang-rhi.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 
 using namespace sgl;
 
@@ -18,6 +22,46 @@ struct RecursiveTaskPayload {
     std::atomic<uint32_t>* delete_count;
     uint32_t depth;
 };
+
+struct BlockingDeletePayload {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool callback_entered{false};
+    bool allow_callback_return{false};
+    bool deleter_entered{false};
+    bool allow_deleter_return{false};
+    bool wait_returned{false};
+};
+
+void execute_blocking_delete_task(void* data)
+{
+    auto* payload = static_cast<BlockingDeletePayload*>(data);
+    std::unique_lock lock(payload->mutex);
+    payload->callback_entered = true;
+    payload->condition.notify_all();
+    payload->condition.wait(
+        lock,
+        [&]
+        {
+            return payload->allow_callback_return;
+        }
+    );
+}
+
+void delete_blocking_task_payload(void* data)
+{
+    auto* payload = static_cast<BlockingDeletePayload*>(data);
+    std::unique_lock lock(payload->mutex);
+    payload->deleter_entered = true;
+    payload->condition.notify_all();
+    payload->condition.wait(
+        lock,
+        [&]
+        {
+            return payload->allow_deleter_return;
+        }
+    );
+}
 
 void delete_recursive_task_payload(void* data)
 {
@@ -94,6 +138,62 @@ TEST_CASE("rhi task pool executes tasks and deletes payloads")
 
     CHECK(execute_count.load() == 1);
     CHECK(delete_count.load() == 1);
+}
+
+TEST_CASE("rhi task wait includes payload deletion")
+{
+    using namespace std::chrono_literals;
+
+    BlockingDeletePayload payload;
+    rhi::ITaskPool* pool = thread::rhi_task_pool();
+    auto task = pool->submitTask(execute_blocking_delete_task, &payload, delete_blocking_task_payload);
+
+    {
+        std::unique_lock lock(payload.mutex);
+        payload.condition.wait(
+            lock,
+            [&]
+            {
+                return payload.callback_entered;
+            }
+        );
+    }
+
+    std::thread waiter(
+        [&]
+        {
+            pool->waitAndReleaseTask(task);
+            std::lock_guard lock(payload.mutex);
+            payload.wait_returned = true;
+            payload.condition.notify_all();
+        }
+    );
+
+    {
+        std::unique_lock lock(payload.mutex);
+        payload.allow_callback_return = true;
+        payload.condition.notify_all();
+        payload.condition.wait(
+            lock,
+            [&]
+            {
+                return payload.deleter_entered;
+            }
+        );
+        CHECK_FALSE(payload.condition.wait_for(
+            lock,
+            100ms,
+            [&]
+            {
+                return payload.wait_returned;
+            }
+        ));
+        payload.allow_deleter_return = true;
+        payload.condition.notify_all();
+    }
+
+    waiter.join();
+    CHECK(payload.wait_returned);
 }
 
 TEST_CASE("rhi task groups include tasks spawned by callbacks")


### PR DESCRIPTION
## Summary

Fix thread-safety and lifetime-ordering issues found by ThreadSanitizer.

- Synchronize intrusive reference-count decrements so cross-thread final release observes writes made by previous object owners.
- Ensure slang-rhi task payload deletion completes before the task is reported as complete.
- Protect `FileSystemWatcher::m_last_event` with the queued-events mutex.
- Give each LMDB stress-test thread its own RNG to remove shared-state races.
- Add regression tests for cross-thread object destruction and task payload cleanup ordering.

## Rationale

`Object::dec_ref()` previously used only relaxed atomic operations. When the final reference was released on another thread, there was no happens-before relationship ensuring that the destructor observed writes made by earlier owners.

The nanothread backend also publishes task completion before invoking its payload deleter. This conflicts with the slang-rhi task-pool contract and allowed `waitAndReleaseTask()` to return while payload cleanup was still running. The adapter now performs user payload cleanup within the task callback, before nanothread can publish completion.