### PR TITLE
Add opacity micromap support

### DIFF
--- a/slangpy/tests/device/test_opacity_micromap.py
+++ b/slangpy/tests/device/test_opacity_micromap.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import gc
+
+import numpy as np
+import pytest
+
+import slangpy as spy
+from slangpy.testing import helpers
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_opacity_micromap_trace(device_type: spy.DeviceType) -> None:
+    device = helpers.get_device(type=device_type)
+    if not device.has_feature(spy.Feature.opacity_micromap):
+        pytest.skip("Opacity micromaps are not supported on this device")
+
+    opacity_data = np.zeros(256, dtype=np.uint8)
+    opacity_data[1] = 1
+    opacity_data[2] = 0b1010
+    opacity_data_buffer = device.create_buffer(
+        data=opacity_data,
+        usage=spy.BufferUsage.micromap_build_input,
+        default_state=spy.ResourceState.micromap_build_input,
+        label="opacity_data",
+    )
+
+    triangle_desc_dtype = np.dtype(
+        [
+            ("data_offset", np.uint32),
+            ("subdivision_level", np.uint16),
+            ("format", np.uint16),
+        ]
+    )
+    triangle_descs = np.zeros(32, dtype=triangle_desc_dtype)
+    triangle_descs[0] = (0, 0, spy.OpacityMicromapFormat.two_state.value)
+    triangle_descs[1] = (1, 0, spy.OpacityMicromapFormat.two_state.value)
+    triangle_descs[2] = (2, 1, spy.OpacityMicromapFormat.two_state.value)
+    triangle_desc_buffer = device.create_buffer(
+        data=triangle_descs.view(np.uint8),
+        usage=spy.BufferUsage.micromap_build_input,
+        default_state=spy.ResourceState.micromap_build_input,
+        label="micromap_triangle_descs",
+    )
+
+    usage_counts = [
+        {
+            "count": 2,
+            "subdivision_level": 0,
+            "format": spy.OpacityMicromapFormat.two_state,
+        },
+        {
+            "count": 1,
+            "subdivision_level": 1,
+            "format": spy.OpacityMicromapFormat.two_state,
+        },
+    ]
+    micromap_build_desc = spy.MicromapBuildDesc(
+        {
+            "data_buffer": opacity_data_buffer,
+            "descriptor_buffer": triangle_desc_buffer,
+            "histogram": usage_counts,
+        }
+    )
+    micromap_sizes = device.get_micromap_sizes(micromap_build_desc)
+    assert micromap_sizes.micromap_size > 0
+    assert micromap_sizes.scratch_size > 0
+
+    micromap = device.create_micromap(
+        size=micromap_sizes.micromap_size,
+        label="opacity_micromap",
+    )
+    micromap_scratch = device.create_buffer(
+        size=micromap_sizes.scratch_size,
+        usage=spy.BufferUsage.unordered_access,
+        default_state=spy.ResourceState.unordered_access,
+        label="micromap_scratch",
+    )
+
+    command_encoder = device.create_command_encoder()
+    command_encoder.build_micromap(
+        micromap_build_desc,
+        micromap,
+        micromap_scratch,
+    )
+    device.submit_command_buffer(command_encoder.finish())
+    device.wait_for_idle()
+
+    vertices = np.array(
+        [
+            [-0.9, -0.5, 1.0],
+            [-0.1, -0.5, 1.0],
+            [-0.5, 0.5, 1.0],
+            [0.1, -0.5, 1.0],
+            [0.9, -0.5, 1.0],
+            [0.5, 0.5, 1.0],
+            [1.0, -0.5, 1.0],
+            [2.0, -0.5, 1.0],
+            [1.5, 0.5, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    vertex_buffer = device.create_buffer(
+        data=vertices,
+        usage=spy.BufferUsage.acceleration_structure_build_input,
+        default_state=spy.ResourceState.acceleration_structure_build_output,
+        label="vertices",
+    )
+
+    opacity_attachment = spy.AccelerationStructureOpacityMicromapDesc(
+        {
+            "micromap": micromap,
+            "usage_counts": usage_counts,
+        }
+    )
+    triangle_input = spy.AccelerationStructureBuildInputTriangles(
+        {
+            "vertex_buffers": [vertex_buffer],
+            "vertex_format": spy.Format.rgb32_float,
+            "vertex_count": vertices.shape[0],
+            "vertex_stride": vertices.strides[0],
+            "flags": spy.AccelerationStructureGeometryFlags.none,
+            "opacity_micromap": opacity_attachment,
+        }
+    )
+    blas_build_desc = spy.AccelerationStructureBuildDesc({"inputs": [triangle_input]})
+    blas_sizes = device.get_acceleration_structure_sizes(blas_build_desc)
+    blas = device.create_acceleration_structure(
+        kind=spy.AccelerationStructureKind.bottom_level,
+        size=blas_sizes.acceleration_structure_size,
+        label="micromap_blas",
+    )
+    blas_scratch = device.create_buffer(
+        size=blas_sizes.scratch_size,
+        usage=spy.BufferUsage.unordered_access,
+        label="blas_scratch",
+    )
+    command_encoder = device.create_command_encoder()
+    command_encoder.build_acceleration_structure(
+        blas_build_desc,
+        blas,
+        None,
+        blas_scratch,
+    )
+    device.submit_command_buffer(command_encoder.finish())
+    device.wait_for_idle()
+
+    triangle_input.opacity_micromap = None
+    opacity_attachment = None
+    blas_build_desc = None
+    micromap = None
+    gc.collect()
+
+    instance_list = device.create_acceleration_structure_instance_list(1)
+    instance_list.write(
+        0,
+        {
+            "transform": spy.float3x4([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]),
+            "instance_id": 0,
+            "instance_mask": 0xFF,
+            "instance_contribution_to_hit_group_index": 0,
+            "flags": spy.AccelerationStructureInstanceFlags.none,
+            "acceleration_structure": blas.handle,
+        },
+    )
+    tlas_build_desc = spy.AccelerationStructureBuildDesc(
+        {"inputs": [instance_list.build_input_instances()]}
+    )
+    tlas_sizes = device.get_acceleration_structure_sizes(tlas_build_desc)
+    tlas = device.create_acceleration_structure(
+        kind=spy.AccelerationStructureKind.top_level,
+        size=tlas_sizes.acceleration_structure_size,
+        label="micromap_tlas",
+    )
+    tlas_scratch = device.create_buffer(
+        size=tlas_sizes.scratch_size,
+        usage=spy.BufferUsage.unordered_access,
+        label="tlas_scratch",
+    )
+    command_encoder = device.create_command_encoder()
+    command_encoder.build_acceleration_structure(
+        tlas_build_desc,
+        tlas,
+        None,
+        tlas_scratch,
+    )
+    device.submit_command_buffer(command_encoder.finish())
+    device.wait_for_idle()
+
+    program = device.load_program(
+        "test_opacity_micromap.slang",
+        ["ray_gen", "miss", "closest_hit"],
+    )
+    pipeline = device.create_ray_tracing_pipeline(
+        program=program,
+        hit_groups=[
+            spy.HitGroupDesc(
+                hit_group_name="hit_group",
+                closest_hit_entry_point="closest_hit",
+            )
+        ],
+        max_recursion=1,
+        max_ray_payload_size=4,
+        flags=spy.RayTracingPipelineFlags.enable_opacity_micromaps,
+    )
+    shader_table = device.create_shader_table(
+        program=program,
+        ray_gen_entry_points=["ray_gen"],
+        miss_entry_points=["miss"],
+        hit_group_names=["hit_group"],
+    )
+    result_buffer = device.create_buffer(
+        data=np.zeros(6, dtype=np.uint32),
+        usage=spy.BufferUsage.unordered_access | spy.BufferUsage.copy_source,
+        label="results",
+    )
+
+    command_encoder = device.create_command_encoder()
+    with command_encoder.begin_ray_tracing_pass() as pass_encoder:
+        shader_object = pass_encoder.bind_pipeline(pipeline, shader_table)
+        cursor = spy.ShaderCursor(shader_object)
+        cursor.result_buffer = result_buffer
+        cursor.scene_bvh = tlas
+        pass_encoder.dispatch_rays(0, [6, 1, 1])
+    device.submit_command_buffer(command_encoder.finish())
+    device.wait_for_idle()
+
+    np.testing.assert_array_equal(
+        result_buffer.to_numpy().view(np.uint32),
+        np.array([1, 2, 1, 2, 1, 2], dtype=np.uint32),
+    )

--- a/slangpy/tests/device/test_opacity_micromap.slang
+++ b/slangpy/tests/device/test_opacity_micromap.slang
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[raypayload]
+struct Payload
+{
+    uint result : read(caller) : write(caller, closesthit, miss);
+};
+
+uniform RWStructuredBuffer<uint> result_buffer;
+uniform RaytracingAccelerationStructure scene_bvh;
+
+[shader("raygeneration")]
+void ray_gen()
+{
+    uint ray_index = DispatchRaysIndex().x;
+
+    static const float2 origins[] =
+    {
+        float2(-0.5, 0.0),
+        float2(0.5, 0.0),
+        float2(1.25, -1.0 / 3.0),
+        float2(1.5, -1.0 / 6.0),
+        float2(1.75, -1.0 / 3.0),
+        float2(1.5, 1.0 / 6.0),
+    };
+
+    RayDesc ray;
+    ray.Origin = float3(origins[ray_index], 0.0);
+    ray.Direction = float3(0.0, 0.0, 1.0);
+    ray.TMin = 0.001;
+    ray.TMax = 100.0;
+
+    Payload payload = {0};
+    TraceRay(scene_bvh, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, payload);
+    result_buffer[ray_index] = payload.result;
+}
+
+[shader("miss")]
+void miss(inout Payload payload)
+{
+    payload.result = 1;
+}
+
+[shader("closesthit")]
+void closest_hit(inout Payload payload, BuiltInTriangleIntersectionAttributes attributes)
+{
+    payload.result = 2;
+}

--- a/src/sgl/device/command.cpp
+++ b/src/sgl/device/command.cpp
@@ -752,6 +752,17 @@ void CommandEncoder::build_acceleration_structure(
         narrow_cast<uint32_t>(rhi_queries.size()),
         rhi_queries.data()
     );
+
+    dst->set_micromap_dependencies(desc);
+}
+
+void CommandEncoder::build_micromap(const MicromapBuildDesc& desc, Micromap* dst, BufferOffsetPair scratch_buffer)
+{
+    SGL_CHECK(m_open, "Command encoder is finished");
+    SGL_CHECK_NOT_NULL(dst);
+
+    MicromapBuildDescConverter converter(desc);
+    m_rhi_command_encoder->buildMicromap(converter.rhi_desc, dst->rhi_micromap(), detail::to_rhi(scratch_buffer));
 }
 
 void CommandEncoder::copy_acceleration_structure(
@@ -768,6 +779,8 @@ void CommandEncoder::copy_acceleration_structure(
         src->rhi_acceleration_structure(),
         static_cast<rhi::AccelerationStructureCopyMode>(mode)
     );
+
+    dst->copy_micromap_dependencies(*src);
 }
 
 void CommandEncoder::query_acceleration_structure_properties(

--- a/src/sgl/device/command.h
+++ b/src/sgl/device/command.h
@@ -363,6 +363,8 @@ public:
         std::span<AccelerationStructureQueryDesc> queries = std::span<AccelerationStructureQueryDesc>()
     );
 
+    void build_micromap(const MicromapBuildDesc& desc, Micromap* dst, BufferOffsetPair scratch_buffer);
+
     void copy_acceleration_structure(
         AccelerationStructure* dst,
         AccelerationStructure* src,

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -646,6 +646,22 @@ ref<AccelerationStructureInstanceList> Device::create_acceleration_structure_ins
     return make_ref<AccelerationStructureInstanceList>(ref<Device>(this), size);
 }
 
+MicromapSizes Device::get_micromap_sizes(const MicromapBuildDesc& desc)
+{
+    MicromapBuildDescConverter converter(desc);
+    rhi::MicromapSizes rhi_sizes;
+    SLANG_RHI_CALL(m_rhi_device->getMicromapSizes(converter.rhi_desc, &rhi_sizes), this);
+    return {
+        .micromap_size = rhi_sizes.micromapSize,
+        .scratch_size = rhi_sizes.scratchSize,
+    };
+}
+
+ref<Micromap> Device::create_micromap(MicromapDesc desc)
+{
+    return make_ref<Micromap>(ref<Device>(this), std::move(desc));
+}
+
 ref<ShaderTable> Device::create_shader_table(ShaderTableDesc desc)
 {
     return make_ref<ShaderTable>(ref<Device>(this), std::move(desc));
@@ -1656,6 +1672,16 @@ ref<AccelerationStructure> create_acceleration_structure(AccelerationStructureDe
 ref<AccelerationStructureInstanceList> create_acceleration_structure_instance_list(size_t size)
 {
     return current_device()->create_acceleration_structure_instance_list(size);
+}
+
+MicromapSizes get_micromap_sizes(const MicromapBuildDesc& desc)
+{
+    return current_device()->get_micromap_sizes(desc);
+}
+
+ref<Micromap> create_micromap(MicromapDesc desc)
+{
+    return current_device()->create_micromap(std::move(desc));
 }
 
 ref<ShaderTable> create_shader_table(ShaderTableDesc desc)

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -519,6 +519,12 @@ public:
     /// Create a new acceleration structure instance list.
     ref<AccelerationStructureInstanceList> create_acceleration_structure_instance_list(size_t size);
 
+    /// Query the device for buffer sizes required for a micromap build.
+    MicromapSizes get_micromap_sizes(const MicromapBuildDesc& desc);
+
+    /// Create a new micromap.
+    ref<Micromap> create_micromap(MicromapDesc desc);
+
     /// Create a new shader table.
     ref<ShaderTable> create_shader_table(ShaderTableDesc desc);
 
@@ -1134,6 +1140,12 @@ SGL_API ref<AccelerationStructure> create_acceleration_structure(AccelerationStr
 
 /// Create a new acceleration structure instance list.
 SGL_API ref<AccelerationStructureInstanceList> create_acceleration_structure_instance_list(size_t size);
+
+/// Query the current device for buffer sizes required for a micromap build.
+SGL_API MicromapSizes get_micromap_sizes(const MicromapBuildDesc& desc);
+
+/// Create a new micromap on the current device.
+SGL_API ref<Micromap> create_micromap(MicromapDesc desc);
 
 /// Create a new shader table.
 SGL_API ref<ShaderTable> create_shader_table(ShaderTableDesc desc);

--- a/src/sgl/device/fwd.h
+++ b/src/sgl/device/fwd.h
@@ -119,6 +119,8 @@ class QueryPool;
 struct AccelerationStructureDesc;
 class AccelerationStructure;
 class AccelerationStructureInstanceList;
+struct MicromapDesc;
+class Micromap;
 struct ShaderTableDesc;
 class ShaderTable;
 

--- a/src/sgl/device/native_handle.h
+++ b/src/sgl/device/native_handle.h
@@ -39,6 +39,7 @@ enum class NativeHandleType {
     VkSampler = static_cast<uint32_t>(rhi::NativeHandleType::VkSampler),
     VkPipeline = static_cast<uint32_t>(rhi::NativeHandleType::VkPipeline),
     VkSemaphore = static_cast<uint32_t>(rhi::NativeHandleType::VkSemaphore),
+    VkMicromapEXT = static_cast<uint32_t>(rhi::NativeHandleType::VkMicromapEXT),
 
     MTLDevice = static_cast<uint32_t>(rhi::NativeHandleType::MTLDevice),
     MTLCommandQueue = static_cast<uint32_t>(rhi::NativeHandleType::MTLCommandQueue),
@@ -102,6 +103,7 @@ SGL_ENUM_INFO(
         {NativeHandleType::VkSampler, "VkSampler"},
         {NativeHandleType::VkPipeline, "VkPipeline"},
         {NativeHandleType::VkSemaphore, "VkSemaphore"},
+        {NativeHandleType::VkMicromapEXT, "VkMicromapEXT"},
 
         {NativeHandleType::MTLDevice, "MTLDevice"},
         {NativeHandleType::MTLCommandQueue, "MTLCommandQueue"},

--- a/src/sgl/device/native_handle_traits.h
+++ b/src/sgl/device/native_handle_traits.h
@@ -75,6 +75,7 @@ SGL_NATIVE_HANDLE(VkPipeline, NativeHandleType::VkPipeline);
 SGL_NATIVE_HANDLE(VkQueue, NativeHandleType::VkQueue);
 SGL_NATIVE_HANDLE(VkCommandBuffer, NativeHandleType::VkCommandBuffer);
 SGL_NATIVE_HANDLE(VkSampler, NativeHandleType::VkSampler);
+SGL_NATIVE_HANDLE(VkMicromapEXT, NativeHandleType::VkMicromapEXT);
 #endif // SGL_HAS_VULKAN
 
 SGL_NATIVE_HANDLE_32(CUdevice, NativeHandleType::CUdevice);

--- a/src/sgl/device/raytracing.cpp
+++ b/src/sgl/device/raytracing.cpp
@@ -15,11 +15,38 @@
 
 namespace sgl {
 
+MicromapBuildDescConverter::MicromapBuildDescConverter(const MicromapBuildDesc& desc)
+{
+    rhi_histogram.reserve(desc.histogram.size());
+    for (const auto& usage : desc.histogram) {
+        rhi_histogram.push_back({
+            .count = usage.count,
+            .subdivisionLevel = usage.subdivision_level,
+            .format = static_cast<uint32_t>(usage.format),
+        });
+    }
+
+    rhi_desc = {
+        .type = static_cast<rhi::MicromapType>(desc.type),
+        .flags = static_cast<rhi::MicromapBuildFlags>(desc.flags),
+        .dataBuffer = detail::to_rhi(desc.data_buffer),
+        .descriptorBuffer = detail::to_rhi(desc.descriptor_buffer),
+        .descriptorStride = desc.descriptor_stride,
+        .histogram = rhi_histogram.data(),
+        .histogramCount = narrow_cast<uint32_t>(rhi_histogram.size()),
+    };
+}
+
 AccelerationStructureBuildDescConverter::AccelerationStructureBuildDescConverter(
     const AccelerationStructureBuildDesc& desc
 )
 {
-    for (const auto& input : desc.inputs) {
+    rhi_build_inputs.reserve(desc.inputs.size());
+    rhi_opacity_micromap_descs.resize(desc.inputs.size());
+    rhi_opacity_micromap_usage_counts.resize(desc.inputs.size());
+
+    for (size_t input_index = 0; input_index < desc.inputs.size(); ++input_index) {
+        const auto& input = desc.inputs[input_index];
         if (auto* instances = std::get_if<AccelerationStructureBuildInputInstances>(&input)) {
             rhi::AccelerationStructureBuildInput rhi_build_input{
                 .type = rhi::AccelerationStructureBuildInputType::Instances,
@@ -47,6 +74,32 @@ AccelerationStructureBuildDescConverter::AccelerationStructureBuildDescConverter
             };
             for (size_t i = 0; i < triangles->vertex_buffers.size(); ++i)
                 rhi_build_input.triangles.vertexBuffers[i] = detail::to_rhi(triangles->vertex_buffers[i]);
+
+            if (triangles->opacity_micromap) {
+                const auto& opacity_micromap = *triangles->opacity_micromap;
+                auto& rhi_usage_counts = rhi_opacity_micromap_usage_counts[input_index];
+                rhi_usage_counts.reserve(opacity_micromap.usage_counts.size());
+                for (const auto& usage : opacity_micromap.usage_counts) {
+                    rhi_usage_counts.push_back({
+                        .count = usage.count,
+                        .subdivisionLevel = usage.subdivision_level,
+                        .format = static_cast<uint32_t>(usage.format),
+                    });
+                }
+
+                auto& rhi_opacity_micromap = rhi_opacity_micromap_descs[input_index];
+                rhi_opacity_micromap.link = {
+                    .micromap = opacity_micromap.micromap ? opacity_micromap.micromap->rhi_micromap() : nullptr,
+                    .indexingMode = static_cast<rhi::MicromapIndexingMode>(opacity_micromap.indexing_mode),
+                    .indexBuffer = detail::to_rhi(opacity_micromap.index_buffer),
+                    .indexFormat = static_cast<rhi::MicromapIndexFormat>(opacity_micromap.index_format),
+                    .indexStride = opacity_micromap.index_stride,
+                    .baseMicromapIndex = opacity_micromap.base_micromap_index,
+                    .usageCounts = rhi_usage_counts.data(),
+                    .usageCount = narrow_cast<uint32_t>(rhi_usage_counts.size()),
+                };
+                rhi_build_input.triangles.next = &rhi_opacity_micromap;
+            }
             rhi_build_inputs.push_back(rhi_build_input);
         } else if (auto* procedural_primitives
                    = std::get_if<AccelerationStructureBuildInputProceduralPrimitives>(&input)) {
@@ -126,6 +179,35 @@ AccelerationStructureBuildDescConverter::AccelerationStructureBuildDescConverter
     rhi_desc.flags = static_cast<rhi::AccelerationStructureBuildFlags>(desc.flags);
 }
 
+Micromap::Micromap(ref<Device> device, MicromapDesc desc)
+    : Resource(std::move(device))
+    , m_desc(std::move(desc))
+{
+    rhi::MicromapDesc rhi_desc{
+        .type = static_cast<rhi::MicromapType>(m_desc.type),
+        .size = m_desc.size,
+        .flags = static_cast<rhi::MicromapBuildFlags>(m_desc.flags),
+        .label = m_desc.label.c_str(),
+    };
+    SLANG_RHI_CALL(m_device->rhi_device()->createMicromap(rhi_desc, m_rhi_micromap.writeRef()), m_device);
+}
+
+Micromap::~Micromap() { }
+
+std::string Micromap::to_string() const
+{
+    return fmt::format(
+        "Micromap(\n"
+        "  device = {},\n"
+        "  size = {},\n"
+        "  label = {}\n"
+        ")",
+        m_device,
+        m_desc.size,
+        m_desc.label
+    );
+}
+
 AccelerationStructure::AccelerationStructure(ref<Device> device, AccelerationStructureDesc desc)
     : DeviceChild(std::move(device))
     , m_desc(std::move(desc))
@@ -146,6 +228,22 @@ AccelerationStructure::~AccelerationStructure() { }
 AccelerationStructureHandle AccelerationStructure::handle() const
 {
     return m_rhi_acceleration_structure->getHandle();
+}
+
+void AccelerationStructure::set_micromap_dependencies(const AccelerationStructureBuildDesc& desc)
+{
+    m_micromap_dependencies.clear();
+    for (const auto& input : desc.inputs) {
+        if (const auto* triangles = std::get_if<AccelerationStructureBuildInputTriangles>(&input)) {
+            if (triangles->opacity_micromap && triangles->opacity_micromap->micromap)
+                m_micromap_dependencies.push_back(triangles->opacity_micromap->micromap);
+        }
+    }
+}
+
+void AccelerationStructure::copy_micromap_dependencies(const AccelerationStructure& src)
+{
+    m_micromap_dependencies = src.m_micromap_dependencies;
 }
 
 void AccelerationStructure::write_to_cursor(const ShaderCursor& cursor, const AccelerationStructure* value)

--- a/src/sgl/device/raytracing.h
+++ b/src/sgl/device/raytracing.h
@@ -18,6 +18,7 @@
 
 #include <slang-rhi.h>
 
+#include <optional>
 #include <variant>
 
 namespace sgl {
@@ -50,6 +51,9 @@ enum class AccelerationStructureInstanceFlags : uint32_t {
     = static_cast<uint32_t>(rhi::AccelerationStructureInstanceFlags::TriangleFrontCounterClockwise),
     force_opaque = static_cast<uint32_t>(rhi::AccelerationStructureInstanceFlags::ForceOpaque),
     no_opaque = static_cast<uint32_t>(rhi::AccelerationStructureInstanceFlags::NoOpaque),
+    force_opacity_micromap_2_state
+    = static_cast<uint32_t>(rhi::AccelerationStructureInstanceFlags::ForceOpacityMicromap2State),
+    disable_opacity_micromaps = static_cast<uint32_t>(rhi::AccelerationStructureInstanceFlags::DisableOpacityMicromaps),
 };
 
 SGL_ENUM_CLASS_OPERATORS(AccelerationStructureInstanceFlags);
@@ -61,6 +65,8 @@ SGL_ENUM_FLAGS_INFO(
         {AccelerationStructureInstanceFlags::triangle_front_counter_clockwise, "triangle_front_counter_clockwise"},
         {AccelerationStructureInstanceFlags::force_opaque, "force_opaque"},
         {AccelerationStructureInstanceFlags::no_opaque, "no_opaque"},
+        {AccelerationStructureInstanceFlags::force_opacity_micromap_2_state, "force_opacity_micromap_2_state"},
+        {AccelerationStructureInstanceFlags::disable_opacity_micromaps, "disable_opacity_micromaps"},
     }
 );
 SGL_ENUM_REGISTER(AccelerationStructureInstanceFlags);
@@ -74,6 +80,159 @@ struct AccelerationStructureInstanceDesc {
     AccelerationStructureHandle acceleration_structure;
 };
 static_assert(sizeof(AccelerationStructureInstanceDesc) == sizeof(rhi::AccelerationStructureInstanceDescGeneric));
+
+enum class MicromapType : uint32_t {
+    opacity = static_cast<uint32_t>(rhi::MicromapType::Opacity),
+};
+SGL_ENUM_INFO(MicromapType, {{MicromapType::opacity, "opacity"}});
+SGL_ENUM_REGISTER(MicromapType);
+
+enum class OpacityMicromapFormat : uint16_t {
+    two_state = static_cast<uint16_t>(rhi::OpacityMicromapFormat::TwoState),
+    four_state = static_cast<uint16_t>(rhi::OpacityMicromapFormat::FourState),
+};
+SGL_ENUM_INFO(
+    OpacityMicromapFormat,
+    {
+        {OpacityMicromapFormat::two_state, "two_state"},
+        {OpacityMicromapFormat::four_state, "four_state"},
+    }
+);
+SGL_ENUM_REGISTER(OpacityMicromapFormat);
+
+enum class OpacityMicromapSpecialIndex : int32_t {
+    fully_transparent = static_cast<int32_t>(rhi::OpacityMicromapSpecialIndex::FullyTransparent),
+    fully_opaque = static_cast<int32_t>(rhi::OpacityMicromapSpecialIndex::FullyOpaque),
+    fully_unknown_transparent = static_cast<int32_t>(rhi::OpacityMicromapSpecialIndex::FullyUnknownTransparent),
+    fully_unknown_opaque = static_cast<int32_t>(rhi::OpacityMicromapSpecialIndex::FullyUnknownOpaque),
+};
+SGL_ENUM_INFO(
+    OpacityMicromapSpecialIndex,
+    {
+        {OpacityMicromapSpecialIndex::fully_transparent, "fully_transparent"},
+        {OpacityMicromapSpecialIndex::fully_opaque, "fully_opaque"},
+        {OpacityMicromapSpecialIndex::fully_unknown_transparent, "fully_unknown_transparent"},
+        {OpacityMicromapSpecialIndex::fully_unknown_opaque, "fully_unknown_opaque"},
+    }
+);
+SGL_ENUM_REGISTER(OpacityMicromapSpecialIndex);
+
+struct MicromapTriangleDesc {
+    uint32_t data_offset{0};
+    uint16_t subdivision_level{0};
+    OpacityMicromapFormat format{OpacityMicromapFormat::two_state};
+};
+static_assert(sizeof(MicromapTriangleDesc) == sizeof(rhi::MicromapTriangleDesc));
+
+struct MicromapUsageCount {
+    uint32_t count{0};
+    uint32_t subdivision_level{0};
+    OpacityMicromapFormat format{OpacityMicromapFormat::two_state};
+};
+
+enum class MicromapIndexingMode : uint32_t {
+    linear = static_cast<uint32_t>(rhi::MicromapIndexingMode::Linear),
+    indexed = static_cast<uint32_t>(rhi::MicromapIndexingMode::Indexed),
+};
+SGL_ENUM_INFO(
+    MicromapIndexingMode,
+    {
+        {MicromapIndexingMode::linear, "linear"},
+        {MicromapIndexingMode::indexed, "indexed"},
+    }
+);
+SGL_ENUM_REGISTER(MicromapIndexingMode);
+
+enum class MicromapIndexFormat : uint32_t {
+    none = static_cast<uint32_t>(rhi::MicromapIndexFormat::None),
+    uint16 = static_cast<uint32_t>(rhi::MicromapIndexFormat::Uint16),
+    uint32 = static_cast<uint32_t>(rhi::MicromapIndexFormat::Uint32),
+};
+SGL_ENUM_INFO(
+    MicromapIndexFormat,
+    {
+        {MicromapIndexFormat::none, "none"},
+        {MicromapIndexFormat::uint16, "uint16"},
+        {MicromapIndexFormat::uint32, "uint32"},
+    }
+);
+SGL_ENUM_REGISTER(MicromapIndexFormat);
+
+enum class MicromapBuildFlags : uint32_t {
+    none = static_cast<uint32_t>(rhi::MicromapBuildFlags::None),
+    prefer_fast_trace = static_cast<uint32_t>(rhi::MicromapBuildFlags::PreferFastTrace),
+    prefer_fast_build = static_cast<uint32_t>(rhi::MicromapBuildFlags::PreferFastBuild),
+    allow_compaction = static_cast<uint32_t>(rhi::MicromapBuildFlags::AllowCompaction),
+};
+SGL_ENUM_CLASS_OPERATORS(MicromapBuildFlags);
+SGL_ENUM_FLAGS_INFO(
+    MicromapBuildFlags,
+    {
+        {MicromapBuildFlags::none, "none"},
+        {MicromapBuildFlags::prefer_fast_trace, "prefer_fast_trace"},
+        {MicromapBuildFlags::prefer_fast_build, "prefer_fast_build"},
+        {MicromapBuildFlags::allow_compaction, "allow_compaction"},
+    }
+);
+SGL_ENUM_REGISTER(MicromapBuildFlags);
+
+struct MicromapBuildDesc {
+    MicromapType type{MicromapType::opacity};
+    MicromapBuildFlags flags{MicromapBuildFlags::none};
+    BufferOffsetPair data_buffer;
+    BufferOffsetPair descriptor_buffer;
+    uint32_t descriptor_stride{sizeof(MicromapTriangleDesc)};
+    std::vector<MicromapUsageCount> histogram;
+};
+
+struct MicromapBuildDescConverter {
+    rhi::MicromapBuildDesc rhi_desc;
+    std::vector<rhi::MicromapUsageCount> rhi_histogram;
+    MicromapBuildDescConverter(const MicromapBuildDesc& desc);
+};
+
+struct MicromapSizes {
+    DeviceSize micromap_size{0};
+    DeviceSize scratch_size{0};
+};
+
+struct MicromapDesc {
+    MicromapType type{MicromapType::opacity};
+    DeviceSize size{0};
+    MicromapBuildFlags flags{MicromapBuildFlags::none};
+    std::string label;
+};
+
+class SGL_API Micromap : public Resource {
+    SGL_OBJECT(Micromap)
+public:
+    Micromap(ref<Device> device, MicromapDesc desc);
+    ~Micromap();
+
+    virtual void _release_rhi_resources() override { m_rhi_micromap.setNull(); }
+
+    const MicromapDesc& desc() const { return m_desc; }
+    DeviceAddress device_address() const { return m_rhi_micromap->getDeviceAddress(); }
+
+    rhi::IMicromap* rhi_micromap() const { return m_rhi_micromap; }
+    virtual rhi::IResource* rhi_resource() const override { return m_rhi_micromap; }
+
+    std::string to_string() const override;
+
+private:
+    MicromapDesc m_desc;
+    Slang::ComPtr<rhi::IMicromap> m_rhi_micromap;
+};
+
+struct AccelerationStructureOpacityMicromapDesc {
+    ref<Micromap> micromap;
+    MicromapIndexingMode indexing_mode{MicromapIndexingMode::linear};
+    BufferOffsetPair index_buffer;
+    MicromapIndexFormat index_format{MicromapIndexFormat::none};
+    uint32_t index_stride{0};
+    uint32_t base_micromap_index{0};
+    std::vector<MicromapUsageCount> usage_counts;
+};
 
 struct AccelerationStructureBuildInputInstances {
     BufferOffsetPair instance_buffer;
@@ -98,6 +257,9 @@ struct AccelerationStructureBuildInputTriangles {
     BufferOffsetPair pre_transform_buffer;
 
     AccelerationStructureGeometryFlags flags{AccelerationStructureGeometryFlags::none};
+
+    /// Optional opacity micromap attachment.
+    std::optional<AccelerationStructureOpacityMicromapDesc> opacity_micromap;
 };
 
 struct AccelerationStructureBuildInputProceduralPrimitives {
@@ -209,6 +371,10 @@ enum class AccelerationStructureBuildFlags : uint32_t {
     prefer_fast_trace = static_cast<uint32_t>(rhi::AccelerationStructureBuildFlags::PreferFastTrace),
     prefer_fast_build = static_cast<uint32_t>(rhi::AccelerationStructureBuildFlags::PreferFastBuild),
     minimize_memory = static_cast<uint32_t>(rhi::AccelerationStructureBuildFlags::MinimizeMemory),
+    allow_opacity_micromap_update
+    = static_cast<uint32_t>(rhi::AccelerationStructureBuildFlags::AllowOpacityMicromapUpdate),
+    allow_disable_opacity_micromaps
+    = static_cast<uint32_t>(rhi::AccelerationStructureBuildFlags::AllowDisableOpacityMicromaps),
 };
 
 SGL_ENUM_CLASS_OPERATORS(AccelerationStructureBuildFlags);
@@ -221,6 +387,8 @@ SGL_ENUM_FLAGS_INFO(
         {AccelerationStructureBuildFlags::prefer_fast_trace, "prefer_fast_trace"},
         {AccelerationStructureBuildFlags::prefer_fast_build, "prefer_fast_build"},
         {AccelerationStructureBuildFlags::minimize_memory, "minimize_memory"},
+        {AccelerationStructureBuildFlags::allow_opacity_micromap_update, "allow_opacity_micromap_update"},
+        {AccelerationStructureBuildFlags::allow_disable_opacity_micromaps, "allow_disable_opacity_micromaps"},
     }
 );
 SGL_ENUM_REGISTER(AccelerationStructureBuildFlags);
@@ -239,6 +407,8 @@ struct AccelerationStructureBuildDescConverter {
     rhi::AccelerationStructureBuildDesc rhi_desc;
     // TODO(slang-rhi) probably use short_vector instead, but short_vector needs some more work
     std::vector<rhi::AccelerationStructureBuildInput> rhi_build_inputs;
+    std::vector<rhi::AccelerationStructureOpacityMicromapDesc> rhi_opacity_micromap_descs;
+    std::vector<std::vector<rhi::MicromapUsageCount>> rhi_opacity_micromap_usage_counts;
     AccelerationStructureBuildDescConverter(const AccelerationStructureBuildDesc& desc);
 };
 
@@ -296,13 +466,20 @@ public:
     AccelerationStructure(ref<Device> device, AccelerationStructureDesc desc);
     ~AccelerationStructure();
 
-    virtual void _release_rhi_resources() override { m_rhi_acceleration_structure.setNull(); }
+    virtual void _release_rhi_resources() override
+    {
+        m_rhi_acceleration_structure.setNull();
+        m_micromap_dependencies.clear();
+    }
 
     const AccelerationStructureDesc& desc() const { return m_desc; }
 
     AccelerationStructureHandle handle() const;
 
     rhi::IAccelerationStructure* rhi_acceleration_structure() const { return m_rhi_acceleration_structure; }
+
+    void set_micromap_dependencies(const AccelerationStructureBuildDesc& desc);
+    void copy_micromap_dependencies(const AccelerationStructure& src);
 
     /// Bind a nullable acceleration structure value to a shader cursor.
     static void write_to_cursor(const ShaderCursor& cursor, const AccelerationStructure* value);
@@ -312,6 +489,7 @@ public:
 private:
     AccelerationStructureDesc m_desc;
     Slang::ComPtr<rhi::IAccelerationStructure> m_rhi_acceleration_structure;
+    std::vector<ref<Micromap>> m_micromap_dependencies;
 };
 
 class SGL_API AccelerationStructureInstanceList : public DeviceChild {

--- a/src/sgl/device/raytracing.h
+++ b/src/sgl/device/raytracing.h
@@ -117,13 +117,6 @@ SGL_ENUM_INFO(
 );
 SGL_ENUM_REGISTER(OpacityMicromapSpecialIndex);
 
-struct MicromapTriangleDesc {
-    uint32_t data_offset{0};
-    uint16_t subdivision_level{0};
-    OpacityMicromapFormat format{OpacityMicromapFormat::two_state};
-};
-static_assert(sizeof(MicromapTriangleDesc) == sizeof(rhi::MicromapTriangleDesc));
-
 struct MicromapUsageCount {
     uint32_t count{0};
     uint32_t subdivision_level{0};
@@ -181,7 +174,7 @@ struct MicromapBuildDesc {
     MicromapBuildFlags flags{MicromapBuildFlags::none};
     BufferOffsetPair data_buffer;
     BufferOffsetPair descriptor_buffer;
-    uint32_t descriptor_stride{sizeof(MicromapTriangleDesc)};
+    uint32_t descriptor_stride{sizeof(rhi::MicromapTriangleDesc)};
     std::vector<MicromapUsageCount> histogram;
 };
 

--- a/src/sgl/device/resource.h
+++ b/src/sgl/device/resource.h
@@ -45,6 +45,9 @@ enum class ResourceState : uint32_t {
     acceleration_structure_read = static_cast<uint32_t>(rhi::ResourceState::AccelerationStructureRead),
     acceleration_structure_write = static_cast<uint32_t>(rhi::ResourceState::AccelerationStructureWrite),
     acceleration_structure_build_output = static_cast<uint32_t>(rhi::ResourceState::AccelerationStructureBuildInput),
+    micromap_build_input = static_cast<uint32_t>(rhi::ResourceState::MicromapBuildInput),
+    micromap_read = static_cast<uint32_t>(rhi::ResourceState::MicromapRead),
+    micromap_write = static_cast<uint32_t>(rhi::ResourceState::MicromapWrite),
 };
 
 SGL_ENUM_INFO(
@@ -70,6 +73,9 @@ SGL_ENUM_INFO(
         {ResourceState::acceleration_structure_read, "acceleration_structure_read"},
         {ResourceState::acceleration_structure_write, "acceleration_structure_write"},
         {ResourceState::acceleration_structure_build_output, "acceleration_structure_build_output"},
+        {ResourceState::micromap_build_input, "micromap_build_input"},
+        {ResourceState::micromap_read, "micromap_read"},
+        {ResourceState::micromap_write, "micromap_write"},
     }
 );
 SGL_ENUM_REGISTER(ResourceState);
@@ -86,6 +92,8 @@ enum class BufferUsage : uint32_t {
     copy_destination = static_cast<uint32_t>(rhi::BufferUsage::CopyDestination),
     acceleration_structure = static_cast<uint32_t>(rhi::BufferUsage::AccelerationStructure),
     acceleration_structure_build_input = static_cast<uint32_t>(rhi::BufferUsage::AccelerationStructureBuildInput),
+    micromap_build_input = static_cast<uint32_t>(rhi::BufferUsage::MicromapBuildInput),
+    micromap_storage = static_cast<uint32_t>(rhi::BufferUsage::MicromapStorage),
     shader_table = static_cast<uint32_t>(rhi::BufferUsage::ShaderTable),
     shared = static_cast<uint32_t>(rhi::BufferUsage::Shared),
 };
@@ -105,6 +113,8 @@ SGL_ENUM_FLAGS_INFO(
         {BufferUsage::copy_destination, "copy_destination"},
         {BufferUsage::acceleration_structure, "acceleration_structure"},
         {BufferUsage::acceleration_structure_build_input, "acceleration_structure_build_input"},
+        {BufferUsage::micromap_build_input, "micromap_build_input"},
+        {BufferUsage::micromap_storage, "micromap_storage"},
         {BufferUsage::shader_table, "shader_table"},
         {BufferUsage::shared, "shared"},
     }

--- a/src/sgl/device/types.h
+++ b/src/sgl/device/types.h
@@ -71,6 +71,7 @@ enum class Feature : uint32_t {
     shader_execution_reordering = static_cast<uint32_t>(rhi::Feature::ShaderExecutionReordering),
     ray_tracing_motion_blur = static_cast<uint32_t>(rhi::Feature::RayTracingMotionBlur),
     ray_tracing_validation = static_cast<uint32_t>(rhi::Feature::RayTracingValidation),
+    opacity_micromap = static_cast<uint32_t>(rhi::Feature::OpacityMicromap),
     cluster_acceleration_structure = static_cast<uint32_t>(rhi::Feature::ClusterAccelerationStructure),
     // Other features
     timestamp_query = static_cast<uint32_t>(rhi::Feature::TimestampQuery),
@@ -152,6 +153,7 @@ SGL_ENUM_INFO(
         {Feature::shader_execution_reordering, "shader_execution_reordering"},
         {Feature::ray_tracing_motion_blur, "ray_tracing_motion_blur"},
         {Feature::ray_tracing_validation, "ray_tracing_validation"},
+        {Feature::opacity_micromap, "opacity_micromap"},
         {Feature::cluster_acceleration_structure, "cluster_acceleration_structure"},
         {Feature::timestamp_query, "timestamp_query"},
         {Feature::timestamp_calibration, "timestamp_calibration"},
@@ -862,6 +864,7 @@ enum class RayTracingPipelineFlags : uint8_t {
     skip_procedurals = static_cast<uint8_t>(rhi::RayTracingPipelineFlags::SkipProcedurals),
     enable_spheres = static_cast<uint8_t>(rhi::RayTracingPipelineFlags::EnableSpheres),
     enable_linear_swept_spheres = static_cast<uint8_t>(rhi::RayTracingPipelineFlags::EnableLinearSweptSpheres),
+    enable_opacity_micromaps = static_cast<uint8_t>(rhi::RayTracingPipelineFlags::EnableOpacityMicromaps),
 };
 
 SGL_ENUM_CLASS_OPERATORS(RayTracingPipelineFlags);
@@ -873,6 +876,7 @@ SGL_ENUM_FLAGS_INFO(
         {RayTracingPipelineFlags::skip_procedurals, "skip_procedurals"},
         {RayTracingPipelineFlags::enable_spheres, "enable_spheres"},
         {RayTracingPipelineFlags::enable_linear_swept_spheres, "enable_linear_swept_spheres"},
+        {RayTracingPipelineFlags::enable_opacity_micromaps, "enable_opacity_micromaps"},
     }
 );
 SGL_ENUM_REGISTER(RayTracingPipelineFlags);

--- a/src/slangpy_ext/device/command.cpp
+++ b/src/slangpy_ext/device/command.cpp
@@ -490,6 +490,14 @@ SGL_PY_EXPORT(device_command)
             D(CommandEncoder, build_acceleration_structure)
         )
         .def(
+            "build_micromap",
+            &CommandEncoder::build_micromap,
+            "desc"_a,
+            "dst"_a,
+            "scratch_buffer"_a,
+            D(CommandEncoder, build_micromap)
+        )
+        .def(
             "copy_acceleration_structure",
             &CommandEncoder::copy_acceleration_structure,
             "dst"_a,

--- a/src/slangpy_ext/device/device.cpp
+++ b/src/slangpy_ext/device/device.cpp
@@ -955,6 +955,25 @@ SGL_PY_EXPORT(device_device)
         "size"_a,
         D(Device, create_acceleration_structure_instance_list)
     );
+    device.def("get_micromap_sizes", &Device::get_micromap_sizes, "desc"_a, D(Device, get_micromap_sizes));
+    device.def(
+        "create_micromap",
+        [](Device* self, MicromapType type, size_t size, MicromapBuildFlags flags, std::string label)
+        {
+            return self->create_micromap({
+                .type = type,
+                .size = size,
+                .flags = flags,
+                .label = std::move(label),
+            });
+        },
+        "type"_a = MicromapDesc().type,
+        "size"_a = MicromapDesc().size,
+        "flags"_a = MicromapDesc().flags,
+        "label"_a = MicromapDesc().label,
+        D(Device, create_micromap)
+    );
+    device.def("create_micromap", &Device::create_micromap, "desc"_a, D(Device, create_micromap));
     device.def(
         "create_shader_table",
         [](Device* self,
@@ -1571,6 +1590,25 @@ SGL_PY_EXPORT(device_device)
         "size"_a,
         D(create_acceleration_structure_instance_list)
     );
+    m.def("get_micromap_sizes", &get_micromap_sizes, "desc"_a, D(get_micromap_sizes));
+    m.def(
+        "create_micromap",
+        [](MicromapType type, size_t size, MicromapBuildFlags flags, std::string label)
+        {
+            return create_micromap({
+                .type = type,
+                .size = size,
+                .flags = flags,
+                .label = std::move(label),
+            });
+        },
+        "type"_a = MicromapDesc().type,
+        "size"_a = MicromapDesc().size,
+        "flags"_a = MicromapDesc().flags,
+        "label"_a = MicromapDesc().label,
+        D(create_micromap)
+    );
+    m.def("create_micromap", nb::overload_cast<MicromapDesc>(&create_micromap), "desc"_a, D(create_micromap));
     m.def(
         "create_shader_table",
         [](ref<ShaderProgram> program,

--- a/src/slangpy_ext/device/raytracing.cpp
+++ b/src/slangpy_ext/device/raytracing.cpp
@@ -23,6 +23,44 @@ SGL_DICT_TO_DESC_FIELD(instance_stride, uint32_t)
 SGL_DICT_TO_DESC_FIELD(instance_count, uint32_t)
 SGL_DICT_TO_DESC_END()
 
+SGL_DICT_TO_DESC_BEGIN(MicromapTriangleDesc)
+SGL_DICT_TO_DESC_FIELD(data_offset, uint32_t)
+SGL_DICT_TO_DESC_FIELD(subdivision_level, uint16_t)
+SGL_DICT_TO_DESC_FIELD(format, OpacityMicromapFormat)
+SGL_DICT_TO_DESC_END()
+
+SGL_DICT_TO_DESC_BEGIN(MicromapUsageCount)
+SGL_DICT_TO_DESC_FIELD(count, uint32_t)
+SGL_DICT_TO_DESC_FIELD(subdivision_level, uint32_t)
+SGL_DICT_TO_DESC_FIELD(format, OpacityMicromapFormat)
+SGL_DICT_TO_DESC_END()
+
+SGL_DICT_TO_DESC_BEGIN(MicromapBuildDesc)
+SGL_DICT_TO_DESC_FIELD(type, MicromapType)
+SGL_DICT_TO_DESC_FIELD(flags, MicromapBuildFlags)
+SGL_DICT_TO_DESC_FIELD(data_buffer, BufferOffsetPair)
+SGL_DICT_TO_DESC_FIELD(descriptor_buffer, BufferOffsetPair)
+SGL_DICT_TO_DESC_FIELD(descriptor_stride, uint32_t)
+SGL_DICT_TO_DESC_FIELD_LIST(histogram, MicromapUsageCount)
+SGL_DICT_TO_DESC_END()
+
+SGL_DICT_TO_DESC_BEGIN(MicromapDesc)
+SGL_DICT_TO_DESC_FIELD(type, MicromapType)
+SGL_DICT_TO_DESC_FIELD(size, DeviceSize)
+SGL_DICT_TO_DESC_FIELD(flags, MicromapBuildFlags)
+SGL_DICT_TO_DESC_FIELD(label, std::string)
+SGL_DICT_TO_DESC_END()
+
+SGL_DICT_TO_DESC_BEGIN(AccelerationStructureOpacityMicromapDesc)
+SGL_DICT_TO_DESC_FIELD(micromap, ref<Micromap>)
+SGL_DICT_TO_DESC_FIELD(indexing_mode, MicromapIndexingMode)
+SGL_DICT_TO_DESC_FIELD(index_buffer, BufferOffsetPair)
+SGL_DICT_TO_DESC_FIELD(index_format, MicromapIndexFormat)
+SGL_DICT_TO_DESC_FIELD(index_stride, uint32_t)
+SGL_DICT_TO_DESC_FIELD(base_micromap_index, uint32_t)
+SGL_DICT_TO_DESC_FIELD_LIST(usage_counts, MicromapUsageCount)
+SGL_DICT_TO_DESC_END()
+
 SGL_DICT_TO_DESC_BEGIN(AccelerationStructureBuildInputTriangles)
 SGL_DICT_TO_DESC_FIELD_LIST(vertex_buffers, BufferOffsetPair)
 SGL_DICT_TO_DESC_FIELD(vertex_format, Format)
@@ -33,6 +71,7 @@ SGL_DICT_TO_DESC_FIELD(index_format, IndexFormat)
 SGL_DICT_TO_DESC_FIELD(index_count, uint32_t)
 SGL_DICT_TO_DESC_FIELD(pre_transform_buffer, BufferOffsetPair)
 SGL_DICT_TO_DESC_FIELD(flags, AccelerationStructureGeometryFlags)
+SGL_DICT_TO_DESC_FIELD(opacity_micromap, std::optional<AccelerationStructureOpacityMicromapDesc>)
 SGL_DICT_TO_DESC_END()
 
 SGL_DICT_TO_DESC_BEGIN(AccelerationStructureBuildInputProceduralPrimitives)
@@ -117,6 +156,144 @@ SGL_PY_EXPORT(device_raytracing)
 
     nb::sgl_enum_flags<AccelerationStructureGeometryFlags>(m, "AccelerationStructureGeometryFlags");
     nb::sgl_enum_flags<AccelerationStructureInstanceFlags>(m, "AccelerationStructureInstanceFlags");
+
+    nb::sgl_enum<MicromapType>(m, "MicromapType");
+    nb::sgl_enum<OpacityMicromapFormat>(m, "OpacityMicromapFormat");
+    nb::sgl_enum<OpacityMicromapSpecialIndex>(m, "OpacityMicromapSpecialIndex");
+    nb::sgl_enum<MicromapIndexingMode>(m, "MicromapIndexingMode");
+    nb::sgl_enum<MicromapIndexFormat>(m, "MicromapIndexFormat");
+    nb::sgl_enum_flags<MicromapBuildFlags>(m, "MicromapBuildFlags");
+
+    nb::class_<MicromapTriangleDesc>(m, "MicromapTriangleDesc", D(MicromapTriangleDesc))
+        .def(nb::init<>())
+        .def(
+            "__init__",
+            [](MicromapTriangleDesc* self, nb::dict dict)
+            {
+                new (self) MicromapTriangleDesc(dict_to_MicromapTriangleDesc(dict));
+            }
+        )
+        .def_rw("data_offset", &MicromapTriangleDesc::data_offset, D(MicromapTriangleDesc, data_offset))
+        .def_rw(
+            "subdivision_level",
+            &MicromapTriangleDesc::subdivision_level,
+            D(MicromapTriangleDesc, subdivision_level)
+        )
+        .def_rw("format", &MicromapTriangleDesc::format, D(MicromapTriangleDesc, format))
+        .def(
+            "to_numpy",
+            [](MicromapTriangleDesc& self)
+            {
+                size_t shape[1] = {sizeof(MicromapTriangleDesc)};
+                return nb::ndarray<nb::numpy, const uint8_t>(&self, 1, shape, nb::handle());
+            }
+        );
+    nb::implicitly_convertible<nb::dict, MicromapTriangleDesc>();
+
+    nb::class_<MicromapUsageCount>(m, "MicromapUsageCount", D(MicromapUsageCount))
+        .def(nb::init<>())
+        .def(
+            "__init__",
+            [](MicromapUsageCount* self, nb::dict dict)
+            {
+                new (self) MicromapUsageCount(dict_to_MicromapUsageCount(dict));
+            }
+        )
+        .def_rw("count", &MicromapUsageCount::count, D(MicromapUsageCount, count))
+        .def_rw("subdivision_level", &MicromapUsageCount::subdivision_level, D(MicromapUsageCount, subdivision_level))
+        .def_rw("format", &MicromapUsageCount::format, D(MicromapUsageCount, format));
+    nb::implicitly_convertible<nb::dict, MicromapUsageCount>();
+
+    nb::class_<MicromapBuildDesc>(m, "MicromapBuildDesc", D(MicromapBuildDesc))
+        .def(nb::init<>())
+        .def(
+            "__init__",
+            [](MicromapBuildDesc* self, nb::dict dict)
+            {
+                new (self) MicromapBuildDesc(dict_to_MicromapBuildDesc(dict));
+            }
+        )
+        .def_rw("type", &MicromapBuildDesc::type, D(MicromapBuildDesc, type))
+        .def_rw("flags", &MicromapBuildDesc::flags, D(MicromapBuildDesc, flags))
+        .def_rw("data_buffer", &MicromapBuildDesc::data_buffer, D(MicromapBuildDesc, data_buffer))
+        .def_rw("descriptor_buffer", &MicromapBuildDesc::descriptor_buffer, D(MicromapBuildDesc, descriptor_buffer))
+        .def_rw("descriptor_stride", &MicromapBuildDesc::descriptor_stride, D(MicromapBuildDesc, descriptor_stride))
+        .def_rw("histogram", &MicromapBuildDesc::histogram, D(MicromapBuildDesc, histogram));
+    nb::implicitly_convertible<nb::dict, MicromapBuildDesc>();
+
+    nb::class_<MicromapSizes>(m, "MicromapSizes", D(MicromapSizes))
+        .def_ro("micromap_size", &MicromapSizes::micromap_size, D(MicromapSizes, micromap_size))
+        .def_ro("scratch_size", &MicromapSizes::scratch_size, D(MicromapSizes, scratch_size));
+
+    nb::class_<MicromapDesc>(m, "MicromapDesc", D(MicromapDesc))
+        .def(nb::init<>())
+        .def(
+            "__init__",
+            [](MicromapDesc* self, nb::dict dict)
+            {
+                new (self) MicromapDesc(dict_to_MicromapDesc(dict));
+            }
+        )
+        .def_rw("type", &MicromapDesc::type, D(MicromapDesc, type))
+        .def_rw("size", &MicromapDesc::size, D(MicromapDesc, size))
+        .def_rw("flags", &MicromapDesc::flags, D(MicromapDesc, flags))
+        .def_rw("label", &MicromapDesc::label, D(MicromapDesc, label));
+    nb::implicitly_convertible<nb::dict, MicromapDesc>();
+
+    nb::class_<Micromap, Resource>(m, "Micromap", D(Micromap))
+        .def_prop_ro("desc", &Micromap::desc, D(Micromap, desc))
+        .def_prop_ro("device_address", &Micromap::device_address, D(Micromap, device_address));
+
+    nb::class_<AccelerationStructureOpacityMicromapDesc>(
+        m,
+        "AccelerationStructureOpacityMicromapDesc",
+        D(AccelerationStructureOpacityMicromapDesc)
+    )
+        .def(nb::init<>())
+        .def(
+            "__init__",
+            [](AccelerationStructureOpacityMicromapDesc* self, nb::dict dict)
+            {
+                new (self)
+                    AccelerationStructureOpacityMicromapDesc(dict_to_AccelerationStructureOpacityMicromapDesc(dict));
+            }
+        )
+        .def_rw(
+            "micromap",
+            &AccelerationStructureOpacityMicromapDesc::micromap,
+            D(AccelerationStructureOpacityMicromapDesc, micromap)
+        )
+        .def_rw(
+            "indexing_mode",
+            &AccelerationStructureOpacityMicromapDesc::indexing_mode,
+            D(AccelerationStructureOpacityMicromapDesc, indexing_mode)
+        )
+        .def_rw(
+            "index_buffer",
+            &AccelerationStructureOpacityMicromapDesc::index_buffer,
+            D(AccelerationStructureOpacityMicromapDesc, index_buffer)
+        )
+        .def_rw(
+            "index_format",
+            &AccelerationStructureOpacityMicromapDesc::index_format,
+            D(AccelerationStructureOpacityMicromapDesc, index_format)
+        )
+        .def_rw(
+            "index_stride",
+            &AccelerationStructureOpacityMicromapDesc::index_stride,
+            D(AccelerationStructureOpacityMicromapDesc, index_stride)
+        )
+        .def_rw(
+            "base_micromap_index",
+            &AccelerationStructureOpacityMicromapDesc::base_micromap_index,
+            D(AccelerationStructureOpacityMicromapDesc, base_micromap_index)
+        )
+        .def_rw(
+            "usage_counts",
+            &AccelerationStructureOpacityMicromapDesc::usage_counts,
+            D(AccelerationStructureOpacityMicromapDesc, usage_counts)
+        );
+    nb::implicitly_convertible<nb::dict, AccelerationStructureOpacityMicromapDesc>();
 
     nb::class_<AccelerationStructureInstanceDesc>(
         m,
@@ -240,7 +417,13 @@ SGL_PY_EXPORT(device_raytracing)
         .def_rw("index_format", &AccelerationStructureBuildInputTriangles::index_format)
         .def_rw("index_count", &AccelerationStructureBuildInputTriangles::index_count)
         .def_rw("pre_transform_buffer", &AccelerationStructureBuildInputTriangles::pre_transform_buffer)
-        .def_rw("flags", &AccelerationStructureBuildInputTriangles::flags);
+        .def_rw("flags", &AccelerationStructureBuildInputTriangles::flags)
+        .def_rw(
+            "opacity_micromap",
+            &AccelerationStructureBuildInputTriangles::opacity_micromap,
+            nb::arg().none(),
+            D(AccelerationStructureBuildInputTriangles, opacity_micromap)
+        );
     nb::implicitly_convertible<nb::dict, AccelerationStructureBuildInputTriangles>();
 
     nb::class_<AccelerationStructureBuildInputProceduralPrimitives>(

--- a/src/slangpy_ext/device/raytracing.cpp
+++ b/src/slangpy_ext/device/raytracing.cpp
@@ -23,12 +23,6 @@ SGL_DICT_TO_DESC_FIELD(instance_stride, uint32_t)
 SGL_DICT_TO_DESC_FIELD(instance_count, uint32_t)
 SGL_DICT_TO_DESC_END()
 
-SGL_DICT_TO_DESC_BEGIN(MicromapTriangleDesc)
-SGL_DICT_TO_DESC_FIELD(data_offset, uint32_t)
-SGL_DICT_TO_DESC_FIELD(subdivision_level, uint16_t)
-SGL_DICT_TO_DESC_FIELD(format, OpacityMicromapFormat)
-SGL_DICT_TO_DESC_END()
-
 SGL_DICT_TO_DESC_BEGIN(MicromapUsageCount)
 SGL_DICT_TO_DESC_FIELD(count, uint32_t)
 SGL_DICT_TO_DESC_FIELD(subdivision_level, uint32_t)
@@ -163,32 +157,6 @@ SGL_PY_EXPORT(device_raytracing)
     nb::sgl_enum<MicromapIndexingMode>(m, "MicromapIndexingMode");
     nb::sgl_enum<MicromapIndexFormat>(m, "MicromapIndexFormat");
     nb::sgl_enum_flags<MicromapBuildFlags>(m, "MicromapBuildFlags");
-
-    nb::class_<MicromapTriangleDesc>(m, "MicromapTriangleDesc", D(MicromapTriangleDesc))
-        .def(nb::init<>())
-        .def(
-            "__init__",
-            [](MicromapTriangleDesc* self, nb::dict dict)
-            {
-                new (self) MicromapTriangleDesc(dict_to_MicromapTriangleDesc(dict));
-            }
-        )
-        .def_rw("data_offset", &MicromapTriangleDesc::data_offset, D(MicromapTriangleDesc, data_offset))
-        .def_rw(
-            "subdivision_level",
-            &MicromapTriangleDesc::subdivision_level,
-            D(MicromapTriangleDesc, subdivision_level)
-        )
-        .def_rw("format", &MicromapTriangleDesc::format, D(MicromapTriangleDesc, format))
-        .def(
-            "to_numpy",
-            [](MicromapTriangleDesc& self)
-            {
-                size_t shape[1] = {sizeof(MicromapTriangleDesc)};
-                return nb::ndarray<nb::numpy, const uint8_t>(&self, 1, shape, nb::handle());
-            }
-        );
-    nb::implicitly_convertible<nb::dict, MicromapTriangleDesc>();
 
     nb::class_<MicromapUsageCount>(m, "MicromapUsageCount", D(MicromapUsageCount))
         .def(nb::init<>())

--- a/src/slangpy_ext/py_doc.h
+++ b/src/slangpy_ext/py_doc.h
@@ -82,6 +82,10 @@ static const char *__doc_sgl_AccelerationStructureBuildDescConverter_rhi_build_i
 
 static const char *__doc_sgl_AccelerationStructureBuildDescConverter_rhi_desc = R"doc()doc";
 
+static const char *__doc_sgl_AccelerationStructureBuildDescConverter_rhi_opacity_micromap_descs = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureBuildDescConverter_rhi_opacity_micromap_usage_counts = R"doc()doc";
+
 static const char *__doc_sgl_AccelerationStructureBuildDesc_flags = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructureBuildDesc_inputs = R"doc(List of build inputs. All inputs must be of the same type.)doc";
@@ -93,6 +97,10 @@ static const char *__doc_sgl_AccelerationStructureBuildDesc_motion_options = R"d
 static const char *__doc_sgl_AccelerationStructureBuildFlags = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructureBuildFlags_allow_compaction = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureBuildFlags_allow_disable_opacity_micromaps = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureBuildFlags_allow_opacity_micromap_update = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructureBuildFlags_allow_update = R"doc()doc";
 
@@ -196,6 +204,8 @@ static const char *__doc_sgl_AccelerationStructureBuildInputTriangles_index_coun
 
 static const char *__doc_sgl_AccelerationStructureBuildInputTriangles_index_format = R"doc()doc";
 
+static const char *__doc_sgl_AccelerationStructureBuildInputTriangles_opacity_micromap = R"doc(Optional opacity micromap attachment.)doc";
+
 static const char *__doc_sgl_AccelerationStructureBuildInputTriangles_pre_transform_buffer =
 R"doc(Optional buffer containing 3x4 transform matrix applied to each
 vertex.)doc";
@@ -260,6 +270,10 @@ static const char *__doc_sgl_AccelerationStructureInstanceDesc_transform = R"doc
 
 static const char *__doc_sgl_AccelerationStructureInstanceFlags = R"doc()doc";
 
+static const char *__doc_sgl_AccelerationStructureInstanceFlags_disable_opacity_micromaps = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureInstanceFlags_force_opacity_micromap_2_state = R"doc()doc";
+
 static const char *__doc_sgl_AccelerationStructureInstanceFlags_force_opaque = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructureInstanceFlags_info = R"doc()doc";
@@ -318,6 +332,22 @@ static const char *__doc_sgl_AccelerationStructureKind_top_level = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructureKind_unknown = R"doc()doc";
 
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc_base_micromap_index = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc_index_buffer = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc_index_format = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc_index_stride = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc_indexing_mode = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc_micromap = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructureOpacityMicromapDesc_usage_counts = R"doc()doc";
+
 static const char *__doc_sgl_AccelerationStructureQueryDesc = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructureQueryDesc_first_query_index = R"doc()doc";
@@ -338,17 +368,23 @@ static const char *__doc_sgl_AccelerationStructure_AccelerationStructure = R"doc
 
 static const char *__doc_sgl_AccelerationStructure_class_name = R"doc()doc";
 
+static const char *__doc_sgl_AccelerationStructure_copy_micromap_dependencies = R"doc()doc";
+
 static const char *__doc_sgl_AccelerationStructure_desc = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructure_handle = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructure_m_desc = R"doc()doc";
 
+static const char *__doc_sgl_AccelerationStructure_m_micromap_dependencies = R"doc()doc";
+
 static const char *__doc_sgl_AccelerationStructure_m_rhi_acceleration_structure = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructure_release_rhi_resources = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructure_rhi_acceleration_structure = R"doc()doc";
+
+static const char *__doc_sgl_AccelerationStructure_set_micromap_dependencies = R"doc()doc";
 
 static const char *__doc_sgl_AccelerationStructure_to_string = R"doc()doc";
 
@@ -510,6 +546,134 @@ static const char *__doc_sgl_Attribute_name = R"doc()doc";
 
 static const char *__doc_sgl_Attribute_to_string = R"doc()doc";
 
+static const char *__doc_sgl_BCCompressedImage = R"doc()doc";
+
+static const char *__doc_sgl_BCCompressedImage_format = R"doc()doc";
+
+static const char *__doc_sgl_BCCompressedImage_mip_levels = R"doc()doc";
+
+static const char *__doc_sgl_BCCompressedMip = R"doc()doc";
+
+static const char *__doc_sgl_BCCompressedMip_data = R"doc()doc";
+
+static const char *__doc_sgl_BCCompressedMip_height = R"doc()doc";
+
+static const char *__doc_sgl_BCCompressedMip_width = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeOptions = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeOptions_channel_weights = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeOptions_generate_mipmaps = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeOptions_has_alpha = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeOptions_mip_filter = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeOptions_quality = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeQuality = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeQuality_fastest = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeQuality_highest = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeQuality_normal = R"doc()doc";
+
+static const char *__doc_sgl_BCEncodeQuality_production = R"doc()doc";
+
+static const char *__doc_sgl_BCEncoder = R"doc(BC1-7 block compression encoder.)doc";
+
+static const char *__doc_sgl_BCEncoderBackend = R"doc(Encoding backend used by BCEncoder.)doc";
+
+static const char *__doc_sgl_BCEncoderBackend_automatic = R"doc(Prefer the NVTT GPU encoder, then NVTT CPU, then the software encoder.)doc";
+
+static const char *__doc_sgl_BCEncoderBackend_nvtt_cpu = R"doc(Require the optional NVTT encoder and run it on the CPU.)doc";
+
+static const char *__doc_sgl_BCEncoderBackend_nvtt_gpu = R"doc(Require the optional NVTT encoder and CUDA support.)doc";
+
+static const char *__doc_sgl_BCEncoderBackend_software = R"doc(Use the built-in rgbcx/bc7enc software encoder.)doc";
+
+static const char *__doc_sgl_BCEncoderImpl = R"doc()doc";
+
+static const char *__doc_sgl_BCEncoder_BCEncoder = R"doc()doc";
+
+static const char *__doc_sgl_BCEncoder_BCEncoder_2 = R"doc()doc";
+
+static const char *__doc_sgl_BCEncoder_backend = R"doc(The resolved backend used by this encoder.)doc";
+
+static const char *__doc_sgl_BCEncoder_can_encode = R"doc(True if the selected backend can encode the given format.)doc";
+
+static const char *__doc_sgl_BCEncoder_encode =
+R"doc(Encode an image to a BC format. If options.generate_mipmaps is true
+the full mip chain is generated from the source image.)doc";
+
+static const char *__doc_sgl_BCEncoder_is_backend_available = R"doc(True if the given backend is available in this build.)doc";
+
+static const char *__doc_sgl_BCEncoder_m_backend = R"doc()doc";
+
+static const char *__doc_sgl_BCEncoder_m_impl = R"doc()doc";
+
+static const char *__doc_sgl_BCEncoder_operator_assign = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc1_unorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc1_unorm_srgb = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc2_unorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc2_unorm_srgb = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc3_unorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc3_unorm_srgb = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc4_snorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc4_unorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc5_snorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc5_unorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc6h_sfloat = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc6h_ufloat = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc7_unorm = R"doc()doc";
+
+static const char *__doc_sgl_BCFormat_bc7_unorm_srgb = R"doc()doc";
+
+static const char *__doc_sgl_BCImage = R"doc(Non-owning immutable view into CPU pixel data.)doc";
+
+static const char *__doc_sgl_BCImage_channel_count = R"doc(< 1-4.)doc";
+
+static const char *__doc_sgl_BCImage_component_type = R"doc()doc";
+
+static const char *__doc_sgl_BCImage_data = R"doc()doc";
+
+static const char *__doc_sgl_BCImage_height = R"doc()doc";
+
+static const char *__doc_sgl_BCImage_row_pitch = R"doc(< Bytes per row (allows stride).)doc";
+
+static const char *__doc_sgl_BCImage_width = R"doc()doc";
+
+static const char *__doc_sgl_BCMutableImage = R"doc(Non-owning mutable view into CPU pixel data.)doc";
+
+static const char *__doc_sgl_BCMutableImage_channel_count = R"doc()doc";
+
+static const char *__doc_sgl_BCMutableImage_component_type = R"doc()doc";
+
+static const char *__doc_sgl_BCMutableImage_data = R"doc()doc";
+
+static const char *__doc_sgl_BCMutableImage_height = R"doc()doc";
+
+static const char *__doc_sgl_BCMutableImage_row_pitch = R"doc()doc";
+
+static const char *__doc_sgl_BCMutableImage_width = R"doc()doc";
+
 static const char *__doc_sgl_BaseReflectionIndexedList =
 R"doc(Base class for read-only lazy evaluation list of search results. To
 use it, the search function (e.g. children_of_kind) fills out the
@@ -623,6 +787,8 @@ static const char *__doc_sgl_Bitmap_FileFormat_auto = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_FileFormat_bmp = R"doc()doc";
 
+static const char *__doc_sgl_Bitmap_FileFormat_dds = R"doc()doc";
+
 static const char *__doc_sgl_Bitmap_FileFormat_exr = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_FileFormat_hdr = R"doc()doc";
@@ -654,6 +820,8 @@ static const char *__doc_sgl_Bitmap_PixelFormat_rgba = R"doc(RGB + alpha.)doc";
 static const char *__doc_sgl_Bitmap_PixelFormat_y = R"doc(Luminance only.)doc";
 
 static const char *__doc_sgl_Bitmap_PixelFormat_ya = R"doc(Luminance + alpha.)doc";
+
+static const char *__doc_sgl_Bitmap_allocate_data = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_buffer_size = R"doc(The total size of the bitmap in bytes.)doc";
 
@@ -697,7 +865,7 @@ static const char *__doc_sgl_Bitmap_m_data = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_m_height = R"doc()doc";
 
-static const char *__doc_sgl_Bitmap_m_owns_data = R"doc()doc";
+static const char *__doc_sgl_Bitmap_m_owned_data = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_m_pixel_format = R"doc()doc";
 
@@ -720,6 +888,8 @@ static const char *__doc_sgl_Bitmap_pixel_struct = R"doc(DataStruct describing t
 static const char *__doc_sgl_Bitmap_read = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_read_bmp = R"doc()doc";
+
+static const char *__doc_sgl_Bitmap_read_dds = R"doc()doc";
 
 static const char *__doc_sgl_Bitmap_read_exr = R"doc()doc";
 
@@ -1303,6 +1473,10 @@ static const char *__doc_sgl_BufferUsage_indirect_argument = R"doc()doc";
 
 static const char *__doc_sgl_BufferUsage_info = R"doc()doc";
 
+static const char *__doc_sgl_BufferUsage_micromap_build_input = R"doc()doc";
+
+static const char *__doc_sgl_BufferUsage_micromap_storage = R"doc()doc";
+
 static const char *__doc_sgl_BufferUsage_none = R"doc()doc";
 
 static const char *__doc_sgl_BufferUsage_shader_resource = R"doc()doc";
@@ -1616,6 +1790,8 @@ Parameter ``filter``:
     Filtering mode to use.)doc";
 
 static const char *__doc_sgl_CommandEncoder_build_acceleration_structure = R"doc()doc";
+
+static const char *__doc_sgl_CommandEncoder_build_micromap = R"doc()doc";
 
 static const char *__doc_sgl_CommandEncoder_class_name = R"doc()doc";
 
@@ -2256,6 +2432,8 @@ static const char *__doc_sgl_DDSFile_detect_dds_file = R"doc()doc";
 
 static const char *__doc_sgl_DDSFile_dxgi_format = R"doc()doc";
 
+static const char *__doc_sgl_DDSFile_get_required_resource_size = R"doc()doc";
+
 static const char *__doc_sgl_DDSFile_get_subresource_data =
 R"doc(Get a pointer to the start of the data for the specified mip and
 slice.
@@ -2268,6 +2446,8 @@ Parameter ``slice``:
 
 Returns:
     Pointer to the start of the data.)doc";
+
+static const char *__doc_sgl_DDSFile_get_subresource_offset = R"doc()doc";
 
 static const char *__doc_sgl_DDSFile_get_subresource_pitch = R"doc()doc";
 
@@ -2296,8 +2476,6 @@ static const char *__doc_sgl_DDSFile_m_height = R"doc()doc";
 static const char *__doc_sgl_DDSFile_m_mip_count = R"doc()doc";
 
 static const char *__doc_sgl_DDSFile_m_row_pitch = R"doc()doc";
-
-static const char *__doc_sgl_DDSFile_m_size = R"doc()doc";
 
 static const char *__doc_sgl_DDSFile_m_slice_pitch = R"doc()doc";
 
@@ -2330,6 +2508,10 @@ static const char *__doc_sgl_DDSFile_to_string = R"doc()doc";
 static const char *__doc_sgl_DDSFile_type = R"doc()doc";
 
 static const char *__doc_sgl_DDSFile_width = R"doc()doc";
+
+static const char *__doc_sgl_DDSFile_write_dds = R"doc(Write a DDS file to a stream.)doc";
+
+static const char *__doc_sgl_DDSFile_write_dds_2 = R"doc(Write a DDS file to a file path.)doc";
 
 static const char *__doc_sgl_DataStruct =
 R"doc(Structured data definition.
@@ -3155,6 +3337,8 @@ Parameter ``vertex_streams``:
 Returns:
     New input layout object.)doc";
 
+static const char *__doc_sgl_Device_create_micromap = R"doc(Create a new micromap.)doc";
+
 static const char *__doc_sgl_Device_create_query_pool =
 R"doc(Create a new query pool.
 
@@ -3352,6 +3536,8 @@ static const char *__doc_sgl_Device_get_coop_vec_matrix_size = R"doc(Get the siz
 static const char *__doc_sgl_Device_get_created_devices = R"doc(Lists all created devices)doc";
 
 static const char *__doc_sgl_Device_get_format_support = R"doc(Returns the supported resource states for a given format.)doc";
+
+static const char *__doc_sgl_Device_get_micromap_sizes = R"doc(Query the device for buffer sizes required for a micromap build.)doc";
 
 static const char *__doc_sgl_Device_get_native_command_queue_handle =
 R"doc(Returns the native API handle for the command queue: - D3D12:
@@ -3856,6 +4042,8 @@ static const char *__doc_sgl_Feature_int64 = R"doc()doc";
 static const char *__doc_sgl_Feature_mesh_shader = R"doc()doc";
 
 static const char *__doc_sgl_Feature_multi_view = R"doc()doc";
+
+static const char *__doc_sgl_Feature_opacity_micromap = R"doc()doc";
 
 static const char *__doc_sgl_Feature_parameter_block = R"doc()doc";
 
@@ -5548,7 +5736,18 @@ static const char *__doc_sgl_Logger_m_name = R"doc()doc";
 
 static const char *__doc_sgl_Logger_m_outputs = R"doc()doc";
 
+static const char *__doc_sgl_Logger_mutate_outputs =
+R"doc(Applies a copy-on-write mutation without copying or destroying output
+references while locked. The mutator returns true if the copied set
+changed and may be called again after a publication race.)doc";
+
 static const char *__doc_sgl_Logger_name = R"doc(The name of the logger.)doc";
+
+static const char *__doc_sgl_Logger_output_snapshot = R"doc(Returns the current immutable output set.)doc";
+
+static const char *__doc_sgl_Logger_publish_outputs =
+R"doc(Publishes an immutable output set and retires the previous set after
+unlocking.)doc";
 
 static const char *__doc_sgl_Logger_remove_all_outputs = R"doc(Remove all logger outputs.)doc";
 
@@ -5561,6 +5760,8 @@ Parameter ``output``:
 static const char *__doc_sgl_Logger_set_level = R"doc()doc";
 
 static const char *__doc_sgl_Logger_set_name = R"doc()doc";
+
+static const char *__doc_sgl_Logger_should_log = R"doc(Returns true if a message at the given level should be logged.)doc";
 
 static const char *__doc_sgl_Logger_static_init = R"doc()doc";
 
@@ -5758,9 +5959,129 @@ static const char *__doc_sgl_MemoryType_read_back = R"doc()doc";
 
 static const char *__doc_sgl_MemoryType_upload = R"doc()doc";
 
+static const char *__doc_sgl_Micromap = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_2 = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDesc = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDescConverter = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDescConverter_MicromapBuildDescConverter = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDescConverter_rhi_desc = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDescConverter_rhi_histogram = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDesc_data_buffer = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDesc_descriptor_buffer = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDesc_descriptor_stride = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDesc_flags = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDesc_histogram = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildDesc_type = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildFlags = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildFlags_allow_compaction = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildFlags_info = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildFlags_none = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildFlags_prefer_fast_build = R"doc()doc";
+
+static const char *__doc_sgl_MicromapBuildFlags_prefer_fast_trace = R"doc()doc";
+
+static const char *__doc_sgl_MicromapDesc = R"doc()doc";
+
+static const char *__doc_sgl_MicromapDesc_2 = R"doc()doc";
+
+static const char *__doc_sgl_MicromapDesc_flags = R"doc()doc";
+
+static const char *__doc_sgl_MicromapDesc_label = R"doc()doc";
+
+static const char *__doc_sgl_MicromapDesc_size = R"doc()doc";
+
+static const char *__doc_sgl_MicromapDesc_type = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexFormat = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexFormat_info = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexFormat_none = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexFormat_uint16 = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexFormat_uint32 = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexingMode = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexingMode_indexed = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexingMode_info = R"doc()doc";
+
+static const char *__doc_sgl_MicromapIndexingMode_linear = R"doc()doc";
+
+static const char *__doc_sgl_MicromapSizes = R"doc()doc";
+
+static const char *__doc_sgl_MicromapSizes_micromap_size = R"doc()doc";
+
+static const char *__doc_sgl_MicromapSizes_scratch_size = R"doc()doc";
+
+static const char *__doc_sgl_MicromapTriangleDesc = R"doc()doc";
+
+static const char *__doc_sgl_MicromapTriangleDesc_data_offset = R"doc()doc";
+
+static const char *__doc_sgl_MicromapTriangleDesc_format = R"doc()doc";
+
+static const char *__doc_sgl_MicromapTriangleDesc_subdivision_level = R"doc()doc";
+
+static const char *__doc_sgl_MicromapType = R"doc()doc";
+
+static const char *__doc_sgl_MicromapType_info = R"doc()doc";
+
+static const char *__doc_sgl_MicromapType_opacity = R"doc()doc";
+
+static const char *__doc_sgl_MicromapUsageCount = R"doc()doc";
+
+static const char *__doc_sgl_MicromapUsageCount_count = R"doc()doc";
+
+static const char *__doc_sgl_MicromapUsageCount_format = R"doc()doc";
+
+static const char *__doc_sgl_MicromapUsageCount_subdivision_level = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_Micromap = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_class_name = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_desc = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_device_address = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_m_desc = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_m_rhi_micromap = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_release_rhi_resources = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_rhi_micromap = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_rhi_resource = R"doc()doc";
+
+static const char *__doc_sgl_Micromap_to_string = R"doc()doc";
+
 static const char *__doc_sgl_MitchellFilter = R"doc()doc";
 
 static const char *__doc_sgl_MitchellFilter_MitchellFilter = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter_b = R"doc()doc";
+
+static const char *__doc_sgl_MitchellFilter_c = R"doc()doc";
 
 static const char *__doc_sgl_MitchellFilter_eval = R"doc()doc";
 
@@ -5910,6 +6231,8 @@ static const char *__doc_sgl_NativeHandleTrait_22 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_23 = R"doc()doc";
 
+static const char *__doc_sgl_NativeHandleTrait_24 = R"doc()doc";
+
 static const char *__doc_sgl_NativeHandleTrait_pack = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_pack_2 = R"doc()doc";
@@ -5952,6 +6275,8 @@ static const char *__doc_sgl_NativeHandleTrait_pack_20 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_pack_21 = R"doc()doc";
 
+static const char *__doc_sgl_NativeHandleTrait_pack_22 = R"doc()doc";
+
 static const char *__doc_sgl_NativeHandleTrait_unpack = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_unpack_2 = R"doc()doc";
@@ -5993,6 +6318,8 @@ static const char *__doc_sgl_NativeHandleTrait_unpack_19 = R"doc()doc";
 static const char *__doc_sgl_NativeHandleTrait_unpack_20 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleTrait_unpack_21 = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleTrait_unpack_22 = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleType = R"doc()doc";
 
@@ -6061,6 +6388,8 @@ static const char *__doc_sgl_NativeHandleType_VkImage = R"doc()doc";
 static const char *__doc_sgl_NativeHandleType_VkImageView = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleType_VkInstance = R"doc()doc";
+
+static const char *__doc_sgl_NativeHandleType_VkMicromapEXT = R"doc()doc";
 
 static const char *__doc_sgl_NativeHandleType_VkPhysicalDevice = R"doc()doc";
 
@@ -6209,6 +6538,26 @@ static const char *__doc_sgl_Object_set_self_py = R"doc(Set the Python object as
 static const char *__doc_sgl_Object_to_string =
 R"doc(Return a string representation of this object. This is used for
 debugging purposes.)doc";
+
+static const char *__doc_sgl_OpacityMicromapFormat = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapFormat_four_state = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapFormat_info = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapFormat_two_state = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapSpecialIndex = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapSpecialIndex_fully_opaque = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapSpecialIndex_fully_transparent = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapSpecialIndex_fully_unknown_opaque = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapSpecialIndex_fully_unknown_transparent = R"doc()doc";
+
+static const char *__doc_sgl_OpacityMicromapSpecialIndex_info = R"doc()doc";
 
 static const char *__doc_sgl_OwnedSubresourceData = R"doc()doc";
 
@@ -7042,8 +7391,11 @@ seals it after all attached zones publish.)doc";
 static const char *__doc_sgl_Profiler_end_zone = R"doc(End a zone previously returned by begin_zone().)doc";
 
 static const char *__doc_sgl_Profiler_flush =
-R"doc(Block until the collector consumes events published before this call
-and publishes both snapshot products.)doc";
+R"doc(Block until a collector pass started for this request consumes inputs
+whose publication happens-before the request and publishes both
+snapshot products. Concurrent publications may be included or
+deferred. Active zones, unsealed frames, and unresolved GPU queries
+are not published inputs and are not awaited.)doc";
 
 static const char *__doc_sgl_Profiler_frame_stats_snapshot =
 R"doc(Return the most recently published immutable frame statistics and
@@ -7342,6 +7694,8 @@ static const char *__doc_sgl_RayTracingPipelineDesc_program = R"doc()doc";
 static const char *__doc_sgl_RayTracingPipelineFlags = R"doc()doc";
 
 static const char *__doc_sgl_RayTracingPipelineFlags_enable_linear_swept_spheres = R"doc()doc";
+
+static const char *__doc_sgl_RayTracingPipelineFlags_enable_opacity_micromaps = R"doc()doc";
 
 static const char *__doc_sgl_RayTracingPipelineFlags_enable_spheres = R"doc()doc";
 
@@ -7669,6 +8023,12 @@ static const char *__doc_sgl_ResourceState_index_buffer = R"doc()doc";
 static const char *__doc_sgl_ResourceState_indirect_argument = R"doc()doc";
 
 static const char *__doc_sgl_ResourceState_info = R"doc()doc";
+
+static const char *__doc_sgl_ResourceState_micromap_build_input = R"doc()doc";
+
+static const char *__doc_sgl_ResourceState_micromap_read = R"doc()doc";
+
+static const char *__doc_sgl_ResourceState_micromap_write = R"doc()doc";
 
 static const char *__doc_sgl_ResourceState_present = R"doc()doc";
 
@@ -9899,6 +10259,8 @@ static const char *__doc_sgl_Window_handle_keyboard_event = R"doc()doc";
 
 static const char *__doc_sgl_Window_handle_mouse_event = R"doc()doc";
 
+static const char *__doc_sgl_Window_handle_window_refresh = R"doc()doc";
+
 static const char *__doc_sgl_Window_handle_window_size = R"doc()doc";
 
 static const char *__doc_sgl_Window_height = R"doc(The height of the window in pixels.)doc";
@@ -9929,9 +10291,9 @@ static const char *__doc_sgl_Window_m_on_keyboard_event = R"doc()doc";
 
 static const char *__doc_sgl_Window_m_on_mouse_event = R"doc()doc";
 
-static const char *__doc_sgl_Window_m_on_resize = R"doc()doc";
-
 static const char *__doc_sgl_Window_m_on_refresh = R"doc()doc";
+
+static const char *__doc_sgl_Window_m_on_resize = R"doc()doc";
 
 static const char *__doc_sgl_Window_m_should_close = R"doc()doc";
 
@@ -9951,9 +10313,11 @@ static const char *__doc_sgl_Window_on_keyboard_event = R"doc(Event handler to b
 
 static const char *__doc_sgl_Window_on_mouse_event = R"doc(Event handler to be called when a mouse event occurs.)doc";
 
-static const char *__doc_sgl_Window_on_resize = R"doc(Event handler to be called when the window is resized.)doc";
+static const char *__doc_sgl_Window_on_refresh =
+R"doc(Event handler to be called when the window contents need to be
+refreshed.)doc";
 
-static const char *__doc_sgl_Window_on_refresh = R"doc(Event handler to be called when the window contents need to be refreshed.)doc";
+static const char *__doc_sgl_Window_on_resize = R"doc(Event handler to be called when the window is resized.)doc";
 
 static const char *__doc_sgl_Window_poll_gamepad_input = R"doc()doc";
 
@@ -9990,6 +10354,8 @@ static const char *__doc_sgl_Window_set_on_keyboard_event = R"doc()doc";
 
 static const char *__doc_sgl_Window_set_on_mouse_event = R"doc()doc";
 
+static const char *__doc_sgl_Window_set_on_refresh = R"doc()doc";
+
 static const char *__doc_sgl_Window_set_on_resize = R"doc()doc";
 
 static const char *__doc_sgl_Window_set_position = R"doc()doc";
@@ -10023,6 +10389,28 @@ static const char *__doc_sgl_YAHandling_info = R"doc()doc";
 static const char *__doc_sgl_YAHandling_preserve_as_rg = R"doc()doc";
 
 static const char *__doc_sgl_align_to = R"doc(Align an integer value to the given alignment.)doc";
+
+static const char *__doc_sgl_bc_block_count = R"doc(Number of 4-pixel blocks needed for one image dimension.)doc";
+
+static const char *__doc_sgl_bc_compressed_image_from_dds =
+R"doc(Extract a BCCompressedImage from a DDS file. The DDS file must contain
+a BC-compressed 2D texture with array_size == 1 and depth == 1.)doc";
+
+static const char *__doc_sgl_bc_compressed_image_to_dds = R"doc(Write a BCCompressedImage as a DDS file to a stream.)doc";
+
+static const char *__doc_sgl_bc_compressed_image_to_dds_2 = R"doc(Write a BCCompressedImage as a DDS file to a file path.)doc";
+
+static const char *__doc_sgl_bc_compressed_size =
+R"doc(Total compressed size in bytes for one mip level (ceiling division for
+non-multiple-of-4).)doc";
+
+static const char *__doc_sgl_bc_format_bytes_per_block = R"doc(Bytes per 4x4 compressed block.)doc";
+
+static const char *__doc_sgl_bc_format_to_format = R"doc(Convert BCFormat to RHI Format.)doc";
+
+static const char *__doc_sgl_bc_image_from_bitmap = R"doc(Create a BCImage from a Bitmap.)doc";
+
+static const char *__doc_sgl_bc_mip_count = R"doc(Full mip chain level count: floor(log2(max(w,h))) + 1.)doc";
 
 static const char *__doc_sgl_breakable_ref = R"doc()doc";
 
@@ -10069,7 +10457,7 @@ static const char *__doc_sgl_breakable_ref_operator_bool = R"doc()doc";
 
 static const char *__doc_sgl_breakable_ref_operator_mul = R"doc()doc";
 
-static const char *__doc_sgl_breakable_ref_operator_ref = R"doc()doc";
+static const char *__doc_sgl_breakable_ref_operator_sgl_ref = R"doc()doc";
 
 static const char *__doc_sgl_breakable_ref_operator_sub = R"doc()doc";
 
@@ -10182,6 +10570,8 @@ Parameter ``vertex_streams``:
 
 Returns:
     New input layout object.)doc";
+
+static const char *__doc_sgl_create_micromap = R"doc(Create a new micromap on the current device.)doc";
 
 static const char *__doc_sgl_create_query_pool =
 R"doc(Create a new query pool.
@@ -10548,6 +10938,8 @@ static const char *__doc_sgl_cursor_utils_write_to_cursor = R"doc()doc";
 
 static const char *__doc_sgl_data_type_size = R"doc(Get the size of a type in bytes.)doc";
 
+static const char *__doc_sgl_decode_bc = R"doc(Decode a single BC-compressed mip level into the destination image.)doc";
+
 static const char *__doc_sgl_detail_CursorWriterOwner = R"doc()doc";
 
 static const char *__doc_sgl_detail_HostTypeToFormat = R"doc()doc";
@@ -10854,6 +11246,18 @@ static const char *__doc_sgl_find_enum_info_adl_84 = R"doc()doc";
 
 static const char *__doc_sgl_find_enum_info_adl_85 = R"doc()doc";
 
+static const char *__doc_sgl_find_enum_info_adl_86 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_87 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_88 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_89 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_90 = R"doc()doc";
+
+static const char *__doc_sgl_find_enum_info_adl_91 = R"doc()doc";
+
 static const char *__doc_sgl_flags_to_string_list = R"doc(Convert an flags enum value to a list of strings.)doc";
 
 static const char *__doc_sgl_flip_bit = R"doc()doc";
@@ -10881,6 +11285,10 @@ static const char *__doc_sgl_flip_bit_11 = R"doc()doc";
 static const char *__doc_sgl_flip_bit_12 = R"doc()doc";
 
 static const char *__doc_sgl_flip_bit_13 = R"doc()doc";
+
+static const char *__doc_sgl_flip_bit_14 = R"doc()doc";
+
+static const char *__doc_sgl_format_to_bc_format = R"doc(Convert RHI Format to BCFormat (returns nullopt if not a BC format).)doc";
 
 static const char *__doc_sgl_func_BaseModule = R"doc(Base class for functional slangpy module.)doc";
 
@@ -11100,6 +11508,10 @@ static const char *__doc_sgl_get_format_2 = R"doc(Convert from Vulkan to sgl for
 
 static const char *__doc_sgl_get_format_info = R"doc()doc";
 
+static const char *__doc_sgl_get_micromap_sizes =
+R"doc(Query the current device for buffer sizes required for a micromap
+build.)doc";
+
 static const char *__doc_sgl_get_shader_model_major_version = R"doc()doc";
 
 static const char *__doc_sgl_get_shader_model_minor_version = R"doc()doc";
@@ -11111,6 +11523,21 @@ static const char *__doc_sgl_hash = R"doc()doc";
 static const char *__doc_sgl_hash_2 = R"doc()doc";
 
 static const char *__doc_sgl_hash_3 = R"doc()doc";
+
+static const char *__doc_sgl_hash_append =
+R"doc(Appends one or more values to an existing hash.
+
+Parameter ``seed``:
+    Existing hash value.
+
+Parameter ``t1``:
+    First value to append.
+
+Parameter ``rest``:
+    Additional values to append.
+
+Returns:
+    Hash containing the seed followed by the supplied values.)doc";
 
 static const char *__doc_sgl_hash_combine = R"doc()doc";
 
@@ -11151,6 +11578,8 @@ static const char *__doc_sgl_is_set_11 = R"doc()doc";
 static const char *__doc_sgl_is_set_12 = R"doc()doc";
 
 static const char *__doc_sgl_is_set_13 = R"doc()doc";
+
+static const char *__doc_sgl_is_set_14 = R"doc()doc";
 
 static const char *__doc_sgl_layout_from_rhilayout = R"doc()doc";
 
@@ -12262,6 +12691,8 @@ static const char *__doc_sgl_operator_band_12 = R"doc()doc";
 
 static const char *__doc_sgl_operator_band_13 = R"doc()doc";
 
+static const char *__doc_sgl_operator_band_14 = R"doc()doc";
+
 static const char *__doc_sgl_operator_bnot = R"doc()doc";
 
 static const char *__doc_sgl_operator_bnot_2 = R"doc()doc";
@@ -12287,6 +12718,8 @@ static const char *__doc_sgl_operator_bnot_11 = R"doc()doc";
 static const char *__doc_sgl_operator_bnot_12 = R"doc()doc";
 
 static const char *__doc_sgl_operator_bnot_13 = R"doc()doc";
+
+static const char *__doc_sgl_operator_bnot_14 = R"doc()doc";
 
 static const char *__doc_sgl_operator_bor = R"doc()doc";
 
@@ -12314,6 +12747,8 @@ static const char *__doc_sgl_operator_bor_12 = R"doc()doc";
 
 static const char *__doc_sgl_operator_bor_13 = R"doc()doc";
 
+static const char *__doc_sgl_operator_bor_14 = R"doc()doc";
+
 static const char *__doc_sgl_operator_iand = R"doc()doc";
 
 static const char *__doc_sgl_operator_iand_2 = R"doc()doc";
@@ -12340,6 +12775,8 @@ static const char *__doc_sgl_operator_iand_12 = R"doc()doc";
 
 static const char *__doc_sgl_operator_iand_13 = R"doc()doc";
 
+static const char *__doc_sgl_operator_iand_14 = R"doc()doc";
+
 static const char *__doc_sgl_operator_ior = R"doc()doc";
 
 static const char *__doc_sgl_operator_ior_2 = R"doc()doc";
@@ -12365,6 +12802,8 @@ static const char *__doc_sgl_operator_ior_11 = R"doc()doc";
 static const char *__doc_sgl_operator_ior_12 = R"doc()doc";
 
 static const char *__doc_sgl_operator_ior_13 = R"doc()doc";
+
+static const char *__doc_sgl_operator_ior_14 = R"doc()doc";
 
 static const char *__doc_sgl_platform_FileDialogFilter = R"doc()doc";
 
@@ -12689,6 +13128,8 @@ static const char *__doc_sgl_refl_Function_Function = R"doc(Create a function fr
 
 static const char *__doc_sgl_refl_Function_class_name = R"doc()doc";
 
+static const char *__doc_sgl_refl_Function_clear_caches = R"doc(Clear lazily derived reflection objects.)doc";
+
 static const char *__doc_sgl_refl_Function_differentiable = R"doc(Return true if this function has the differentiable modifier.)doc";
 
 static const char *__doc_sgl_refl_Function_full_name = R"doc(Return the reflected function spelling used when generating calls.)doc";
@@ -12814,6 +13255,10 @@ R"doc(Return the reflection array type for an element type and element
 count.)doc";
 
 static const char *__doc_sgl_refl_Layout_class_name = R"doc()doc";
+
+static const char *__doc_sgl_refl_Layout_clear_caches =
+R"doc(Clear cached reflection objects and break their internal reference
+cycles.)doc";
 
 static const char *__doc_sgl_refl_Layout_difftensorview_type = R"doc(Return the reflection DiffTensorView type for an element type.)doc";
 
@@ -13112,6 +13557,8 @@ R"doc(Build fields for this type. Override in types that expose field-like
 members.)doc";
 
 static const char *__doc_sgl_refl_Type_class_name = R"doc()doc";
+
+static const char *__doc_sgl_refl_Type_clear_caches = R"doc(Clear lazily derived reflection objects.)doc";
 
 static const char *__doc_sgl_refl_Type_derivative = R"doc(Return the derivative type, if one exists.)doc";
 

--- a/tools/postprocess_stub.py
+++ b/tools/postprocess_stub.py
@@ -41,7 +41,6 @@ DESCRIPTOR_CONVERT_TYPES = {
     "MultisampleDesc": True,
     "MicromapBuildDesc": True,
     "MicromapDesc": True,
-    "MicromapTriangleDesc": True,
     "MicromapUsageCount": True,
     "QueryPoolDesc": True,
     "RasterizerDesc": True,

--- a/tools/postprocess_stub.py
+++ b/tools/postprocess_stub.py
@@ -20,6 +20,7 @@ DESCRIPTOR_CONVERT_TYPES = {
     "AccelerationStructureBuildInputTriangles": True,
     "AccelerationStructureDesc": True,
     "AccelerationStructureInstanceDesc": True,
+    "AccelerationStructureOpacityMicromapDesc": True,
     "AccelerationStructureQueryDesc": True,
     "AppDesc": True,
     "AppWindowDesc": True,
@@ -38,6 +39,10 @@ DESCRIPTOR_CONVERT_TYPES = {
     "InputElementDesc": True,
     "InputLayoutDesc": True,
     "MultisampleDesc": True,
+    "MicromapBuildDesc": True,
+    "MicromapDesc": True,
+    "MicromapTriangleDesc": True,
+    "MicromapUsageCount": True,
     "QueryPoolDesc": True,
     "RasterizerDesc": True,
     "RayTracingPipelineDesc": True,
@@ -147,11 +152,11 @@ class FindConvertableToDictionaryTypes(cst.CSTVisitor):
             # Not an init function but we're in a valid descriptor class, so
             # so we want to record any setter types.
             if self._is_setter(node):
-                self.stack[-1].fields.append(
-                    FCDFieldInfo(
-                        node.name, node.params.posonly_params[1].annotation.annotation  # type: ignore (bad libcst typing info)
+                params = (*node.params.posonly_params, *node.params.params)
+                if len(params) >= 2 and params[1].annotation is not None:
+                    self.stack[-1].fields.append(
+                        FCDFieldInfo(node.name, params[1].annotation.annotation)
                     )
-                )
 
     def _annotation_name_equals(self, annotation: Optional[cst.Annotation], name: str):
         if annotation is not None:


### PR DESCRIPTION
## Summary

- Add opacity micromap resources, descriptors, size queries, and build commands to the C++ and Python APIs.
- Allow opacity micromaps to be attached to triangle inputs when building acceleration structures.
- Add the associated feature checks, formats, indexing modes, build flags, resource states, buffer usages, instance flags, pipeline flags, and Vulkan native handle type.
- Preserve micromap dependencies across acceleration-structure builds and copies so their lifetimes remain valid.
- Update `slang-rhi` for the underlying opacity micromap support.
- Update generated bindings and stub post-processing for the new descriptor types.

## Testing

- Add an end-to-end ray-tracing test that builds a two-state opacity micromap, attaches it to a BLAS, and verifies opaque and transparent ray results.
- Parameterize the test across the default device types and skip devices without `Feature.opacity_micromap`.