### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Upload pre-commit version
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pre-commit-version
         path: pre-commit-version.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0077 NEW)
+if(POLICY CMP0177)
+    cmake_policy(SET CMP0177 NEW)
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(utils)

--- a/slangpy/tests/core/test_data_struct.py
+++ b/slangpy/tests/core/test_data_struct.py
@@ -133,7 +133,7 @@ def test_convert_passthrough(param: TSupportedType):
     check_conversion(ss, "@" + param[0] * len(values), "@" + param[0] * len(values), values)
 
 
-@pytest.mark.parametrize("param", itertools.product(supported_types, repeat=2))
+@pytest.mark.parametrize("param", list(itertools.product(supported_types, repeat=2)))
 def test_convert_types(param: tuple[TSupportedType, TSupportedType]):
     p1, p2 = param
     values = list(range(10))

--- a/src/sgl/ui/imguisw.slang
+++ b/src/sgl/ui/imguisw.slang
@@ -16,9 +16,9 @@
 #endif
 
 /// Subpixel precision (number of subpixels per pixel).
-static constexpr int SUBPIXEL = 8;
+static const int SUBPIXEL = 8;
 /// Tile size.
-static constexpr uint TILE_SIZE = 16;
+static const uint TILE_SIZE = 16;
 /// Number of words (32 bits) in the tile bitmask. Each bit corresponds to a bucket of triangles.
 #define TILE_BITMASK_WORDS 4
 


### PR DESCRIPTION
## Summary

- Replace `static constexpr` with `static const` for Slang shader constants in `imguisw.slang`.
- Materialize the `itertools.product` parameter set to satisfy pytest’s `Collection` requirement.
- Enable CMake policy `CMP0177` when available, while retaining compatibility with CMake 3.20.