### PR TITLE
Allow Slang CI to cherry-pick a SlangPy PR for coordinated breaking changes

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -110,7 +110,12 @@ jobs:
           SLANGPY_PR: ${{ github.event.client_payload.slangpy_cherry_pick_pr }}
         run: |
           set -euo pipefail
-          pr="${SLANGPY_PR//[[:space:]]/}"
+          # Trim leading and trailing whitespace only. Whitespace *inside* the value
+          # has to survive so that a malformed "12 34" fails the digit check below
+          # instead of collapsing into 1234 and cherry-picking a different PR.
+          pr="$SLANGPY_PR"
+          pr="${pr#"${pr%%[![:space:]]*}"}"
+          pr="${pr%"${pr##*[![:space:]]}"}"
           # An empty value means "nothing to cherry-pick", not an error. Slang CI sends
           # this field empty whenever no cherry-pick is active, and older Slang CI does
           # not send it at all, so both must behave exactly like an ordinary run.
@@ -136,7 +141,10 @@ jobs:
           if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
             git fetch --unshallow origin
           fi
-          git fetch origin "pull/${SLANGPY_PR}/head:slangpy-pr-under-test"
+          # --force because these jobs run on reused self-hosted workspaces, where a
+          # slangpy-pr-under-test ref left behind by an earlier run will not
+          # fast-forward to a different PR and would fail the fetch.
+          git fetch --force origin "pull/${SLANGPY_PR}/head:slangpy-pr-under-test"
           git merge --no-edit slangpy-pr-under-test
           echo "::notice::Merged SlangPy PR #${SLANGPY_PR} into main for this run"
 

--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -96,6 +96,50 @@ jobs:
           submodules: recursive
           lfs: true
 
+      # A Slang change that breaks SlangPy is a chicken-and-egg problem: neither side
+      # compiles against the other until both have landed. Slang CI names the matching
+      # SlangPy PR in the dispatch payload, and we merge it in here so both halves are
+      # tested together. See SLANGPY_CHERRY_PICK_PR in ci-slangpy-trigger-test.yml in
+      # shader-slang/slang.
+      #
+      # This only affects the checkout for this run; nothing is pushed.
+      - name: Cherry-pick SlangPy PR
+        if: github.event.client_payload.slangpy_cherry_pick_pr
+        shell: bash
+        env:
+          SLANGPY_PR: ${{ github.event.client_payload.slangpy_cherry_pick_pr }}
+        run: |
+          set -euo pipefail
+          pr="${SLANGPY_PR//[[:space:]]/}"
+          # An empty value means "nothing to cherry-pick", not an error. Slang CI sends
+          # this field empty whenever no cherry-pick is active, and older Slang CI does
+          # not send it at all, so both must behave exactly like an ordinary run.
+          if [ -z "$pr" ]; then
+            echo "No SlangPy PR to cherry-pick; building this branch as-is"
+            exit 0
+          fi
+          # A non-empty value crosses a repository boundary, so validate it here rather
+          # than trusting the sender.
+          case "$pr" in
+            *[!0-9]*)
+              echo "Invalid SlangPy PR number to cherry-pick: '$SLANGPY_PR'" >&2
+              exit 1
+              ;;
+          esac
+          SLANGPY_PR="$pr"
+          git config user.name "slangpy-ci"
+          git config user.email "slangpy-ci@users.noreply.github.com"
+          # actions/checkout leaves a depth-1 clone by default, which has no ancestry
+          # for the merge to find a merge base in; without this the merge below fails
+          # with "refusing to merge unrelated histories". Deepening only here keeps the
+          # ordinary, non-cherry-picked runs on the cheap shallow checkout.
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --unshallow origin
+          fi
+          git fetch origin "pull/${SLANGPY_PR}/head:slangpy-pr-under-test"
+          git merge --no-edit slangpy-pr-under-test
+          echo "::notice::Merged SlangPy PR #${SLANGPY_PR} into main for this run"
+
       - uses: ./.github/actions/build-and-test-with-slang
         with:
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
       - "**.md"
       - .github/workflows/wheels.yml
       - .github/workflows/ci-gcp.yml
-      - .github/workflows/ci-latest-slang.yml
   pull_request:
     branches: [main]
     paths-ignore:
@@ -20,7 +19,6 @@ on:
       - "**.md"
       - .github/workflows/wheels.yml
       - .github/workflows/ci-gcp.yml
-      - .github/workflows/ci-latest-slang.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR adds a feature to cherry-pick a slangpy PR for slangpy CI test.
This is required to break the cyclic dependency between slang and slangpy regarding the CI runs.

With this feature, we will make a backward-compatibility breaking changes on slang repo first.
If the slang change requires a change in slangpy repo, we will temporarily cherry-pick a PR for slangpy when we run the slangpy CI on slang repo.
Once the required change in slangpy repo is merged, we will drop the cherry-pick remedy in slang repo.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] An empty `slangpy_cherry_pick_pr` payload value must be a no-op, not an error, so that Slang PRs dispatched with no cherry-pick active (and by older Slang CI that does not send the field at all) behave exactly as before. Do not tighten the step's `if:` guard to `!= null` in a way that turns empty into a validation failure.
- [human @jkwak-work] Use "cherry-pick" rather than "pin" in the naming for this mechanism (step name, `SLANGPY_CHERRY_PICK_PR`, payload field `slangpy_cherry_pick_pr`).
