### PR TITLE
Thread sanitizer

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -174,3 +174,100 @@ jobs:
           name: sanitizer-reports-${{ matrix.os }}-${{ matrix.platform }}
           path: build/${{ matrix.preset }}/${{ matrix.config }}/sanitizer-logs/
           if-no-files-found: ignore
+
+  tsan:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: linux, platform: x86_64, compiler: clang, preset: linux-clang, config: RelWithDebInfo, runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] }, llvm_version: 22.1.8, skip_device_tests: true, tsan_options: "halt_on_error=0:exitcode=66:second_deadlock_stack=1" }
+          - { os: macos, platform: aarch64, compiler: clang, preset: macos-arm64-clang, config: RelWithDebInfo, runs-on: macos-latest, skip_device_tests: false, tsan_options: "halt_on_error=0:exitcode=66:second_deadlock_stack=1" }
+
+    runs-on: ${{ matrix.runs-on }}
+
+    env:
+      CI_OS: ${{ matrix.os }}
+      CI_PLATFORM: ${{ matrix.platform }}
+      CI_COMPILER: ${{ matrix.compiler }}
+      CI_CONFIG: ${{ matrix.config }}
+      CI_PYTHON: "3.10"
+      CI_CMAKE_ARGS: "-DSGL_ENABLE_TSAN=ON -DSGL_BUILD_PYTHON=OFF -DSGL_BUILD_EXAMPLES=OFF"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Cleanup submodules
+        run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
+
+      - name: Setup CMake/Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Setup Python environment
+        run: python -m pip install -r requirements-dev.txt
+
+      # LLVM 18 can expose a partially initialized thread to TSan interceptors
+      # before attaching its trace slot (llvm/llvm-project#86342). Download a
+      # current compiler and matching runtime without requiring root access.
+      - name: Setup LLVM 22 for Linux TSan
+        if: matrix.os == 'linux'
+        env:
+          LLVM_VERSION: ${{ matrix.llvm_version }}
+        run: |
+          llvm_archive="$RUNNER_TEMP/LLVM-$LLVM_VERSION-Linux-X64.tar.xz"
+          llvm_dir="$RUNNER_TEMP/llvm-$LLVM_VERSION"
+          curl --proto '=https' --tlsv1.2 --fail --location --retry 3 \
+            "https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VERSION/LLVM-$LLVM_VERSION-Linux-X64.tar.xz" \
+            --output "$llvm_archive"
+          mkdir -p "$llvm_dir"
+          tar --extract --xz --file "$llvm_archive" --strip-components=1 --directory "$llvm_dir"
+
+          clang_path="$llvm_dir/bin/clang"
+          clangxx_path="$llvm_dir/bin/clang++"
+          symbolizer_path="$llvm_dir/bin/llvm-symbolizer"
+          "$clang_path" --version
+          "$clangxx_path" --version
+          "$symbolizer_path" --version
+
+          printf 'int main() { return 0; }\n' | \
+            "$clangxx_path" -x c++ -fsanitize=thread -o "$RUNNER_TEMP/tsan-smoke-test" -
+
+          echo "$llvm_dir/bin" >> "$GITHUB_PATH"
+          echo "LLVM_PATH=$llvm_dir" >> "$GITHUB_ENV"
+          echo "CC=$clang_path" >> "$GITHUB_ENV"
+          echo "CXX=$clangxx_path" >> "$GITHUB_ENV"
+
+      - name: Setup repository
+        run: python tools/ci.py setup
+
+      - name: Configure
+        run: python tools/ci.py configure
+
+      - name: Build
+        run: python tools/ci.py build
+
+      - name: Unit Tests (C++, ThreadSanitizer)
+        env:
+          # Keep TSan local to the instrumented executable. Exporting its runtime
+          # through GITHUB_ENV also instruments Node-based post-job actions.
+          LD_PRELOAD: ""
+          DYLD_INSERT_LIBRARIES: ""
+          TSAN_OPTIONS: ${{ matrix.tsan_options }}
+        run: |
+          if [ "${{ matrix.os }}" = "linux" ]; then
+            export TSAN_OPTIONS="$TSAN_OPTIONS:external_symbolizer_path=$LLVM_PATH/bin/llvm-symbolizer"
+          fi
+          if [ "${{ matrix.skip_device_tests }}" = "true" ]; then
+            python tools/ci.py unit-test-cpp --skip-device-tests
+          else
+            python tools/ci.py unit-test-cpp
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ option(SGL_ENABLE_COVERAGE "Enable code coverage (gcov)" OFF)
 # Enable/disable sanitizers.
 option(SGL_ENABLE_ASAN "Enable AddressSanitizer (Clang only)" OFF)
 option(SGL_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer (Clang only)" OFF)
+option(SGL_ENABLE_TSAN "Enable ThreadSanitizer (Linux/macOS Clang only)" OFF)
 
 include(sanitizers)
 

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,13 +1,25 @@
 # Configure sanitizer instrumentation for SlangPy-owned native targets.
 
-if(NOT SGL_ENABLE_ASAN AND NOT SGL_ENABLE_UBSAN)
+if(NOT SGL_ENABLE_ASAN AND NOT SGL_ENABLE_UBSAN AND NOT SGL_ENABLE_TSAN)
     function(sgl_enable_sanitizers target)
     endfunction()
     return()
 endif()
 
+if(SGL_ENABLE_TSAN AND SGL_ENABLE_ASAN)
+    message(FATAL_ERROR "ThreadSanitizer cannot be combined with AddressSanitizer")
+endif()
+
+if(SGL_ENABLE_TSAN AND NOT CMAKE_SYSTEM_NAME MATCHES "^(Linux|Darwin)$")
+    message(FATAL_ERROR "SlangPy ThreadSanitizer is only supported on Linux and macOS")
+endif()
+
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     message(FATAL_ERROR "SlangPy sanitizers are only supported with Clang")
+endif()
+
+if(SGL_ENABLE_TSAN AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
+    message(FATAL_ERROR "SlangPy ThreadSanitizer on Linux requires Clang 19 or newer")
 endif()
 
 set(SGL_SANITIZERS)
@@ -16,6 +28,9 @@ if(SGL_ENABLE_ASAN)
 endif()
 if(SGL_ENABLE_UBSAN)
     list(APPEND SGL_SANITIZERS undefined)
+endif()
+if(SGL_ENABLE_TSAN)
+    list(APPEND SGL_SANITIZERS thread)
 endif()
 list(JOIN SGL_SANITIZERS "," SGL_SANITIZER_FLAGS)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -61,6 +61,7 @@ if(SGL_LINUX AND SGL_ARCHITECTURE MATCHES "aarch64|arm64")
     set(NANOTHREAD_NATIVE_FLAGS "-march=armv8-a" CACHE STRING "" FORCE)
 endif()
 add_subdirectory(nanothread)
+sgl_enable_sanitizers(nanothread)
 # Disable LTO for nanothread as this causes problems when linking with sgl.
 set_target_properties(nanothread PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE FALSE)
 target_compile_definitions(nanothread PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/external/vcpkg-overlays/libdeflate/portfile.cmake
+++ b/external/vcpkg-overlays/libdeflate/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ebiggers/libdeflate
+    REF "v${VERSION}"
+    SHA512 c20a772aeeac593c34e8a68be80b23cb116699141de269d94df072636b6c90572f541b3344d830325cf45b03e7a1303e0274d79ce96c360fd421d4eb05ae1f92
+    HEAD_REF master
+    PATCHES
+        remove_wrong_c_flags_modification.diff
+        restrict-evex512-workaround.diff
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        compression   LIBDEFLATE_COMPRESSION_SUPPORT
+        decompression LIBDEFLATE_DECOMPRESSION_SUPPORT
+        gzip          LIBDEFLATE_GZIP_SUPPORT
+        zlib          LIBDEFLATE_ZLIB_SUPPORT
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBDEFLATE_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBDEFLATE_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBDEFLATE_BUILD_SHARED_LIB=${LIBDEFLATE_BUILD_SHARED}
+        -DLIBDEFLATE_BUILD_STATIC_LIB=${LIBDEFLATE_BUILD_STATIC}
+        -DLIBDEFLATE_BUILD_GZIP=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libdeflate")
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libdeflate.h" "defined(LIBDEFLATE_DLL)" "1")
+    elseif(NOT VCPKG_TARGET_IS_MINGW)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libdeflate.pc" " -ldeflate" " -ldeflatestatic")
+        if(NOT VCPKG_BUILD_TYPE)
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libdeflate.pc" " -ldeflate" " -ldeflatestatic")
+        endif()
+    endif()
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/external/vcpkg-overlays/libdeflate/remove_wrong_c_flags_modification.diff
+++ b/external/vcpkg-overlays/libdeflate/remove_wrong_c_flags_modification.diff
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0acd26f..218c48b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -61,7 +61,6 @@ if(NOT LIBDEFLATE_BUILD_STATIC_LIB)
+ endif()
+ 
+ # Set common C compiler flags for all targets (the library and the programs).
+-set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+ set(CMAKE_C_STANDARD 99)
+ if(NOT MSVC)
+     check_c_compiler_flag(-Wdeclaration-after-statement HAVE_WDECLARATION_AFTER_STATEMENT)

--- a/external/vcpkg-overlays/libdeflate/restrict-evex512-workaround.diff
+++ b/external/vcpkg-overlays/libdeflate/restrict-evex512-workaround.diff
@@ -1,0 +1,14 @@
+diff --git a/lib/x86/cpu_features.h b/lib/x86/cpu_features.h
+index 8b29816..6b92f84 100644
+--- a/lib/x86/cpu_features.h
++++ b/lib/x86/cpu_features.h
+@@ -165,7 +165,8 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
+ #  define HAVE_AVXVNNI(features)	((features) & X86_CPU_FEATURE_AVXVNNI)
+ #endif
+ 
+-#if (GCC_PREREQ(14, 0) || CLANG_PREREQ(18, 0, 18000000)) \
++#if ((GCC_PREREQ(14, 0) && !GCC_PREREQ(16, 0)) || \
++     (CLANG_PREREQ(18, 0, 18000000) && !CLANG_PREREQ(19, 0, 19000000))) \
+ 	&& !defined(__EVEX512__) /* avoid subtracting the evex512 feature */
+ #  define EVEX512	",evex512"	/* needed to override potential -mno-evex512 */
+ #  define NO_EVEX512	",no-evex512"

--- a/external/vcpkg-overlays/libdeflate/usage
+++ b/external/vcpkg-overlays/libdeflate/usage
@@ -1,0 +1,4 @@
+libdeflate provides CMake targets:
+
+    find_package(libdeflate CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:libdeflate::libdeflate_shared>,libdeflate::libdeflate_shared,libdeflate::libdeflate_static>)

--- a/external/vcpkg-overlays/libdeflate/vcpkg.json
+++ b/external/vcpkg-overlays/libdeflate/vcpkg.json
@@ -1,0 +1,37 @@
+{
+  "name": "libdeflate",
+  "version": "1.24",
+  "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
+  "homepage": "https://github.com/ebiggers/libdeflate",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "compression",
+    "decompression",
+    "gzip",
+    "zlib"
+  ],
+  "features": {
+    "compression": {
+      "description": "Support compression"
+    },
+    "decompression": {
+      "description": "Support decompression"
+    },
+    "gzip": {
+      "description": "Support the gzip format"
+    },
+    "zlib": {
+      "description": "Support the zlib format"
+    }
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,11 @@ if(SGL_BUILD_TESTS)
     target_include_directories(sgl_tests BEFORE PRIVATE sgl)
     target_link_libraries(sgl_tests PRIVATE sgl header_only)
     target_compile_definitions(sgl_tests PRIVATE SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+    if(SGL_ENABLE_TSAN AND SGL_LINUX)
+        # LLVM TSan can assert if doctest's signal handler runs while TSan is
+        # intercepting fork(). Let TSan handle fatal signals in this build.
+        target_compile_definitions(sgl_tests PRIVATE DOCTEST_CONFIG_NO_POSIX_SIGNALS)
+    endif()
 
     set_target_properties(sgl_tests PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${SGL_RUNTIME_OUTPUT_DIRECTORY}

--- a/tools/setup-sanitizer-env.py
+++ b/tools/setup-sanitizer-env.py
@@ -101,6 +101,11 @@ def configure_linux_preload(sanitizers: set[str]) -> None:
         "libclang_rt.ubsan_standalone-x86_64.so",
         "libclang_rt.ubsan_standalone-aarch64.so",
     )
+    tsan_runtime_names = (
+        "libclang_rt.tsan.so",
+        "libclang_rt.tsan-x86_64.so",
+        "libclang_rt.tsan-aarch64.so",
+    )
 
     runtime_paths: list[str] = []
     if "address" in sanitizers:
@@ -114,6 +119,8 @@ def configure_linux_preload(sanitizers: set[str]) -> None:
             if runtime_path:
                 runtime_paths.append(str(runtime_path))
                 break
+    if "thread" in sanitizers:
+        runtime_paths.append(str(find_clang_runtime(tsan_runtime_names)))
     existing_preload = os.environ.get("LD_PRELOAD")
     if existing_preload:
         runtime_paths.append(existing_preload)
@@ -130,9 +137,13 @@ def main() -> int:
     args = parser.parse_args()
 
     sanitizers = set(args.sanitizers.split(","))
-    unsupported_sanitizers = sanitizers - {"address", "undefined"}
+    unsupported_sanitizers = sanitizers - {"address", "undefined", "thread"}
     if unsupported_sanitizers:
         parser.error("Unsupported sanitizers: " + ", ".join(sorted(unsupported_sanitizers)))
+    if "address" in sanitizers and "thread" in sanitizers:
+        parser.error("AddressSanitizer and ThreadSanitizer cannot be combined")
+    if "thread" in sanitizers and args.os == "windows":
+        parser.error("ThreadSanitizer is not supported on Windows")
 
     workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
     binary_dir = args.binary_dir.resolve()
@@ -189,6 +200,13 @@ def main() -> int:
         append_github_env("ASAN_OPTIONS", ":".join(asan_options))
     if "undefined" in sanitizers:
         append_github_env("UBSAN_OPTIONS", "print_stacktrace=1:halt_on_error=1")
+    if "thread" in sanitizers:
+        tsan_options = ["halt_on_error=0", "exitcode=66", "second_deadlock_stack=1"]
+        if symbolizer:
+            tsan_options.append(
+                f"external_symbolizer_path={sanitizer_path(pathlib.Path(symbolizer))}"
+            )
+        append_github_env("TSAN_OPTIONS", ":".join(tsan_options))
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds ThreadSanitizer build support and continuous testing for SlangPy’s native C++ code on Linux and macOS.

## Changes

- Add the `SGL_ENABLE_TSAN` CMake option.
- Apply TSan instrumentation to SlangPy targets and `nanothread`.
- Reject unsupported compiler, platform, and ASan/TSan combinations.
- Disable doctest’s POSIX signal handler for Linux TSan builds to avoid conflicts with TSan’s signal and `fork()` interceptors.
- Extend the sanitizer environment tooling to configure the TSan runtime and `TSAN_OPTIONS`.
- Add TSan CI jobs for:
  - Linux x86-64 using LLVM 22, with device tests skipped.
  - macOS arm64, including device tests.
- Continue after individual TSan reports while returning a failing exit code when races are detected.
- Keep sanitizer runtimes local to the instrumented test process so they are not injected into GitHub Actions’ Node-based post-job steps.

## LLVM 22 support

Linux uses LLVM 22 instead of the runner’s LLVM 18 because LLVM 18 can expose a partially initialized thread to TSan interceptors.

A temporary `libdeflate` vcpkg overlay is included to support this toolchain. It:

- Preserves externally supplied release compiler flags, including sanitizer instrumentation.
- Restricts the `evex512` workaround to compiler versions where it is supported and required.

## Scope

The TSan jobs build and run the native C++ test suite. Python bindings and examples are disabled for these jobs. Linux device tests are skipped through the `-skip-device-tests` option because the GPU stack is outside the supported TSan scope.