### PR TITLE
Make the cherry-pick step run on Windows as well as Linux

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -103,50 +103,64 @@ jobs:
       # shader-slang/slang.
       #
       # This only affects the checkout for this run; nothing is pushed.
+      # Runs through github-script rather than a `run:` block because the Windows
+      # runners in this matrix have no `bash`, and the logic is not worth maintaining
+      # twice in bash and PowerShell. `exec` invokes `git` straight from PATH -- that
+      # resolves on every runner in the matrix -- so no shell is involved at all.
+      #
+      # This needs no Node on the machine: the Actions runner bundles its own, which
+      # is what already runs actions/checkout (itself a node24 JavaScript action) in
+      # the step above. v8 is pinned because it targets that same node24.
       - name: Cherry-pick SlangPy PR
         if: github.event.client_payload.slangpy_cherry_pick_pr
-        shell: bash
+        uses: actions/github-script@v8
         env:
           SLANGPY_PR: ${{ github.event.client_payload.slangpy_cherry_pick_pr }}
-        run: |
-          set -euo pipefail
-          # Trim leading and trailing whitespace only. Whitespace *inside* the value
-          # has to survive so that a malformed "12 34" fails the digit check below
-          # instead of collapsing into 1234 and cherry-picking a different PR.
-          pr="$SLANGPY_PR"
-          pr="${pr#"${pr%%[![:space:]]*}"}"
-          pr="${pr%"${pr##*[![:space:]]}"}"
-          # An empty value means "nothing to cherry-pick", not an error. Slang CI sends
-          # this field empty whenever no cherry-pick is active, and older Slang CI does
-          # not send it at all, so both must behave exactly like an ordinary run.
-          if [ -z "$pr" ]; then
-            echo "No SlangPy PR to cherry-pick; building this branch as-is"
-            exit 0
-          fi
-          # A non-empty value crosses a repository boundary, so validate it here rather
-          # than trusting the sender.
-          case "$pr" in
-            *[!0-9]*)
-              echo "Invalid SlangPy PR number to cherry-pick: '$SLANGPY_PR'" >&2
-              exit 1
-              ;;
-          esac
-          SLANGPY_PR="$pr"
-          git config user.name "slangpy-ci"
-          git config user.email "slangpy-ci@users.noreply.github.com"
-          # actions/checkout leaves a depth-1 clone by default, which has no ancestry
-          # for the merge to find a merge base in; without this the merge below fails
-          # with "refusing to merge unrelated histories". Deepening only here keeps the
-          # ordinary, non-cherry-picked runs on the cheap shallow checkout.
-          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-            git fetch --unshallow origin
-          fi
-          # --force because these jobs run on reused self-hosted workspaces, where a
-          # slangpy-pr-under-test ref left behind by an earlier run will not
-          # fast-forward to a different PR and would fail the fetch.
-          git fetch --force origin "pull/${SLANGPY_PR}/head:slangpy-pr-under-test"
-          git merge --no-edit slangpy-pr-under-test
-          echo "::notice::Merged SlangPy PR #${SLANGPY_PR} into main for this run"
+        with:
+          script: |
+            const raw = process.env.SLANGPY_PR ?? '';
+            // Trim leading and trailing whitespace only. Whitespace *inside* the value
+            // has to survive so that a malformed "12 34" fails the digit check below
+            // instead of collapsing into 1234 and cherry-picking a different PR.
+            const pr = raw.trim();
+
+            // An empty value means "nothing to cherry-pick", not an error. Slang CI
+            // sends this field empty whenever no cherry-pick is active, and older
+            // Slang CI does not send it at all, so both must behave exactly like an
+            // ordinary run.
+            if (pr === '') {
+              core.info('No SlangPy PR to cherry-pick; building this branch as-is');
+              return;
+            }
+
+            // A non-empty value crosses a repository boundary, so validate it here
+            // rather than trusting the sender.
+            if (!/^[0-9]+$/.test(pr)) {
+              core.setFailed(`Invalid SlangPy PR number to cherry-pick: '${raw}'`);
+              return;
+            }
+
+            // exec.exec rejects on a non-zero exit, so any git failure below fails the
+            // step, as `set -e` did before.
+            await exec.exec('git', ['config', 'user.name', 'slangpy-ci']);
+            await exec.exec('git', ['config', 'user.email', 'slangpy-ci@users.noreply.github.com']);
+
+            // actions/checkout leaves a depth-1 clone by default, which has no ancestry
+            // for the merge to find a merge base in; without this the merge below fails
+            // with "refusing to merge unrelated histories". Deepening only here keeps
+            // the ordinary, non-cherry-picked runs on the cheap shallow checkout.
+            const shallow = await exec.getExecOutput('git', ['rev-parse', '--is-shallow-repository']);
+            if (shallow.stdout.trim() === 'true') {
+              await exec.exec('git', ['fetch', '--unshallow', 'origin']);
+            }
+
+            // --force because these jobs run on reused self-hosted workspaces, where a
+            // slangpy-pr-under-test ref left behind by an earlier run will not
+            // fast-forward to a different PR and would fail the fetch.
+            await exec.exec('git', ['fetch', '--force', 'origin', `pull/${pr}/head:slangpy-pr-under-test`]);
+            await exec.exec('git', ['merge', '--no-edit', 'slangpy-pr-under-test']);
+
+            core.notice(`Merged SlangPy PR #${pr} into main for this run`);
 
       - uses: ./.github/actions/build-and-test-with-slang
         with:


### PR DESCRIPTION
## Motivation

The `Cherry-pick SlangPy PR` step added in #1143 fails immediately on Windows:

```
##[error]bash: command not found
```

It was written with `shell: bash`, but the self-hosted Windows runners in this
matrix have no `bash` on `PATH`. So on every cherry-picked run the step dies before
doing anything and takes the whole Windows job down with it, leaving that half of the
matrix with no coverage of the Slang/SlangPy combination under test.

This was caught by an end-to-end validation run of the mechanism
(https://github.com/shader-slang/slangpy/actions/runs/34327287060), where the Linux
job cherry-picked and built correctly while the Windows job failed on the missing
shell.

The rest of this workflow already accounts for the missing shell — both other places
that run commands use `shell: ${{ matrix.os == 'windows' && 'pwsh' || 'bash' }}`
(lines 68 and 169). The new step simply did not follow that convention.

## Proposed solution

Run the logic through `actions/github-script` instead of a shell.

The git commands themselves are already portable: `git` resolves on every runner in
the matrix. Only the surrounding control flow — trimming, validating, and the
shallow-repository check — needed a shell, and that has no shared bash/PowerShell
syntax. `exec.exec` spawns `git` directly through Node's child-process API, so no
shell is involved at all and one implementation covers both platforms.

Two alternatives were rejected:

- **A `pwsh` twin of the step, selected by `matrix.os`.** This duplicates the same
  logic in two languages, in two places that must be kept in sync.
- **A single straight-line script under `matrix.os == 'windows' && 'pwsh' || 'bash'`.**
  Two things block this. Reading the value is not portable — bash needs
  `$SLANGPY_PR` and pwsh needs `$env:SLANGPY_PR` — and the alternative of
  interpolating the payload directly into the script is the standard Actions
  script-injection pattern. More seriously, GitHub's `pwsh` wrapper sets
  `$ErrorActionPreference = 'stop'`, which governs PowerShell errors but not non-zero
  exits from native executables, so a failing `git fetch` mid-script would not fail
  the step. That is the opposite of the `set -e` behavior the bash version relied on.

This adds no dependency on the runner machines. The Actions runner bundles its own
Node in order to execute JavaScript actions at all; `actions/checkout@v6` is itself a
`node24` JavaScript action and runs in the step directly above this one on the same
Windows runner. `v8` is pinned because it targets that same `node24`.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/ci-latest-slang.yml` | Replaces the `shell: bash` `run:` block in `Cherry-pick SlangPy PR` with an equivalent `actions/github-script@v8` step. |

## Process report

**Behavior is unchanged.** The JS mirrors the shell version case for case:

| Payload value | Behavior |
| --- | --- |
| `1135`, `"  1135  "` | Cherry-picks PR 1135 |
| `"12 34"`, `abc`, `11a35` | Fails the step |
| `""`, `"   "`, absent | No-op; the run proceeds as an ordinary build |

Leading and trailing whitespace is trimmed while embedded whitespace still fails
validation, so a malformed `"12 34"` is rejected rather than collapsing into `1234`
and cherry-picking an unrelated PR. `exec.exec` rejects on a non-zero exit, so any
git failure fails the step exactly as `set -e` did.

**Why the input is validated here at all.** The PR number arrives in a
`repository_dispatch` payload from another repository, so it is re-validated as
digits on this side rather than trusted from the sender, even though the value
originates in a workflow constant on Slang `master`.

**Why the shallow check remains.** `actions/checkout` leaves a depth-1 clone, which
has no ancestry for the merge to find a merge base in; without deepening, the merge
fails with `refusing to merge unrelated histories`. Deepening only inside this step
keeps ordinary, non-cherry-picked runs on the cheap shallow checkout.
