### PR TITLE
Add window refresh callback

### DIFF
--- a/src/sgl/core/window.cpp
+++ b/src/sgl/core/window.cpp
@@ -231,6 +231,13 @@ struct EventHandlers {
         window->handle_window_size(width, height);
     }
 
+    static void handle_window_refresh(GLFWwindow* glfw_window)
+    {
+        Window* window = static_cast<Window*>(glfwGetWindowUserPointer(glfw_window));
+
+        window->handle_window_refresh();
+    }
+
     static void handle_key(GLFWwindow* glfw_window, int key, int scancode, int action, int mods)
     {
         SGL_UNUSED(scancode);
@@ -383,6 +390,7 @@ Window::Window(WindowDesc desc)
     glfwSetWindowUserPointer(m_window, this);
     glfwSetErrorCallback(&EventHandlers::handle_error);
     glfwSetWindowSizeCallback(m_window, &EventHandlers::handle_window_size);
+    glfwSetWindowRefreshCallback(m_window, &EventHandlers::handle_window_refresh);
     glfwSetKeyCallback(m_window, &EventHandlers::handle_key);
     glfwSetCharCallback(m_window, &EventHandlers::handle_char);
     glfwSetMouseButtonCallback(m_window, &EventHandlers::handle_mouse_button);
@@ -653,6 +661,12 @@ void Window::handle_window_size(uint32_t width, uint32_t height)
     m_height = height;
     if (m_on_resize)
         m_on_resize(m_width, m_height);
+}
+
+void Window::handle_window_refresh()
+{
+    if (m_on_refresh)
+        m_on_refresh();
 }
 
 void Window::handle_keyboard_event(const KeyboardEvent& event)

--- a/src/sgl/core/window.h
+++ b/src/sgl/core/window.h
@@ -175,6 +175,7 @@ public:
     // events
 
     using ResizeCallback = std::function<void(uint32_t /* width */, uint32_t /* height */)>;
+    using RefreshCallback = std::function<void()>;
     using KeyboardEventCallback = std::function<void(const KeyboardEvent& /* event */)>;
     using MouseEventCallback = std::function<void(const MouseEvent& /* event */)>;
     using GamepadEventCallback = std::function<void(const GamepadEvent& /* event */)>;
@@ -184,6 +185,10 @@ public:
     /// Event handler to be called when the window is resized.
     const ResizeCallback& on_resize() const { return m_on_resize; }
     void set_on_resize(ResizeCallback on_resize) { m_on_resize = std::move(on_resize); }
+
+    /// Event handler to be called when the window contents need to be refreshed.
+    const RefreshCallback& on_refresh() const { return m_on_refresh; }
+    void set_on_refresh(RefreshCallback on_refresh) { m_on_refresh = std::move(on_refresh); }
 
     /// Event handler to be called when a keyboard event occurs.
     const KeyboardEventCallback& on_keyboard_event() const { return m_on_keyboard_event; }
@@ -220,6 +225,7 @@ private:
     void poll_gamepad_input();
 
     void handle_window_size(uint32_t width, uint32_t height);
+    void handle_window_refresh();
     void handle_keyboard_event(const KeyboardEvent& event);
     void handle_mouse_event(const MouseEvent& event);
     void handle_gamepad_event(const GamepadEvent& event);
@@ -243,6 +249,7 @@ private:
     GamepadState m_gamepad_prev_state;
 
     ResizeCallback m_on_resize;
+    RefreshCallback m_on_refresh;
     KeyboardEventCallback m_on_keyboard_event;
     MouseEventCallback m_on_mouse_event;
     GamepadEventCallback m_on_gamepad_event;

--- a/src/slangpy_ext/core/window.cpp
+++ b/src/slangpy_ext/core/window.cpp
@@ -11,6 +11,7 @@ struct GcHelper<Window> {
     void traverse(Window*, GcVisitor& visitor)
     {
         visitor("on_resize");
+        visitor("on_refresh");
         visitor("on_keyboard_event");
         visitor("on_mouse_event");
         visitor("on_gamepad_event");
@@ -65,6 +66,13 @@ SGL_PY_EXPORT(core_window)
     window.def_prop_rw("cursor_shape", &Window::cursor_shape, &Window::set_cursor_shape, D(Window, cursor_shape));
 
     window.def_prop_rw("on_resize", &Window::on_resize, &Window::set_on_resize, nb::arg().none(), D(Window, on_resize));
+    window.def_prop_rw(
+        "on_refresh",
+        &Window::on_refresh,
+        &Window::set_on_refresh,
+        nb::arg().none(),
+        D(Window, on_refresh)
+    );
     window.def_prop_rw(
         "on_keyboard_event",
         &Window::on_keyboard_event,

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -9931,6 +9931,8 @@ static const char *__doc_sgl_Window_m_on_mouse_event = R"doc()doc";
 
 static const char *__doc_sgl_Window_m_on_resize = R"doc()doc";
 
+static const char *__doc_sgl_Window_m_on_refresh = R"doc()doc";
+
 static const char *__doc_sgl_Window_m_should_close = R"doc()doc";
 
 static const char *__doc_sgl_Window_m_title = R"doc()doc";
@@ -9950,6 +9952,8 @@ static const char *__doc_sgl_Window_on_keyboard_event = R"doc(Event handler to b
 static const char *__doc_sgl_Window_on_mouse_event = R"doc(Event handler to be called when a mouse event occurs.)doc";
 
 static const char *__doc_sgl_Window_on_resize = R"doc(Event handler to be called when the window is resized.)doc";
+
+static const char *__doc_sgl_Window_on_refresh = R"doc(Event handler to be called when the window contents need to be refreshed.)doc";
 
 static const char *__doc_sgl_Window_poll_gamepad_input = R"doc()doc";
 


### PR DESCRIPTION
## Summary

Add an `on_refresh` callback to `Window`, invoked when GLFW reports that the window contents need to be redrawn.

- Expose the callback through the native and Python APIs
- Register the GLFW window refresh handler
- Include the Python callback in garbage-collection traversal
- Add the callback to the generated API documentation
