### PR TITLE
Update Slang to 2026.16.1

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -92,7 +92,7 @@ set(SGL_LOCAL_SLANG OFF CACHE BOOL "Use a local build of slang instead of downlo
 set(SGL_LOCAL_SLANG_DIR "${CMAKE_SOURCE_DIR}/../slang" CACHE PATH "Path to a local slang build")
 set(SGL_LOCAL_SLANG_BUILD_DIR "build/Debug" CACHE STRING "Build directory of the local slang build")
 
-set(SGL_SLANG_VERSION "2026.12" CACHE STRING "Slang version to download when not using a local build")
+set(SGL_SLANG_VERSION "2026.16.1" CACHE STRING "Slang version to download when not using a local build")
 
 set(SGL_SLANG_GLIBC_COMPAT OFF CACHE BOOL "Download glibc-2.28-compatible Slang binaries (for manylinux wheels)")
 


### PR DESCRIPTION
## Summary

- update the bundled Slang compiler from 2026.12 to 2026.16.1

## Testing

- built Slang 2026.16.1 from source with native build parallelism capped at 8
- built SlangPy against Slang 2026.16.1 with native build parallelism capped at 8
- verified SLANG_BUILD_TAG=2026.16.1
- pytest slangpy/tests/device/test_standard_modules.py -v (3 passed)
- pre-commit run --all-files
- git diff --check

Slang release: https://github.com/shader-slang/slang/releases/tag/v2026.16.1