### PR TITLE
Grant PR board-sync callers GITHUB_TOKEN write

### DIFF
--- a/.github/workflows/pr-checks-complete.yml
+++ b/.github/workflows/pr-checks-complete.yml
@@ -41,6 +41,11 @@ permissions: {}
 
 jobs:
   board-sync:
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-commit-status.yml
+++ b/.github/workflows/pr-commit-status.yml
@@ -25,6 +25,11 @@ jobs:
     # (success -> recovery, failure/error -> Snagged) changes the outcome, and the
     # recompute is idempotent regardless.
     if: ${{ github.event.state != 'pending' }}
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -52,6 +52,11 @@ jobs:
     if: >-
       github.event_name != 'pull_request_review' ||
       github.event.pull_request.head.repo.fork == false
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-review-fork-apply.yml
+++ b/.github/workflows/pr-review-fork-apply.yml
@@ -25,6 +25,11 @@ jobs:
     # Only when the bridge completed successfully (it always should; this guards
     # against a cancelled/failed relay run).
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-sweep-nightly.yml
+++ b/.github/workflows/pr-sweep-nightly.yml
@@ -24,6 +24,11 @@ permissions: {}
 
 jobs:
   board-sweep:
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     with:
       mode: sweep


### PR DESCRIPTION
## Summary

- Grant `issues: write` and `pull-requests: write` on the slangpy jobs that call `shader-slang/slang/.github/workflows/pr-board-sync.yml`.
- That lets the reusable workflow post repo-scoped writes (assignees, review requests, assignment comments) as `github-actions[bot]` via `GITHUB_TOKEN` instead of `SLANG_PR_BOT_TOKEN`.
- Leave `pr-review-fork-bridge.yml` at `permissions: {}`; it only relays fork-PR reviews and does not write to the repo or board.

Org-team reads and ProjectsV2 writes still use the PAT. This is safe to merge before [shader-slang/slang#12888](https://github.com/shader-slang/slang/pull/12888): current slang `master` still sets `permissions: {}` on the reusable workflow and authenticates every call with the PAT, so these grants are inert until that PR lands.

## Test plan

- [ ] Confirm Actionlint / workflow YAML checks pass
- [ ] After slang#12888 is on `master`, run a slangpy PR through board-sync and confirm assignment comments / assignee changes appear as `github-actions[bot]`, not the PAT owner
- [ ] Confirm fork-PR reviews still flow bridge → apply and that the bridge job does not gain write permissions