### PR TITLE
Keep the cherry-pick fetches out of the submodules

### DIFF
--- a/.github/workflows/ci-latest-slang.yml
+++ b/.github/workflows/ci-latest-slang.yml
@@ -149,15 +149,21 @@ jobs:
             // for the merge to find a merge base in; without this the merge below fails
             // with "refusing to merge unrelated histories". Deepening only here keeps
             // the ordinary, non-cherry-picked runs on the cheap shallow checkout.
+            //
+            // --no-recurse-submodules because only this repository's history is needed
+            // to find that merge base. Recursing made the fetch also walk the
+            // submodules, where a recorded commit that has since been force-pushed away
+            // upstream fails the whole step with "remote error: upload-pack: not our
+            // ref". actions/checkout has already placed the submodules this build needs.
             const shallow = await exec.getExecOutput('git', ['rev-parse', '--is-shallow-repository']);
             if (shallow.stdout.trim() === 'true') {
-              await exec.exec('git', ['fetch', '--unshallow', 'origin']);
+              await exec.exec('git', ['fetch', '--unshallow', '--no-recurse-submodules', 'origin']);
             }
 
             // --force because these jobs run on reused self-hosted workspaces, where a
             // slangpy-pr-under-test ref left behind by an earlier run will not
             // fast-forward to a different PR and would fail the fetch.
-            await exec.exec('git', ['fetch', '--force', 'origin', `pull/${pr}/head:slangpy-pr-under-test`]);
+            await exec.exec('git', ['fetch', '--force', '--no-recurse-submodules', 'origin', `pull/${pr}/head:slangpy-pr-under-test`]);
             await exec.exec('git', ['merge', '--no-edit', 'slangpy-pr-under-test']);
 
             core.notice(`Merged SlangPy PR #${pr} into main for this run`);


### PR DESCRIPTION
## Motivation

The `Cherry-pick SlangPy PR` step deepens the shallow checkout so `git merge` can
find a merge base. That fetch recursed into the submodules, and on a reused Windows
workspace it hit a submodule commit that no longer exists upstream, which failed the
step and took the whole job with it:

```
[command]git.exe fetch --unshallow origin
  Fetching submodule external/slang-rhi
  Fetching submodule external/tevclient
  Fetching submodule external/vcpkg
  Fetching submodule samples
fatal: remote error: upload-pack: not our ref 3923979fc17e284a69cf5f11503269e1e85176b0
##[error]Unhandled error: Error: The process 'git.exe' failed with exit code 1
```

Seen in https://github.com/shader-slang/slangpy/actions/runs/34498449640 — the first
run where the cherry-pick actually engaged. Linux succeeded; Windows failed here.

## Proposed solution

Pass `--no-recurse-submodules` to both fetches in the step.

Only this repository's history is needed to compute the merge base, and
`actions/checkout` has already placed the submodules the build uses, so the submodule
traversal was doing work that is thrown away — while coupling the step's success to
whether every submodule's recorded commit is still fetchable.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/ci-latest-slang.yml` | Adds `--no-recurse-submodules` to the `--unshallow` fetch and to the PR-head fetch in `Cherry-pick SlangPy PR`. |

## Process report

**Why the submodules were being fetched at all.** Neither fetch asks for them; the
recursion comes from the repository/workspace fetch configuration that
`actions/checkout` leaves behind, so `git fetch` walks submodules by default. The
step never reads submodule history, so opting out is the correct scope rather than a
workaround.

**Why not drop `--unshallow` instead.** It is required: `actions/checkout` leaves a
depth-1 clone, and without deepening the merge fails with `refusing to merge
unrelated histories`. Deepening stays inside the conditional so ordinary,
non-cherry-picked runs keep the cheap shallow checkout.

**Why the failure is Windows-only in that run.** Nothing platform-specific — it
depends on which submodule commits the reused workspace still references. The Linux
runner's workspace happened to be consistent with its remotes. Left unfixed this
would fail intermittently on any runner.
