### PR TITLE
Release Module native caches on device close to fix nightly LSan leak

### DIFF
--- a/slangpy/core/module.py
+++ b/slangpy/core/module.py
@@ -25,12 +25,20 @@ def _check_for_hot_reload(event_info: Any = None):
             module.on_hot_reload()
 
 
+def _release_module_caches(event_info: Any = None):
+    global LOADED_MODULES
+    for module in LOADED_MODULES.values():
+        if module is not None:
+            module._release_native_caches()
+
+
 def _register_hot_reload_hook(device: Device):
     for x in LOADED_MODULES.values():
         if isinstance(x, Module):
             if x.device == device:
                 return
     device.register_shader_hot_reload_callback(_check_for_hot_reload)
+    device.register_device_close_callback(_release_module_caches)
 
 
 class CallDataCache(NativeCallDataCache):
@@ -186,7 +194,21 @@ class Module(BaseModule):
         Called by device when the module is hot reloaded.
         """
         BaseModule.on_hot_reload(self, self.device_module, self.device_module.layout)
+        self._release_native_caches()
 
+    def _release_native_caches(self):
+        """
+        Drop this module's caches, releasing any NativeCallData/NativeBoundCallRuntime
+        trees they retain.
+
+        sgl::Object (the base of NativeCallDataCache and the native types it caches) uses
+        plain Py_INCREF/Py_DECREF once owned by Python, with no tp_traverse/tp_clear. A
+        Module that stays alive for the process lifetime (e.g. because pytest retains it
+        via LOADED_MODULES/a traceback) therefore keeps its whole call_data_cache tree
+        reachable until process exit, which LeakSanitizer reports as a leak even though
+        it is just an unreleased cache. Replacing the caches here - called on device close
+        as well as hot reload - drops those references deterministically.
+        """
         # Create new cache and update all tracked Function objects
         self.call_data_cache = CallDataCache()
         for func in self._all_functions:


### PR DESCRIPTION
## Summary

Fixes the deterministic LeakSanitizer finding reported in #1130: every scheduled `sanitizers.yml` run on the Linux `asan-ubsan` leg has failed since the workflow was introduced, on a `NativeBoundCallRuntime::args` setter allocation (`std::vector<sgl::ref<NativeBoundVariableRuntime>>`).

## Root cause

`NativeCallDataCache`, `NativeCallData`, `NativeBoundCallRuntime`, and `NativeBoundVariableRuntime` all derive from `sgl::Object`, which is bound to Python via nanobind's `nb::intrusive_ptr` mechanism (`src/slangpy_ext/core/object.cpp`). That mechanism uses plain `Py_INCREF`/`Py_DECREF` once an instance is owned by Python — there is no `tp_traverse`/`tp_clear`, so these objects are invisible to Python's cyclic GC.

`slangpy.core.module.Module` (pure Python) owns `call_data_cache` (a `CallDataCache`/`NativeCallDataCache` subclass) and a strong `_attr_cache: dict[str, Function]`. Calling a `Function` populates `call_data_cache` with a `NativeCallData`, which holds `runtime()` — a `NativeBoundCallRuntime` whose `m_args`/`m_kwargs` are exactly the leaked `NativeBoundVariableRuntime` trees.

Nothing currently ties a `Module`'s lifetime, or its `call_data_cache`, to `Device.close()`. `Device::close()` is documented to "remove all cyclic references that might prevent the device from being destroyed," and is invoked for every open device via the `atexit`-registered `Device::close_all_devices()` (`src/slangpy_ext/slangpy_ext.cpp`). But that path is pure C++ and has no visibility into the Python-level `Module` wrapper or its caches. If any `Module` stays alive until interpreter shutdown (e.g. referenced from the module-level `LOADED_MODULES` weak dict combined with some other live reference, or a retained pytest traceback), its whole `call_data_cache` tree stays reachable-but-unreleased at process exit — which LSan reports as a leak even though it's just an unreleased cache, not a genuine leak.

## Fix

`Module` already has a proven pattern for releasing these caches: `on_hot_reload()` replaces `call_data_cache` with a fresh `CallDataCache()` and clears `_attr_cache`, `dispatch_data_cache`, `pipeline_cache`, and `shader_table_cache`. This PR extracts that into `Module._release_native_caches()` and also calls it from a new `device.register_device_close_callback` hook, registered alongside the existing hot-reload hook in `_register_hot_reload_hook`. Device-close callbacks run "at start of device close," before the device tears down, so replacing these caches is safe (nothing is dereferenced, only re-pointed at empty containers).

This means every path that closes a device — explicit `device.close()` and the `atexit`-driven `close_all_devices()` alike — now also releases every live `Module`'s native cache tree, matching `Device::close()`'s documented purpose.

## Verification

I was unable to get a working ASan+UBSan LeakSanitizer repro locally (clang-14's LD_PRELOAD combination for ASan+UBSan is broken via a `sigaction` interceptor bug, clang-18's apt.llvm.org build has an internal UBSan ABI mismatch, and clang-19 built and linked cleanly but `import slangpy` spun in a `nanothread`/ASan interceptor-related `sched_yield` loop that looked unrelated to this leak). This fix is therefore based on static analysis of the reference-counting/ownership chain, not a live before/after LSan comparison — the `sanitizers.yml` nightly run is the actual verification.