### PR TITLE
Fix SGL_INLINE on GCC and Clang

### DIFF
--- a/src/sgl/core/macros.h
+++ b/src/sgl/core/macros.h
@@ -106,7 +106,7 @@
 #if SGL_MSVC
 #define SGL_INLINE __forceinline
 #elif SGL_CLANG | SGL_GCC
-#define SGL_INLINE __attribute__((always_inline))
+#define SGL_INLINE inline __attribute__((always_inline))
 #endif
 
 #define SGL_NON_COPYABLE(cls)                                                                                          \


### PR DESCRIPTION
## Summary

- add the missing C++ `inline` specifier to `SGL_INLINE` on GCC and Clang
- make the non-MSVC expansion semantically consistent with MSVC's `__forceinline`
- allow `SGL_INLINE` to be used on namespace-scope functions without GCC `-Werror=attributes` failures

## Validation

- pre-commit hooks passed
- tests not run (one-line compiler macro fix)