### PR TITLE
Compile report cache keys

### DIFF
--- a/slangpy/tests/device/test_compilation_reports.py
+++ b/slangpy/tests/device/test_compilation_reports.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import re
+from pathlib import Path
+
 import pytest
 
 import slangpy as spy
@@ -29,6 +32,7 @@ ENTRY_POINT_REPORT_KEYS = {
     "compile_downstream_time",
     "is_cached",
     "cache_size",
+    "cache_key",
 }
 
 PIPELINE_REPORT_KEYS = {
@@ -38,14 +42,16 @@ PIPELINE_REPORT_KEYS = {
     "create_time",
     "is_cached",
     "cache_size",
+    "cache_key",
 }
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
-def test_compilation_reports(test_id: str, device_type: spy.DeviceType):
+def test_compilation_reports(tmp_path: Path, test_id: str, device_type: spy.DeviceType):
     device = spy.Device(
         type=device_type,
         enable_compilation_reports=True,
+        shader_cache_path=tmp_path,
         label=f"compilation-reports-{device_type.name}",
     )
     try:
@@ -75,16 +81,38 @@ def test_compilation_reports(test_id: str, device_type: spy.DeviceType):
         assert len(entry_point_reports) == 1
         assert set(entry_point_reports[0].keys()) == ENTRY_POINT_REPORT_KEYS
         assert entry_point_reports[0]["name"] == "compute_main"
+        assert entry_point_reports[0]["is_cached"] is False
+        entry_point_cache_key = entry_point_reports[0]["cache_key"]
+        assert isinstance(entry_point_cache_key, str)
+        assert re.fullmatch(r"sha1:[0-9a-f]{40}", entry_point_cache_key)
 
         pipeline_reports = program_report["pipeline_reports"]
         assert isinstance(pipeline_reports, list)
         assert len(pipeline_reports) == 1
         assert set(pipeline_reports[0].keys()) == PIPELINE_REPORT_KEYS
         assert pipeline_reports[0]["type"] == "compute"
+        pipeline_cache_key = pipeline_reports[0]["cache_key"]
+        if device.has_feature(spy.Feature.pipeline_cache):
+            assert isinstance(pipeline_cache_key, str)
+            assert re.fullmatch(r"sha1:[0-9a-f]{40}", pipeline_cache_key)
+        else:
+            assert pipeline_cache_key is None
 
         device_reports = device.get_compilation_reports()
         assert isinstance(device_reports, list)
         assert len(device_reports) == 1
         assert device_reports[0] == program_report
+
+        cached_program = device.link_program([module], [module.entry_point("compute_main")])
+        cached_pipeline = device.create_compute_pipeline(
+            cached_program,
+            compilation_policy=spy.PipelineCompilationPolicy.immediate,
+        )
+        assert cached_pipeline is not None
+
+        cached_report = cached_program.get_compilation_report()
+        cached_entry_point_report = cached_report["entry_point_reports"][0]
+        assert cached_entry_point_report["is_cached"] is True
+        assert cached_entry_point_report["cache_key"] == entry_point_reports[0]["cache_key"]
     finally:
         device.close()

--- a/src/slangpy_ext/device/compilation_report.h
+++ b/src/slangpy_ext/device/compilation_report.h
@@ -4,6 +4,7 @@
 
 #include "nanobind.h"
 
+#include "sgl/core/string.h"
 #include "sgl/device/device.h"
 #include "sgl/device/helpers.h"
 #include "sgl/device/shader.h"
@@ -37,6 +38,17 @@ inline const char* compilation_pipeline_type_to_string(rhi::CompilationReport::P
     }
 }
 
+inline nb::object cache_key_to_py(const rhi::CompilationReport::CacheKeyDigest& cache_key)
+{
+    if (cache_key.type == rhi::CompilationReport::CacheKeyDigest::Type::None)
+        return nb::none();
+
+    SGL_ASSERT(cache_key.type == rhi::CompilationReport::CacheKeyDigest::Type::SHA1);
+    std::string result = "sha1:";
+    result += string::hexlify(cache_key.bytes, sizeof(cache_key.bytes));
+    return nb::str(result.c_str(), result.size());
+}
+
 inline nb::dict
 compilation_entry_point_report_to_dict(const rhi::CompilationReport::EntryPointReport& entry_point_report)
 {
@@ -50,6 +62,7 @@ compilation_entry_point_report_to_dict(const rhi::CompilationReport::EntryPointR
     result["compile_downstream_time"] = entry_point_report.compileDownstreamTime;
     result["is_cached"] = entry_point_report.isCached;
     result["cache_size"] = entry_point_report.cacheSize;
+    result["cache_key"] = cache_key_to_py(entry_point_report.cacheKey);
     return result;
 }
 
@@ -62,6 +75,7 @@ inline nb::dict compilation_pipeline_report_to_dict(const rhi::CompilationReport
     result["create_time"] = pipeline_report.createTime;
     result["is_cached"] = pipeline_report.isCached;
     result["cache_size"] = pipeline_report.cacheSize;
+    result["cache_key"] = cache_key_to_py(pipeline_report.cacheKey);
     return result;
 }
 

--- a/src/slangpy_ext/slangpy_stub_patterns.nb
+++ b/src/slangpy_ext/slangpy_stub_patterns.nb
@@ -13,6 +13,7 @@ slangpy.__prefix__:
         "compile_downstream_time": float,
         "is_cached": bool,
         "cache_size": int,
+        "cache_key": str | None,
     })
 
     CompilationPipelineReport = TypedDict("CompilationPipelineReport", {
@@ -22,6 +23,7 @@ slangpy.__prefix__:
         "create_time": float,
         "is_cached": bool,
         "cache_size": int,
+        "cache_key": str | None,
     })
 
     CompilationReport = TypedDict("CompilationReport", {


### PR DESCRIPTION
## Summary

Expose cache keys in SlangPy compilation reports.

- Update `slang-rhi` to provide stable cache-key digests.
- Add `cache_key` to entry-point and pipeline compilation reports.
- Represent available keys as `sha1:<40 lowercase hex characters>`.
- Return `None` when a backend does not provide a cache key.
- Update TypedDict definitions to use `str | None`.
- Verify cache-key stability across cache misses and hits, including backends without pipeline-cache support.
